### PR TITLE
댓글/답글에서 줄바꿈이 적용되도록 수정

### DIFF
--- a/src/components/pages/comment/CommentRow.tsx
+++ b/src/components/pages/comment/CommentRow.tsx
@@ -81,7 +81,7 @@ const CommentRow: React.FC<CommentRowProps> = ({
                 initialValue={comment.content}
               />
             ) : (
-              <p>{comment.content}</p>
+              <p className="whitespace-pre-wrap">{comment.content}</p>
             )}
           </div>
         </div>

--- a/src/components/pages/reply/ReplyRow.tsx
+++ b/src/components/pages/reply/ReplyRow.tsx
@@ -87,7 +87,7 @@ const ReplyRow: React.FC<ReplyRowProps> = ({
               initialValue={reply.content}
             />
           ) : (
-            <p>{reply.content}</p>
+            <p className="whitespace-pre-wrap">{reply.content}</p>
           )}
         </div>
       </div>


### PR DESCRIPTION
- html에서 기본적으로 줄바꿈을 띄어쓰기로 치환해버리는 동작이 있다
- utility class를 사용하여 줄바꿈이 적용되도록 한다.

https://github.com/BumgeunSong/daily-writing-friends/issues/25
resolve #25 