### PR TITLE
feat: 글/댓글/답글에 URL 링크가 달려있을 경우, <a> 태그와 hyperlink 스타일 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-avatar": "^1.1.1",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-slot": "^1.1.0",
+        "@tailwindcss/typography": "^0.5.15",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -1543,6 +1544,32 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.15.tgz",
+      "integrity": "sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2957,6 +2984,21 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/long": {
       "version": "5.2.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
+    "@tailwindcss/typography": "^0.5.15",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/src/components/pages/comment/CommentRow.tsx
+++ b/src/components/pages/comment/CommentRow.tsx
@@ -43,17 +43,8 @@ const CommentRow: React.FC<CommentRowProps> = ({
   }, [comment.userId]);
 
   const EditIcon = isEditing ? X : Edit;
-
-  const sanitizedContent = DOMPurify.sanitize(convertUrlsToLinks(comment.content), {
-    ADD_ATTR: ['target'],
-    ADD_TAGS: ['a'],
-  });
-
-  const contentWithStyledLinks = sanitizedContent.replace(
-    /<a /g,
-    '<a class="text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer" '
-  );
-
+  const sanitizedContent = DOMPurify.sanitize(convertUrlsToLinks(comment.content));
+  
   return (
     <div className="flex flex-col space-y-4">
       <div className="flex items-start space-x-4">
@@ -95,7 +86,7 @@ const CommentRow: React.FC<CommentRowProps> = ({
             ) : (
               <div 
                 className="whitespace-pre-wrap"
-                dangerouslySetInnerHTML={{ __html: contentWithStyledLinks }}
+                dangerouslySetInnerHTML={{ __html: sanitizedContent }}
               />
             )}
           </div>

--- a/src/components/pages/comment/CommentRow.tsx
+++ b/src/components/pages/comment/CommentRow.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Edit, Trash2, X } from "lucide-react";
 import CommentInput from "./CommentInput";
 import { deleteCommentToPost, updateCommentToPost } from "@/utils/commentUtils";
+import { convertUrlsToLinks } from "@/utils/contentUtils";
 
 interface CommentRowProps {
   postId: string;
@@ -78,7 +79,7 @@ const CommentRow: React.FC<CommentRowProps> = ({
             {isEditing ? (
               <CommentInput
                 onSubmit={handleEditSubmit}
-                initialValue={comment.content}
+                initialValue={convertUrlsToLinks(comment.content)}
               />
             ) : (
               <p className="whitespace-pre-wrap">{comment.content}</p>

--- a/src/components/pages/comment/CommentRow.tsx
+++ b/src/components/pages/comment/CommentRow.tsx
@@ -3,10 +3,11 @@ import { Comment } from "../../../types/Comment";
 import Replies from "../reply/Replies";
 import { fetchUserNickname } from "../../../utils/userUtils";
 import { Button } from "@/components/ui/button";
-import { Edit, Trash2, X } from "lucide-react";
+import { Edit, Trash2, X } from 'lucide-react';
 import CommentInput from "./CommentInput";
 import { deleteCommentToPost, updateCommentToPost } from "@/utils/commentUtils";
 import { convertUrlsToLinks } from "@/utils/contentUtils";
+import DOMPurify from 'dompurify';
 
 interface CommentRowProps {
   postId: string;
@@ -42,6 +43,16 @@ const CommentRow: React.FC<CommentRowProps> = ({
   }, [comment.userId]);
 
   const EditIcon = isEditing ? X : Edit;
+
+  const sanitizedContent = DOMPurify.sanitize(convertUrlsToLinks(comment.content), {
+    ADD_ATTR: ['target'],
+    ADD_TAGS: ['a'],
+  });
+
+  const contentWithStyledLinks = sanitizedContent.replace(
+    /<a /g,
+    '<a class="text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer" '
+  );
 
   return (
     <div className="flex flex-col space-y-4">
@@ -79,10 +90,13 @@ const CommentRow: React.FC<CommentRowProps> = ({
             {isEditing ? (
               <CommentInput
                 onSubmit={handleEditSubmit}
-                initialValue={convertUrlsToLinks(comment.content)}
+                initialValue={comment.content}
               />
             ) : (
-              <p className="whitespace-pre-wrap">{comment.content}</p>
+              <div 
+                className="whitespace-pre-wrap"
+                dangerouslySetInnerHTML={{ __html: contentWithStyledLinks }}
+              />
             )}
           </div>
         </div>

--- a/src/components/pages/comment/CommentRow.tsx
+++ b/src/components/pages/comment/CommentRow.tsx
@@ -77,7 +77,7 @@ const CommentRow: React.FC<CommentRowProps> = ({
               </div>
             )}
           </div>
-          <div className="text-base mt-2">
+          <div className="text-base mt-2 prose">
             {isEditing ? (
               <CommentInput
                 onSubmit={handleEditSubmit}

--- a/src/components/pages/post/PostDetailPage.tsx
+++ b/src/components/pages/post/PostDetailPage.tsx
@@ -11,6 +11,7 @@ import { ChevronLeft, Edit, Trash2 } from 'lucide-react';
 import Comments from '../comment/Comments';
 import { fetchUserNickname } from '@/utils/userUtils';
 import { convertUrlsToLinks } from '@/utils/contentUtils';
+import DOMPurify from 'dompurify';
 
 const deletePost = async (id: string): Promise<void> => {
   await deleteDoc(doc(firestore, 'posts', id));
@@ -100,6 +101,9 @@ export default function PostDetailPage() {
 
   const isAuthor = currentUser?.uid === post.authorId;
 
+  const editedContent = convertUrlsToLinks(post.content);
+  const sanitizedContent = DOMPurify.sanitize(editedContent);
+
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
       <Link to={`/board/${boardId}`}>
@@ -129,7 +133,7 @@ export default function PostDetailPage() {
           </div>
         </header>
         <div 
-          dangerouslySetInnerHTML={{ __html: convertUrlsToLinks(post.content) }} 
+          dangerouslySetInnerHTML={{ __html: sanitizedContent }} 
           className="prose prose-lg max-w-none"
         />
       </article>

--- a/src/components/pages/post/PostDetailPage.tsx
+++ b/src/components/pages/post/PostDetailPage.tsx
@@ -106,12 +106,6 @@ export default function PostDetailPage() {
     ADD_TAGS: ['a'],
   });
 
-  // Apply hyperlink styles to <a> tags
-  const contentWithStyledLinks = sanitizedContent.replace(
-    /<a /g,
-    '<a class="text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer" '
-  );
-
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
       <Link to={`/board/${boardId}`}>
@@ -141,7 +135,7 @@ export default function PostDetailPage() {
           </div>
         </header>
         <div 
-          dangerouslySetInnerHTML={{ __html: contentWithStyledLinks }} 
+          dangerouslySetInnerHTML={{ __html: sanitizedContent }} 
           className="prose prose-lg max-w-none"
         />
       </article>

--- a/src/components/pages/post/PostDetailPage.tsx
+++ b/src/components/pages/post/PostDetailPage.tsx
@@ -101,8 +101,16 @@ export default function PostDetailPage() {
 
   const isAuthor = currentUser?.uid === post.authorId;
 
-  const editedContent = convertUrlsToLinks(post.content);
-  const sanitizedContent = DOMPurify.sanitize(editedContent);
+  const sanitizedContent = DOMPurify.sanitize(post.content, {
+    ADD_ATTR: ['target'],
+    ADD_TAGS: ['a'],
+  });
+
+  // Apply hyperlink styles to <a> tags
+  const contentWithStyledLinks = sanitizedContent.replace(
+    /<a /g,
+    '<a class="text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer" '
+  );
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
@@ -133,7 +141,7 @@ export default function PostDetailPage() {
           </div>
         </header>
         <div 
-          dangerouslySetInnerHTML={{ __html: sanitizedContent }} 
+          dangerouslySetInnerHTML={{ __html: contentWithStyledLinks }} 
           className="prose prose-lg max-w-none"
         />
       </article>

--- a/src/components/pages/post/PostDetailPage.tsx
+++ b/src/components/pages/post/PostDetailPage.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ChevronLeft, Edit, Trash2 } from 'lucide-react';
 import Comments from '../comment/Comments';
 import { fetchUserNickname } from '@/utils/userUtils';
+import { convertUrlsToLinks } from '@/utils/contentUtils';
 
 const deletePost = async (id: string): Promise<void> => {
   await deleteDoc(doc(firestore, 'posts', id));
@@ -128,7 +129,7 @@ export default function PostDetailPage() {
           </div>
         </header>
         <div 
-          dangerouslySetInnerHTML={{ __html: post.content }} 
+          dangerouslySetInnerHTML={{ __html: convertUrlsToLinks(post.content) }} 
           className="prose prose-lg max-w-none"
         />
       </article>

--- a/src/components/pages/reply/ReplyRow.tsx
+++ b/src/components/pages/reply/ReplyRow.tsx
@@ -56,11 +56,6 @@ const ReplyRow: React.FC<ReplyRowProps> = ({
     ADD_TAGS: ['a'],
   });
 
-  const contentWithStyledLinks = sanitizedContent.replace(
-    /<a /g,
-    '<a class="text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer" '
-  );
-
   return (
     <div key={reply.id} className="flex items-start space-x-4">
       <div className="flex-1">
@@ -101,7 +96,7 @@ const ReplyRow: React.FC<ReplyRowProps> = ({
           ) : (
             <div 
               className="whitespace-pre-wrap"
-              dangerouslySetInnerHTML={{ __html: contentWithStyledLinks }}
+              dangerouslySetInnerHTML={{ __html: sanitizedContent }}
             />
           )}
         </div>

--- a/src/components/pages/reply/ReplyRow.tsx
+++ b/src/components/pages/reply/ReplyRow.tsx
@@ -9,6 +9,8 @@ import {
   updateReplyToComment,
 } from "@/utils/commentUtils";
 import { convertUrlsToLinks } from "@/utils/contentUtils";
+import DOMPurify from 'dompurify';
+
 interface ReplyRowProps {
   reply: Reply;
   commentId: string;
@@ -49,6 +51,16 @@ const ReplyRow: React.FC<ReplyRowProps> = ({
     loadNickname();
   }, [reply.userId]);
 
+  const sanitizedContent = DOMPurify.sanitize(convertUrlsToLinks(reply.content), {
+    ADD_ATTR: ['target'],
+    ADD_TAGS: ['a'],
+  });
+
+  const contentWithStyledLinks = sanitizedContent.replace(
+    /<a /g,
+    '<a class="text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer" '
+  );
+
   return (
     <div key={reply.id} className="flex items-start space-x-4">
       <div className="flex-1">
@@ -84,10 +96,13 @@ const ReplyRow: React.FC<ReplyRowProps> = ({
           {isEditing ? (
             <ReplyInput
               onSubmit={handleEditSubmit}
-              initialValue={convertUrlsToLinks(reply.content)}
+              initialValue={reply.content}
             />
           ) : (
-            <p className="whitespace-pre-wrap">{reply.content}</p>
+            <div 
+              className="whitespace-pre-wrap"
+              dangerouslySetInnerHTML={{ __html: contentWithStyledLinks }}
+            />
           )}
         </div>
       </div>

--- a/src/components/pages/reply/ReplyRow.tsx
+++ b/src/components/pages/reply/ReplyRow.tsx
@@ -95,7 +95,7 @@ const ReplyRow: React.FC<ReplyRowProps> = ({
             />
           ) : (
             <div 
-              className="whitespace-pre-wrap"
+              className="prose whitespace-pre-wrap"
               dangerouslySetInnerHTML={{ __html: sanitizedContent }}
             />
           )}

--- a/src/components/pages/reply/ReplyRow.tsx
+++ b/src/components/pages/reply/ReplyRow.tsx
@@ -8,7 +8,7 @@ import {
   deleteReplyToComment,
   updateReplyToComment,
 } from "@/utils/commentUtils";
-
+import { convertUrlsToLinks } from "@/utils/contentUtils";
 interface ReplyRowProps {
   reply: Reply;
   commentId: string;
@@ -84,7 +84,7 @@ const ReplyRow: React.FC<ReplyRowProps> = ({
           {isEditing ? (
             <ReplyInput
               onSubmit={handleEditSubmit}
-              initialValue={reply.content}
+              initialValue={convertUrlsToLinks(reply.content)}
             />
           ) : (
             <p className="whitespace-pre-wrap">{reply.content}</p>

--- a/src/utils/contentUtils.ts
+++ b/src/utils/contentUtils.ts
@@ -1,0 +1,6 @@
+function convertUrlsToLinks(content: string): string {
+    const urlRegex = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi;
+    return content.replace(urlRegex, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>');
+}
+
+export { convertUrlsToLinks };

--- a/src/utils/contentUtils.ts
+++ b/src/utils/contentUtils.ts
@@ -1,6 +1,9 @@
 function convertUrlsToLinks(content: string): string {
-    const urlRegex = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi;
-    return content.replace(urlRegex, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>');
+    const urlRegex = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|]|\bwww\.[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|]|\b[-A-Z0-9+&@#\/%?=~_|!:,.;]+\.[A-Z]{2,4}\b)/gi;
+    return content.replace(urlRegex, (url) => {
+        const href = url.startsWith('http') ? url : `http://${url}`;
+        return `<a href="${href}" target="_blank" rel="noopener noreferrer">${url}</a>`;
+    });
 }
 
 export { convertUrlsToLinks };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -56,6 +56,9 @@ export default {
   		}
   	}
   },
-  plugins: [require("tailwindcss-animate")],
-}
+  plugins: [
+    require('tailwindcss-animate'),
+    require('@tailwindcss/typography'),
+  ],
+};
 


### PR DESCRIPTION
resolve #28 

## 게시글의 경우
- 링크를 거는 기능이 에디터에 있으므로 따로 <a> 태그를 전환해주진 않음.
- 하지만 <a> 태그가 들어있으면 hyperlink 스타일 적용해준다.
![image](https://github.com/user-attachments/assets/4f24b813-1666-4647-b50a-ecd324236862)

## 댓글/답글의 경우, 
URL 링크가 달려있으면 <a> 태그를 넣고, a tag에 hyperlink 스타일 적용
![image](https://github.com/user-attachments/assets/2ac4acc2-b14f-4ef6-b777-bf632df7e738)
