### PR TITLE
Feat: 유저 정보 LocalStorage 에 캐싱하기

### DIFF
--- a/src/utils/userUtils.ts
+++ b/src/utils/userUtils.ts
@@ -2,14 +2,24 @@ import { firestore } from '../firebase';
 import { doc, getDoc, setDoc, updateDoc, deleteDoc } from 'firebase/firestore';
 import { User } from '../types/User';
 
-// Function to fetch user data from Firestore
+// Function to fetch user data from Firestore with caching
 export async function fetchUserData(uid: string): Promise<User | null> {
   try {
+    // Check if user data is in localStorage
+    const cachedUserData = localStorage.getItem(`user-${uid}`);
+    if (cachedUserData) {
+      return JSON.parse(cachedUserData) as User;
+    }
+
+    // Fetch from Firestore if not in cache
     const userDocRef = doc(firestore, 'users', uid);
     const userDoc = await getDoc(userDocRef);
 
     if (userDoc.exists()) {
-      return userDoc.data() as User;
+      const userData = userDoc.data() as User;
+      // Cache the user data in localStorage
+      localStorage.setItem(`user-${uid}`, JSON.stringify(userData));
+      return userData;
     } else {
       console.log(`No such user document called ${uid}!`);
       return null;
@@ -26,22 +36,32 @@ export async function fetchUserNickname(uid: string): Promise<string | null> {
   return user?.nickname || null;
 } 
 
-// Function to update user data in Firestore
+// Function to update user data in Firestore and cache
 export async function updateUserData(uid: string, data: Partial<User>): Promise<void> {
   try {
     const userDocRef = doc(firestore, 'users', uid);
     await updateDoc(userDocRef, data);
+
+    // Update the cache with the new data
+    const cachedUserData = localStorage.getItem(`user-${uid}`);
+    if (cachedUserData) {
+      const updatedUserData = { ...JSON.parse(cachedUserData), ...data };
+      localStorage.setItem(`user-${uid}`, JSON.stringify(updatedUserData));
+    }
   } catch (error) {
     console.error('Error updating user data:', error);
     throw error;
   }
 }
 
-// Function to delete user data from Firestore
+// Function to delete user data from Firestore and cache
 export async function deleteUserData(uid: string): Promise<void> {
   try {
     const userDocRef = doc(firestore, 'users', uid);
     await deleteDoc(userDocRef);
+
+    // Remove the user data from cache
+    localStorage.removeItem(`user-${uid}`);
   } catch (error) {
     console.error('Error deleting user data:', error);
     throw error;
@@ -53,6 +73,9 @@ export async function createUserData(data: User): Promise<void> {
   try {
     const userDocRef = doc(firestore, 'users', data.uid);
     await setDoc(userDocRef, data);
+
+    // Cache the new user data
+    localStorage.setItem(`user-${data.uid}`, JSON.stringify(data));
   } catch (error) {
     console.error('Error creating user data:', error);
     throw error;


### PR DESCRIPTION
- CRUD 함수로 따로 분리해놓은 `userUtils.ts`에 공통으로 적용
- 유저 정보는 유저가 직접 변경할 때가 아니면 바뀌지 않으므로, 로컬 스토리지에 캐싱해서 로딩 속도를 줄인다.

- 그런데 유저 정보는 다른 사람의 유저 정보를 불러오는 경우도 있다. 그럴 때는 내가 CRUD를 호출하지 않았어도 캐싱된 정보가 변경될 수 있고, 그러면 최신화되지 않은 정보를 보여주게 된다.
- 다른 사람의 유저 정보를 불러오는 경우는, 변경을 구독해서 캐시를 무효화해준다.

- https://github.com/BumgeunSong/daily-writing-friends/issues/17

resolve #17 