### PR TITLE
Feat: Post 데이터를 Board 하위로 마이그레이션

### DIFF
--- a/src/components/pages/comment/CommentList.tsx
+++ b/src/components/pages/comment/CommentList.tsx
@@ -7,15 +7,16 @@ import CommentRow from './CommentRow';
 import { Comment } from '../../../types/Comment';
 
 interface CommentListProps {
+  boardId: string;
   postId: string;
 }
 
-const CommentList: React.FC<CommentListProps> = ({ postId }) => {
+const CommentList: React.FC<CommentListProps> = ({ boardId, postId }) => {
   const [comments, setComments] = useState<Comment[]>([]);
   const { currentUser } = useAuth();
 
   useEffect(() => {
-    const postRef = collection(firestore, 'posts', postId, 'comments');
+    const postRef = collection(firestore, `boards/${boardId}/posts/${postId}/comments`);
     const commentsQuery = query(postRef, orderBy('createdAt', 'asc'));
 
     const unsubscribe = onSnapshot(commentsQuery, (snapshot) => {
@@ -27,13 +28,14 @@ const CommentList: React.FC<CommentListProps> = ({ postId }) => {
     });
 
     return () => unsubscribe();
-  }, [postId]);
+  }, [boardId, postId]);
 
   return (
     <div className='space-y-6'>
       {comments.map((comment) => (
         <CommentRow
           key={comment.id}
+          boardId={boardId}
           postId={postId}
           comment={comment}
           isAuthor={comment.userId === currentUser?.uid}

--- a/src/components/pages/comment/CommentList.tsx
+++ b/src/components/pages/comment/CommentList.tsx
@@ -1,10 +1,8 @@
-import { onSnapshot, orderBy, query, collection } from 'firebase/firestore';
 import React, { useEffect, useState } from 'react';
-
 import { useAuth } from '@/contexts/AuthContext';
-import { firestore } from '@/firebase';
 import CommentRow from './CommentRow';
 import { Comment } from '../../../types/Comment';
+import { fetchComments } from '@/utils/commentUtils';
 
 interface CommentListProps {
   boardId: string;
@@ -14,19 +12,8 @@ interface CommentListProps {
 const CommentList: React.FC<CommentListProps> = ({ boardId, postId }) => {
   const [comments, setComments] = useState<Comment[]>([]);
   const { currentUser } = useAuth();
-
   useEffect(() => {
-    const postRef = collection(firestore, `boards/${boardId}/posts/${postId}/comments`);
-    const commentsQuery = query(postRef, orderBy('createdAt', 'asc'));
-
-    const unsubscribe = onSnapshot(commentsQuery, (snapshot) => {
-      const fetchedComments = snapshot.docs.map((doc) => ({
-        id: doc.id,
-        ...doc.data(),
-      })) as Comment[];
-      setComments(fetchedComments);
-    });
-
+    const unsubscribe = fetchComments(boardId, postId, setComments);
     return () => unsubscribe();
   }, [boardId, postId]);
 

--- a/src/components/pages/comment/CommentRow.tsx
+++ b/src/components/pages/comment/CommentRow.tsx
@@ -11,6 +11,7 @@ import { fetchUserNickname } from '../../../utils/userUtils';
 import Replies from '../reply/Replies';
 
 interface CommentRowProps {
+  boardId: string;
   postId: string;
   comment: Comment;
   isAuthor: boolean;

--- a/src/components/pages/comment/CommentRow.tsx
+++ b/src/components/pages/comment/CommentRow.tsx
@@ -17,7 +17,7 @@ interface CommentRowProps {
   isAuthor: boolean;
 }
 
-const CommentRow: React.FC<CommentRowProps> = ({ postId, comment, isAuthor }) => {
+const CommentRow: React.FC<CommentRowProps> = ({ boardId, postId, comment, isAuthor }) => {
   const [userNickName, setUserNickName] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(false);
 
@@ -27,12 +27,12 @@ const CommentRow: React.FC<CommentRowProps> = ({ postId, comment, isAuthor }) =>
 
   const handleDelete = async () => {
     if (window.confirm('댓글을 삭제하시겠습니까?')) {
-      await deleteCommentToPost(postId, comment.id);
+      await deleteCommentToPost(boardId, postId, comment.id);
     }
   };
 
   const handleEditSubmit = async (content: string) => {
-    await updateCommentToPost(postId, comment.id, content);
+    await updateCommentToPost(boardId, postId, comment.id, content);
     setIsEditing(false);
   };
 
@@ -82,7 +82,7 @@ const CommentRow: React.FC<CommentRowProps> = ({ postId, comment, isAuthor }) =>
           </div>
         </div>
       </div>
-      <Replies postId={postId} commentId={comment.id} />
+      <Replies boardId={boardId} postId={postId} commentId={comment.id} />
     </div>
   );
 };

--- a/src/components/pages/comment/Comments.tsx
+++ b/src/components/pages/comment/Comments.tsx
@@ -6,10 +6,11 @@ import CommentInput from './CommentInput';
 import CommentList from './CommentList';
 
 interface CommentsProps {
+  boardId: string;
   postId: string;
 }
 
-const Comments: React.FC<CommentsProps> = ({ postId }) => {
+const Comments: React.FC<CommentsProps> = ({ boardId, postId }) => {
   const { currentUser } = useAuth();
 
   const handleSubmit = async (content: string) => {
@@ -18,6 +19,7 @@ const Comments: React.FC<CommentsProps> = ({ postId }) => {
     }
 
     await addCommentToPost(
+      boardId,
       postId,
       content,
       currentUser.uid,
@@ -26,10 +28,11 @@ const Comments: React.FC<CommentsProps> = ({ postId }) => {
     );
   };
 
+  console.log('boardId', boardId);
   return (
     <section className='mt-12 space-y-8'>
       <h2 className='text-2xl font-semibold'>댓글</h2>
-      <CommentList postId={postId} />
+      <CommentList boardId={boardId} postId={postId} />
       <div className='my-6 border-t border-gray-200' />
       <CommentInput onSubmit={handleSubmit} />
     </section>

--- a/src/components/pages/comment/Comments.tsx
+++ b/src/components/pages/comment/Comments.tsx
@@ -28,7 +28,6 @@ const Comments: React.FC<CommentsProps> = ({ boardId, postId }) => {
     );
   };
 
-  console.log('boardId', boardId);
   return (
     <section className='mt-12 space-y-8'>
       <h2 className='text-2xl font-semibold'>댓글</h2>

--- a/src/components/pages/post/EditPostPage.tsx
+++ b/src/components/pages/post/EditPostPage.tsx
@@ -23,9 +23,9 @@ export default function EditPostPage() {
 
   useEffect(() => {
     const loadPost = async () => {
-      if (!id) return;
+      if (!id || !boardId) return;
       try {
-        const fetchedPost = await fetchPost(id);
+        const fetchedPost = await fetchPost(boardId, id);
         if (!fetchedPost) throw new Error('Post not found');
         setPost(fetchedPost);
         setContent(fetchedPost.content);

--- a/src/components/pages/post/EditPostPage.tsx
+++ b/src/components/pages/post/EditPostPage.tsx
@@ -41,9 +41,8 @@ export default function EditPostPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!content.trim() || !id) return;
-
     try {
-      const docRef = doc(firestore, 'posts', id);
+      const docRef = doc(firestore, `boards/${boardId}/posts`, id);
       await updateDoc(docRef, {
         content,
         updatedAt: serverTimestamp(),

--- a/src/components/pages/post/PostCreationPage.tsx
+++ b/src/components/pages/post/PostCreationPage.tsx
@@ -1,4 +1,3 @@
-import { collection, addDoc, serverTimestamp, setDoc, doc } from 'firebase/firestore';
 import { ChevronLeft } from 'lucide-react';
 import React, { useState, useRef, useEffect } from 'react';
 import ReactQuill from 'react-quill';
@@ -6,7 +5,7 @@ import { useNavigate, Link, useParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useAuth } from '../../../contexts/AuthContext';
-import { firestore } from '../../../firebase';
+import { createPost } from '@/utils/postUtils';
 import 'react-quill/dist/quill.snow.css';
 
 const TitleInput = React.forwardRef<
@@ -54,16 +53,10 @@ export default function PostCreationPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim() || !content.trim()) return;
+    if (!boardId) return;
 
     try {
-      const postRef = doc(collection(firestore, `boards/${boardId}/posts`));
-      await setDoc(postRef, {
-        title,
-        content,
-        authorId: currentUser?.uid,
-        authorName: currentUser?.displayName,
-        createdAt: serverTimestamp(),
-      });
+      await createPost(boardId, title, content, currentUser?.uid, currentUser?.displayName);
       navigate(`/board/${boardId}`);
     } catch (error) {
       console.error('Error creating post:', error);

--- a/src/components/pages/post/PostCreationPage.tsx
+++ b/src/components/pages/post/PostCreationPage.tsx
@@ -1,4 +1,4 @@
-import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { collection, addDoc, serverTimestamp, setDoc, doc } from 'firebase/firestore';
 import { ChevronLeft } from 'lucide-react';
 import React, { useState, useRef, useEffect } from 'react';
 import ReactQuill from 'react-quill';
@@ -51,16 +51,15 @@ export default function PostCreationPage() {
   const { currentUser } = useAuth();
   const navigate = useNavigate();
   const { boardId } = useParams<{ boardId: string }>();
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim() || !content.trim()) return;
 
     try {
-      await addDoc(collection(firestore, 'posts'), {
+      const postRef = doc(collection(firestore, `boards/${boardId}/posts`));
+      await setDoc(postRef, {
         title,
         content,
-        boardId,
         authorId: currentUser?.uid,
         authorName: currentUser?.displayName,
         createdAt: serverTimestamp(),

--- a/src/components/pages/post/PostDetailPage.tsx
+++ b/src/components/pages/post/PostDetailPage.tsx
@@ -12,8 +12,8 @@ import { Post } from '../../../types/Posts';
 import { fetchPost } from '../../../utils/postUtils';
 import Comments from '../comment/Comments';
 
-const deletePost = async (id: string): Promise<void> => {
-  await deleteDoc(doc(firestore, 'posts', id));
+const deletePost = async (boardId: string, id: string): Promise<void> => {
+  await deleteDoc(doc(firestore, `boards/${boardId}/posts`, id));
 };
 
 const handleDelete = async (
@@ -27,7 +27,7 @@ const handleDelete = async (
   if (!confirmDelete) return;
 
   try {
-    await deletePost(id);
+    await deletePost(boardId, id);
     navigate(`/board/${boardId}`);
   } catch (error) {
     console.error('게시물 삭제 오류:', error);

--- a/src/components/pages/post/PostDetailPage.tsx
+++ b/src/components/pages/post/PostDetailPage.tsx
@@ -44,14 +44,14 @@ export default function PostDetailPage() {
 
   useEffect(() => {
     const loadPost = async () => {
-      if (!id) {
+      if (!id || !boardId) {
         console.error('게시물 ID가 제공되지 않았습니다');
         setIsLoading(false);
         return;
       }
 
       try {
-        const fetchedPost = await fetchPost(id);
+        const fetchedPost = await fetchPost(boardId, id);
         setPost(fetchedPost);
       } catch (error) {
         console.error('게시물 가져오기 오류:', error);
@@ -148,7 +148,7 @@ export default function PostDetailPage() {
       </article>
       <div className='mt-12 border-t border-gray-200'></div>
       <div className='mt-12'>
-        <Comments postId={id!} />
+        <Comments boardId={boardId!} postId={id!} />
       </div>
     </div>
   );

--- a/src/components/pages/post/PostDetailPage.tsx
+++ b/src/components/pages/post/PostDetailPage.tsx
@@ -148,7 +148,7 @@ export default function PostDetailPage() {
       </article>
       <div className='mt-12 border-t border-gray-200'></div>
       <div className='mt-12'>
-        <Comments boardId={boardId!} postId={id!} />
+        {boardId && id && <Comments boardId={boardId} postId={id} />}
       </div>
     </div>
   );

--- a/src/components/pages/post/PostSummaryCard.tsx
+++ b/src/components/pages/post/PostSummaryCard.tsx
@@ -57,7 +57,7 @@ const PostSummaryCard: React.FC<PostSummaryCardProps> = ({ post, onClick }) => {
           <div className='ml-2'>
             <p className='text-sm font-medium'>{authorData?.nickname}</p>
             <p className='text-xs text-muted-foreground'>
-              {formatDistanceToNow(post.createdAt.toDate(), { addSuffix: true })}
+              {formatDistanceToNow(post.createdAt.toLocaleString(), { addSuffix: true })}
             </p>
           </div>
         </div>

--- a/src/components/pages/post/PostSummaryCard.tsx
+++ b/src/components/pages/post/PostSummaryCard.tsx
@@ -57,7 +57,7 @@ const PostSummaryCard: React.FC<PostSummaryCardProps> = ({ post, onClick }) => {
           <div className='ml-2'>
             <p className='text-sm font-medium'>{authorData?.nickname}</p>
             <p className='text-xs text-muted-foreground'>
-              {formatDistanceToNow(post.createdAt, { addSuffix: true })}
+              {formatDistanceToNow(post.createdAt.toDate(), { addSuffix: true })}
             </p>
           </div>
         </div>

--- a/src/components/pages/reply/Replies.tsx
+++ b/src/components/pages/reply/Replies.tsx
@@ -9,17 +9,19 @@ import ReplyList from './ReplyList';
 import { firestore } from '../../../firebase';
 
 interface RepliesProps {
+  boardId: string;
   postId: string;
   commentId: string;
 }
 
-const Replies: React.FC<RepliesProps> = ({ postId, commentId }) => {
+const Replies: React.FC<RepliesProps> = ({ boardId, postId, commentId }) => {
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
   const [replyCount, setReplyCount] = useState<number>(0);
   const { currentUser } = useAuth();
 
   const handleSubmit = async (content: string) => {
     await addReplyToComment(
+      boardId,
       postId,
       commentId,
       content,
@@ -54,7 +56,7 @@ const Replies: React.FC<RepliesProps> = ({ postId, commentId }) => {
       </Button>
       {replyingTo === commentId && (
         <div className='mt-2 space-y-4 border-l-2 border-gray-200 pl-4'>
-          <ReplyList postId={postId} commentId={commentId} />
+          <ReplyList boardId={boardId} postId={postId} commentId={commentId} />
           <ReplyInput onSubmit={handleSubmit} />
         </div>
       )}

--- a/src/components/pages/reply/ReplyList.tsx
+++ b/src/components/pages/reply/ReplyList.tsx
@@ -36,6 +36,7 @@ const ReplyList: React.FC<ReplyListProps> = ({ boardId, postId, commentId }) => 
       {replies.map((reply) => (
         <ReplyRow
           key={reply.id}
+          boardId={boardId}
           reply={reply}
           isAuthor={currentUser?.uid === reply.userId}
           commentId={commentId}

--- a/src/components/pages/reply/ReplyList.tsx
+++ b/src/components/pages/reply/ReplyList.tsx
@@ -1,10 +1,8 @@
-import { collection, query, orderBy, onSnapshot } from 'firebase/firestore';
 import React, { useEffect, useState } from 'react';
-
 import { useAuth } from '@/contexts/AuthContext';
 import { Reply } from '@/types/Reply';
 import ReplyRow from './ReplyRow';
-import { firestore } from '../../../firebase';
+import { fetchReplies } from '@/utils/replyUtils';
 
 interface ReplyListProps {
   boardId: string;
@@ -15,19 +13,8 @@ interface ReplyListProps {
 const ReplyList: React.FC<ReplyListProps> = ({ boardId, postId, commentId }) => {
   const [replies, setReplies] = useState<Reply[]>([]);
   const { currentUser } = useAuth();
-
   useEffect(() => {
-    const repliesRef = collection(firestore, `boards/${boardId}/posts/${postId}/comments/${commentId}/replies`);
-    const repliesQuery = query(repliesRef, orderBy('createdAt', 'asc'));
-
-    const unsubscribe = onSnapshot(repliesQuery, (snapshot) => {
-      const fetchedReplies = snapshot.docs.map((doc) => ({
-        id: doc.id,
-        ...doc.data(),
-      })) as Reply[];
-      setReplies(fetchedReplies);
-    });
-
+    const unsubscribe = fetchReplies(boardId, postId, commentId, setReplies);
     return () => unsubscribe();
   }, [boardId, postId, commentId]);
 

--- a/src/components/pages/reply/ReplyList.tsx
+++ b/src/components/pages/reply/ReplyList.tsx
@@ -7,16 +7,17 @@ import ReplyRow from './ReplyRow';
 import { firestore } from '../../../firebase';
 
 interface ReplyListProps {
+  boardId: string;
   postId: string;
   commentId: string;
 }
 
-const ReplyList: React.FC<ReplyListProps> = ({ postId, commentId }) => {
+const ReplyList: React.FC<ReplyListProps> = ({ boardId, postId, commentId }) => {
   const [replies, setReplies] = useState<Reply[]>([]);
   const { currentUser } = useAuth();
 
   useEffect(() => {
-    const repliesRef = collection(firestore, 'posts', postId, 'comments', commentId, 'replies');
+    const repliesRef = collection(firestore, `boards/${boardId}/posts/${postId}/comments/${commentId}/replies`);
     const repliesQuery = query(repliesRef, orderBy('createdAt', 'asc'));
 
     const unsubscribe = onSnapshot(repliesQuery, (snapshot) => {
@@ -28,7 +29,7 @@ const ReplyList: React.FC<ReplyListProps> = ({ postId, commentId }) => {
     });
 
     return () => unsubscribe();
-  }, [postId, commentId]);
+  }, [boardId, postId, commentId]);
 
   return (
     <div className='space-y-4'>

--- a/src/components/pages/reply/ReplyRow.tsx
+++ b/src/components/pages/reply/ReplyRow.tsx
@@ -11,12 +11,13 @@ import ReplyInput from './ReplyInput';
 
 interface ReplyRowProps {
   reply: Reply;
+  boardId: string;
   commentId: string;
   postId: string;
   isAuthor: boolean;
 }
 
-const ReplyRow: React.FC<ReplyRowProps> = ({ reply, commentId, postId, isAuthor }) => {
+const ReplyRow: React.FC<ReplyRowProps> = ({ boardId, reply, commentId, postId, isAuthor }) => {
   const [userNickname, setUserNickname] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(false);
 
@@ -26,12 +27,12 @@ const ReplyRow: React.FC<ReplyRowProps> = ({ reply, commentId, postId, isAuthor 
 
   const handleDelete = async () => {
     if (window.confirm('답글을 삭제하시겠습니까?')) {
-      await deleteReplyToComment(postId, commentId, reply.id);
+      await deleteReplyToComment(boardId, postId, commentId, reply.id);
     }
   };
 
   const handleEditSubmit = async (content: string) => {
-    await updateReplyToComment(postId, commentId, reply.id, content);
+    await updateReplyToComment(boardId, postId, commentId, reply.id, content);
     setIsEditing(false);
   };
 

--- a/src/types/Posts.ts
+++ b/src/types/Posts.ts
@@ -1,4 +1,6 @@
 // src/types/Post.ts
+import { Timestamp } from 'firebase/firestore';
+
 export interface Post {
   id: string;
   boardId: string;
@@ -6,7 +8,7 @@ export interface Post {
   content: string;
   authorId: string;
   authorName: string;
-  createdAt: Date;
+  createdAt: Timestamp;
   comments: number;
-  updatedAt?: Date;
+  updatedAt?: Timestamp;
 }

--- a/src/utils/commentUtils.ts
+++ b/src/utils/commentUtils.ts
@@ -1,6 +1,31 @@
-import { collection, addDoc, doc, serverTimestamp, updateDoc, deleteDoc } from 'firebase/firestore';
-
+import { collection, addDoc, doc, serverTimestamp, updateDoc, deleteDoc, getDocs, query, orderBy, onSnapshot, QueryDocumentSnapshot, DocumentData } from 'firebase/firestore';
+import { Comment } from '../types/Comment';
 import { firestore } from '../firebase';
+
+export function fetchComments(
+  boardId: string,
+  postId: string,
+  setComments: React.Dispatch<React.SetStateAction<Comment[]>>,
+) {
+  const commentsRef = collection(firestore, `boards/${boardId}/posts/${postId}/comments`);
+  const commentsQuery = query(commentsRef, orderBy('createdAt', 'asc'));
+  return onSnapshot(commentsQuery, async (snapshot) => {
+    const comments = await Promise.all(snapshot.docs.map((doc) => mapDocToComment(doc)));
+    setComments(comments);
+  });
+};
+
+async function mapDocToComment(docSnap: QueryDocumentSnapshot<DocumentData>): Promise<Comment> {
+  const data = docSnap.data();
+  return {
+    id: docSnap.id,
+    content: data.content,
+    userId: data.userId,
+    userName: data.userName,
+    userProfileImage: data.userProfileImage,
+    createdAt: data.createdAt,
+  };
+}
 
 export const addCommentToPost = async (
   boardId: string,

--- a/src/utils/commentUtils.ts
+++ b/src/utils/commentUtils.ts
@@ -3,6 +3,7 @@ import { collection, addDoc, doc, serverTimestamp, updateDoc, deleteDoc } from '
 import { firestore } from '../firebase';
 
 export const addCommentToPost = async (
+  boardId: string,
   postId: string,
   content: string,
   userId: string,
@@ -10,7 +11,7 @@ export const addCommentToPost = async (
   userProfileImage: string,
 ) => {
   try {
-    const postRef = doc(firestore, 'posts', postId);
+    const postRef = doc(firestore, `boards/${boardId}/posts/${postId}`);
     await addDoc(collection(postRef, 'comments'), {
       content,
       userId,
@@ -24,18 +25,18 @@ export const addCommentToPost = async (
   }
 };
 
-export const updateCommentToPost = async (postId: string, commentId: string, content: string) => {
+export const updateCommentToPost = async (boardId: string, postId: string, commentId: string, content: string) => {
   try {
-    const postRef = doc(firestore, 'posts', postId);
+    const postRef = doc(firestore, `boards/${boardId}/posts/${postId}`);
     await updateDoc(doc(postRef, 'comments', commentId), { content });
   } catch (error) {
     console.error('Error updating comment:', error);
   }
 };
 
-export const deleteCommentToPost = async (postId: string, commentId: string) => {
+export const deleteCommentToPost = async (boardId: string, postId: string, commentId: string) => {
   try {
-    const postRef = doc(firestore, 'posts', postId);
+    const postRef = doc(firestore, `boards/${boardId}/posts/${postId}`);
     await deleteDoc(doc(postRef, 'comments', commentId));
   } catch (error) {
     console.error('Error deleting comment:', error);
@@ -43,6 +44,7 @@ export const deleteCommentToPost = async (postId: string, commentId: string) => 
 };
 
 export const addReplyToComment = async (
+  boardId: string,
   postId: string,
   commentId: string,
   content: string,
@@ -51,7 +53,7 @@ export const addReplyToComment = async (
   userProfileImage: string,
 ) => {
   try {
-    const postRef = doc(firestore, 'posts', postId);
+    const postRef = doc(firestore, `boards/${boardId}/posts/${postId}`);
     await addDoc(collection(postRef, 'comments', commentId, 'replies'), {
       content,
       userId,
@@ -66,13 +68,14 @@ export const addReplyToComment = async (
 };
 
 export const updateReplyToComment = async (
+  boardId: string,
   postId: string,
   commentId: string,
   replyId: string,
   content: string,
 ) => {
   try {
-    const postRef = doc(firestore, 'posts', postId);
+    const postRef = doc(firestore, `boards/${boardId}/posts/${postId}`);
     await updateDoc(doc(postRef, 'comments', commentId, 'replies', replyId), {
       content,
     });
@@ -81,9 +84,9 @@ export const updateReplyToComment = async (
   }
 };
 
-export const deleteReplyToComment = async (postId: string, commentId: string, replyId: string) => {
+export const deleteReplyToComment = async (boardId: string, postId: string, commentId: string, replyId: string) => {
   try {
-    const postRef = doc(firestore, 'posts', postId);
+    const postRef = doc(firestore, `boards/${boardId}/posts/${postId}`);
     await deleteDoc(doc(postRef, 'comments', commentId, 'replies', replyId));
   } catch (error) {
     console.error('Error deleting reply:', error);

--- a/src/utils/postUtils.ts
+++ b/src/utils/postUtils.ts
@@ -9,6 +9,8 @@ import {
   QueryDocumentSnapshot,
   DocumentData,
   getDocs,
+  setDoc,
+  serverTimestamp,
 } from 'firebase/firestore';
 
 import { firestore } from '../firebase';
@@ -71,4 +73,16 @@ async function getCommentsCount(boardId: string, postId: string): Promise<number
     }),
   );
   return commentsCount.reduce((acc, curr) => acc + curr, 0);
+}
+
+export async function createPost(boardId: string, title: string, content: string, authorId: string, authorName: string) {
+  const postRef = doc(collection(firestore, `boards/${boardId}/posts`));
+  return setDoc(postRef, {
+    title,
+    boardId,
+    content,
+    authorId,
+    authorName,
+    createdAt: serverTimestamp(),
+  });
 }

--- a/src/utils/postUtils.ts
+++ b/src/utils/postUtils.ts
@@ -14,15 +14,15 @@ import {
 import { firestore } from '../firebase';
 import { Post } from '../types/Posts';
 
-export const fetchPost = async (id: string): Promise<Post | null> => {
-  const docSnap = await getDoc(doc(firestore, 'posts', id));
+export const fetchPost = async (boardId: string, postId: string): Promise<Post | null> => {
+  const docSnap = await getDoc(doc(firestore, `boards/${boardId}/posts`, postId));
 
   if (!docSnap.exists()) {
     console.log('해당 문서가 없습니다!');
     return null;
   }
 
-  return mapDocToPost(docSnap);
+  return mapDocToPost(docSnap, boardId);
 };
 
 export function fetchPosts(
@@ -31,8 +31,7 @@ export function fetchPosts(
   setPosts: React.Dispatch<React.SetStateAction<Post[]>>,
 ) {
   let q = query(
-    collection(firestore, 'posts'),
-    where('boardId', '==', boardId),
+    collection(firestore, `boards/${boardId}/posts`),
     orderBy('createdAt', 'desc'),
   );
 
@@ -41,12 +40,12 @@ export function fetchPosts(
   }
 
   return onSnapshot(q, async (snapshot) => {
-    const postsData = await Promise.all(snapshot.docs.map(mapDocToPost));
+    const postsData = await Promise.all(snapshot.docs.map((doc) => mapDocToPost(doc, boardId)));
     setPosts(postsData);
   });
 }
 
-async function mapDocToPost(docSnap: QueryDocumentSnapshot<DocumentData>): Promise<Post> {
+async function mapDocToPost(docSnap: QueryDocumentSnapshot<DocumentData>, boardId: string): Promise<Post> {
   const data = docSnap.data();
   return {
     id: docSnap.id,
@@ -55,18 +54,18 @@ async function mapDocToPost(docSnap: QueryDocumentSnapshot<DocumentData>): Promi
     content: data.content,
     authorId: data.authorId,
     authorName: data.authorName,
-    comments: await getCommentsCount(docSnap.id),
+    comments: await getCommentsCount(boardId, docSnap.id),
     createdAt: data.createdAt?.toDate() || new Date(),
     updatedAt: data.updatedAt?.toDate(),
   };
 }
 
-async function getCommentsCount(postId: string): Promise<number> {
-  const commentsSnapshot = await getDocs(collection(firestore, 'posts', postId, 'comments'));
+async function getCommentsCount(boardId: string, postId: string): Promise<number> {
+  const commentsSnapshot = await getDocs(collection(firestore, `boards/${boardId}/posts/${postId}/comments`));
   const commentsCount = await Promise.all(
     commentsSnapshot.docs.map(async (comment) => {
       const repliesSnapshot = await getDocs(
-        collection(firestore, 'posts', postId, 'comments', comment.id, 'replies'),
+        collection(firestore, `boards/${boardId}/posts/${postId}/comments/${comment.id}/replies`),
       );
       return Number(comment.exists()) + repliesSnapshot.docs.length;
     }),

--- a/src/utils/replyUtils.ts
+++ b/src/utils/replyUtils.ts
@@ -1,0 +1,16 @@
+import { collection, onSnapshot } from 'firebase/firestore';
+import { Reply } from '@/types/Reply';
+import { firestore } from '@/firebase';
+
+export function fetchReplies(boardId: string, postId: string, commentId: string, setReplies: (replies: Reply[]) => void) {
+  const repliesRef = collection(firestore, `boards/${boardId}/posts/${postId}/comments/${commentId}/replies`);
+  const unsubscribe = onSnapshot(repliesRef, (snapshot) => {
+    const fetchedReplies = snapshot.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    })) as Reply[];
+    setReplies(fetchedReplies);
+  });
+  return unsubscribe;
+}
+    


### PR DESCRIPTION
resolve #23 

- Post의 쿼리를 스케일이 커져도 효율적으로 만들기 위해, board > post > comment > reply 의 구조로 DB를 재편했습니다.
- post > comment > reply 를 바라보고 있던 CRUD 함수들의 레퍼런스를 모두 업데이트해줍니다.
- 현재 기존 데이터는 그대로 존재하는 상태에서 새로운 컬렉션에 복제만 한 것이고 아직 없어지지는 않았습니다. 
- 기능에 이상이 없는 것이 확인되면 나중에 지울 예정