### PR TITLE
Feat: 특정 글로 가는 링크를 외부에서 실행했을 때, 로그인 성공하면 해당 링크로 자동 리다이렉트한다.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import PostCreationPage from './components/pages/post/PostCreationPage';
 import PostDetailPage from './components/pages/post/PostDetailPage';
 import { useAuth } from './contexts/AuthContext';
 import './index.css';
+import { ProtectedRoute } from './components/route/ProtectedRoute';
 
 const AuthenticatedLayout = () => {
   return (
@@ -31,7 +32,13 @@ export default function App() {
   return (
     <Routes>
       <Route path='/login' element={!currentUser ? <LoginPage /> : <Navigate to='/boards' />} />
-      <Route element={currentUser ? <AuthenticatedLayout /> : <Navigate to='/login' />}>
+      <Route
+        element={
+          <ProtectedRoute>
+            <AuthenticatedLayout />
+          </ProtectedRoute>
+        }
+      >
         <Route path='/boards' element={<RecentBoard />} />
         <Route path='/boards/list' element={<BoardListPage />} />
         <Route path='/board/:boardId' element={<BoardPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,8 +36,8 @@ export default function App() {
         <Route path='/boards/list' element={<BoardListPage />} />
         <Route path='/board/:boardId' element={<BoardPage />} />
         <Route path='/create/:boardId' element={<PostCreationPage />} />
-        <Route path='/board/:boardId/post/:id' element={<PostDetailPage />} />
-        <Route path='/board/:boardId/edit/:id' element={<EditPostPage />} />
+        <Route path='/board/:boardId/post/:postId' element={<PostDetailPage />} />
+        <Route path='/board/:boardId/edit/:postId' element={<EditPostPage />} />
         <Route path='/notifications' element={<NotificationsPage />} />
         <Route path='/account' element={<AccountPage />} />
         <Route path='/account/edit' element={<EditAccountPage />} />

--- a/src/components/pages/login/LoginPage.tsx
+++ b/src/components/pages/login/LoginPage.tsx
@@ -7,19 +7,25 @@ import { User } from '@/types/User';
 import { createUserData, fetchUserData } from '@/utils/userUtils';
 import { useAuth } from '../../../contexts/AuthContext';
 import { signInWithGoogle } from '../../../firebase';
+import { useNavigate } from 'react-router-dom';
 
 export default function LoginPage() {
-  const { loading } = useAuth();
+  const { loading, redirectPathAfterLogin, setRedirectPathAfterLogin } = useAuth();
+  const navigate = useNavigate();
 
   const handleLogin = async () => {
     try {
       const userCredential = await signInWithGoogle();
       await ensureUserDataInFirestore(userCredential);
+
+      // Redirect to the stored path or a default path after successful login
+      const redirectTo = redirectPathAfterLogin || '/boards';
+      setRedirectPathAfterLogin(null); // Clear the redirect path
+      navigate(redirectTo, { replace: true });
     } catch (error) {
       console.error('Error signing in with Google:', error);
     }
   };
-
   const ensureUserDataInFirestore = async (userCredential: UserCredential) => {
     // Fetch user data from Firestore
     const userData = await fetchUserData(userCredential.user.uid);

--- a/src/components/pages/post/PostDetailPage.tsx
+++ b/src/components/pages/post/PostDetailPage.tsx
@@ -35,7 +35,7 @@ const handleDelete = async (
 };
 
 export default function PostDetailPage() {
-  const { id, boardId } = useParams<{ id: string; boardId: string }>();
+  const { postId, boardId } = useParams<{ postId: string; boardId: string }>();
   const [post, setPost] = useState<Post | null>(null);
   const [authorNickname, setAuthorNickname] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -44,14 +44,14 @@ export default function PostDetailPage() {
 
   useEffect(() => {
     const loadPost = async () => {
-      if (!id || !boardId) {
+      if (!postId || !boardId) {
         console.error('게시물 ID가 제공되지 않았습니다');
         setIsLoading(false);
         return;
       }
 
       try {
-        const fetchedPost = await fetchPost(boardId, id);
+        const fetchedPost = await fetchPost(boardId, postId);
         setPost(fetchedPost);
       } catch (error) {
         console.error('게시물 가져오기 오류:', error);
@@ -61,7 +61,7 @@ export default function PostDetailPage() {
     };
 
     loadPost();
-  }, [id]);
+  }, [postId]);
 
   useEffect(() => {
     const loadNickname = async () => {
@@ -125,7 +125,7 @@ export default function PostDetailPage() {
             </p>
             {isAuthor && (
               <div className='flex space-x-2'>
-                <Link to={`/board/${boardId}/edit/${id}`}>
+                <Link to={`/board/${boardId}/edit/${postId}`}>
                   <Button variant='outline' size='sm'>
                     <Edit className='mr-2 size-4' /> 수정
                   </Button>
@@ -133,7 +133,7 @@ export default function PostDetailPage() {
                 <Button
                   variant='outline'
                   size='sm'
-                  onClick={() => handleDelete(id!, boardId!, (path) => navigate(path))}
+                  onClick={() => handleDelete(postId!, boardId!, (path) => navigate(path))}
                 >
                   <Trash2 className='mr-2 size-4' /> 삭제
                 </Button>
@@ -148,7 +148,7 @@ export default function PostDetailPage() {
       </article>
       <div className='mt-12 border-t border-gray-200'></div>
       <div className='mt-12'>
-        {boardId && id && <Comments boardId={boardId} postId={id} />}
+        {boardId && postId && <Comments boardId={boardId} postId={postId} />}
       </div>
     </div>
   );

--- a/src/components/route/ProtectedRoute.tsx
+++ b/src/components/route/ProtectedRoute.tsx
@@ -1,11 +1,21 @@
 import { useAuth } from '../../contexts/AuthContext';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 
 export const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
-  const { currentUser } = useAuth();
+  const { currentUser, redirectPathAfterLogin, setRedirectPathAfterLogin } = useAuth();
+  const location = useLocation();
 
+  // If the user is not logged in, redirect to login and store the current path
   if (!currentUser) {
+    setRedirectPathAfterLogin(location.pathname);
     return <Navigate to="/login" />;
+  }
+
+  // If the user is logged in but has a redirect path, navigate to it
+  if (currentUser && redirectPathAfterLogin) {
+    const redirectTo = redirectPathAfterLogin;
+    setRedirectPathAfterLogin(null);
+    return <Navigate to={redirectTo} />;
   }
 
   return children;

--- a/src/components/route/ProtectedRoute.tsx
+++ b/src/components/route/ProtectedRoute.tsx
@@ -1,0 +1,12 @@
+import { useAuth } from '../../contexts/AuthContext';
+import { Navigate } from 'react-router-dom';
+
+export const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
+  const { currentUser } = useAuth();
+
+  if (!currentUser) {
+    return <Navigate to="/login" />;
+  }
+
+  return children;
+};

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -6,9 +6,16 @@ import { auth } from '../firebase';
 interface AuthContextType {
   currentUser: any;
   loading: boolean;
+  redirectPathAfterLogin: string | null;
+  setRedirectPathAfterLogin: (path: string | null) => void;
 }
 
-const AuthContext = createContext<AuthContextType>({ currentUser: null, loading: true });
+const AuthContext = createContext<AuthContextType>({
+  currentUser: null,
+  loading: true,
+  redirectPathAfterLogin: null,
+  setRedirectPathAfterLogin: () => {},
+});
 
 export function useAuth() {
   return useContext(AuthContext);
@@ -17,6 +24,7 @@ export function useAuth() {
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const [redirectPathAfterLogin, setRedirectPathAfterLogin] = useState<string | null>(null);
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged((user) => {
@@ -30,6 +38,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const value = {
     currentUser,
     loading,
+    redirectPathAfterLogin,
+    setRedirectPathAfterLogin,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
- App.tsx 에 보면, 글이나 상세 페이지 등으로 가는 path는 모두 로그인이 되어있는지를 한번 확인하고 이동하도록 되어있습니다.
- useAuth라는 hook을 사용하는데 이것은 firebase에서 최신 유저 세션을 불러오기 때문에 처음에는 존재하지 않고 무조건 login 페이지로 한번은 이동하게 됩니다.
- 그런데 만약 `/board/688l8OwFJ5PnE0zz8M4f/post/4yTvuHZj5uXPyhRIIf2j`와 같이 특정 게시글을 가리키는 링크를 외부에서 실행하는 경우,
- 로그인을 확인하는 동안은 currentUser = null 이므로 login 페이지로 가게 됩니다. 
- 잠깐 뒤에 currentUser가 불러와져서 다시 라우팅 로직을 탑니다.
- 이때는 이전에 실행했던 링크가 소실되어 현재 링크가 `/login `이 되므로 `/boards`로 이동합니다.
- 따라서 처음 외부에서 실행한 링크가 소실됩니다.

- 이것을 막기 위해서 useAuth hook 안에 redirectPathAfterLogin이라는 state를 만들어줍니다.
- 그리고 나서 유저 세션 (currentUser) 이 불러와졌거나, 로그인이 완료되었을 때 이 redirectPathAfterLogin가 있는지 확인하고 있다면 거기로 navigate 하도록 추가해줍니다.

- 결과적으로 '/board/688l8OwFJ5PnE0zz8M4f/post/4yTvuHZj5uXPyhRIIf2j' 와 같은 path를 실행하면 로그인 페이지로 잠깐 갔다가 세션이 확인되면 다시 게시글로 이동합니다.