### PR TITLE
Fix: 고장내버린 댓글/답글 카운트 로직 복구

### DIFF
--- a/src/components/pages/board/PostList.tsx
+++ b/src/components/pages/board/PostList.tsx
@@ -1,17 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { firestore } from '../../../firebase';
-import {
-  collection,
-  query,
-  orderBy,
-  onSnapshot,
-  DocumentData,
-  QueryDocumentSnapshot,
-  where,
-  Query,
-} from 'firebase/firestore';
 import { Post } from '../../../types/Posts';
 import PostSummaryCard from '../post/PostSummaryCard';
+import { fetchPosts } from '@/utils/postUtils';
 
 interface PostListProps {
   boardId: string;
@@ -28,32 +18,7 @@ const PostList: React.FC<PostListProps> = ({ boardId, onPostClick, selectedAutho
       return;
     }
 
-    let q: Query<DocumentData> = query(
-      collection(firestore, 'posts'),
-      where('boardId', '==', boardId),
-      orderBy('createdAt', 'desc')
-    );
-
-    if (selectedAuthorId) {
-      q = query(q, where('authorId', '==', selectedAuthorId));
-    }
-
-    const unsubscribe = onSnapshot(q, (snapshot) => {
-      const postsData: Post[] = snapshot.docs.map((doc: QueryDocumentSnapshot<DocumentData>) => {
-        const data = doc.data();
-        return {
-          id: doc.id,
-          boardId: data.boardId,
-          title: data.title,
-          content: data.content,
-          authorId: data.authorId,
-          authorName: data.authorName,
-          createdAt: data.createdAt?.toDate() || new Date(),
-          comments: data.comments || 0,
-        };
-      });
-      setPosts(postsData);
-    });
+    const unsubscribe = fetchPosts(boardId, setPosts);
 
     return () => unsubscribe();
   }, [boardId, selectedAuthorId]);

--- a/src/utils/postUtils.ts
+++ b/src/utils/postUtils.ts
@@ -1,11 +1,11 @@
 import { firestore } from '../firebase';
-import { doc, getDoc } from 'firebase/firestore';
+import { collection, orderBy, doc, getDoc, where, query, onSnapshot, QueryDocumentSnapshot, DocumentData, getDocs } from 'firebase/firestore';
 import { Post } from '../types/Posts';
 
 export const fetchPost = async (id: string): Promise<Post | null> => {
   const docRef = doc(firestore, 'posts', id);
   const docSnap = await getDoc(docRef);
-  
+
   if (!docSnap.exists()) {
     console.log('해당 문서가 없습니다!');
     return null;
@@ -19,7 +19,69 @@ export const fetchPost = async (id: string): Promise<Post | null> => {
     content: data.content,
     authorId: data.authorId,
     authorName: data.authorName,
+    comments: await getCommentsCount(docSnap.id),
     createdAt: data.createdAt?.toDate() || new Date(),
     updatedAt: data.updatedAt?.toDate(),
   };
 };
+
+export function fetchPosts(
+  boardId: string,
+  setPosts: React.Dispatch<React.SetStateAction<Post[]>>
+) {
+  const q = query(
+    collection(firestore, "posts"),
+    where("boardId", "==", boardId),
+    orderBy("createdAt", "desc")
+  );
+
+  const unsubscribe = onSnapshot(q, async (snapshot) => {
+    const postsData: Post[] = await Promise.all(
+      snapshot.docs.map(async (post: QueryDocumentSnapshot<DocumentData>) => {
+        return await getPostWithComments(post);
+      })
+    );
+    setPosts(postsData)
+  });
+
+  return unsubscribe;
+}
+
+export async function getPostWithComments(post: QueryDocumentSnapshot<DocumentData>): Promise<Post> {
+  const data = post.data();
+
+  return {
+    id: post.id,
+    boardId: data.boardId,
+    title: data.title,
+    content: data.content,
+    authorId: data.authorId,
+    authorName: data.authorName,
+    comments: await getCommentsCount(post.id),
+    createdAt: data.createdAt?.toDate() || new Date(),
+    updatedAt: data.updatedAt?.toDate(),
+  };
+}
+
+async function getCommentsCount(postId: string): Promise<number> {
+
+  const commentsRef = collection(firestore, "posts", postId, "comments");
+  const commentsSnapshot = await getDocs(commentsRef);
+  const commentsCount = await Promise.all(
+    commentsSnapshot.docs.map(async (comment) => {
+      const repliesRef = collection(
+        firestore,
+        "posts",
+        postId,
+        "comments",
+        comment.id,
+        "replies"
+      );
+      const repliesSnapshot = await getDocs(repliesRef);
+      const repliesCount = repliesSnapshot.docs.length;
+
+      return Number(comment.exists()) + repliesCount;
+    })
+  );
+  return commentsCount.reduce((acc, curr) => acc + curr, 0)
+}


### PR DESCRIPTION
- cursor와 함께 리팩토링하다가 comment & reply의 갯수를 세어서 post 모델 안에 mapping하는 코드가 날아갔었음.
- 복구합니다.
- 함수 리팩토링도 같이 진행합니다.

resolve #31 