### PR TITLE
Fix: 서버 데이터는 Date인데 TimeStamp로 잘못 파싱하고 있던 문제 해결

### DIFF
--- a/src/components/pages/post/EditPostPage.tsx
+++ b/src/components/pages/post/EditPostPage.tsx
@@ -90,7 +90,7 @@ export default function EditPostPage() {
             <h1 className='text-3xl font-bold'>{post.title}</h1>
             <div className='flex items-center justify-between text-sm text-muted-foreground'>
               <p>
-                작성자: {post.authorName} | 작성일: {post.createdAt.toLocaleString()}
+                작성자: {post.authorName} | 작성일: {post.createdAt?.toLocaleString() || '?'}
               </p>
             </div>
           </CardHeader>

--- a/src/components/pages/post/PostDetailPage.tsx
+++ b/src/components/pages/post/PostDetailPage.tsx
@@ -121,7 +121,7 @@ export default function PostDetailPage() {
           <h1 className='text-4xl font-bold leading-tight'>{post.title}</h1>
           <div className='flex items-center justify-between text-sm text-muted-foreground'>
             <p>
-              작성자: {authorNickname || '??'} | 작성일: {post.createdAt.toLocaleString()}
+              작성자: {authorNickname || '??'} | 작성일: {post.createdAt?.toLocaleString() || '?'}
             </p>
             {isAuthor && (
               <div className='flex space-x-2'>

--- a/src/components/pages/post/PostSummaryCard.tsx
+++ b/src/components/pages/post/PostSummaryCard.tsx
@@ -57,7 +57,7 @@ const PostSummaryCard: React.FC<PostSummaryCardProps> = ({ post, onClick }) => {
           <div className='ml-2'>
             <p className='text-sm font-medium'>{authorData?.nickname}</p>
             <p className='text-xs text-muted-foreground'>
-              {formatDistanceToNow(post.createdAt?.toLocaleString() || '?', { addSuffix: true })}
+              {post.createdAt?.toLocaleString() || '?'}
             </p>
           </div>
         </div>

--- a/src/components/pages/post/PostSummaryCard.tsx
+++ b/src/components/pages/post/PostSummaryCard.tsx
@@ -57,7 +57,7 @@ const PostSummaryCard: React.FC<PostSummaryCardProps> = ({ post, onClick }) => {
           <div className='ml-2'>
             <p className='text-sm font-medium'>{authorData?.nickname}</p>
             <p className='text-xs text-muted-foreground'>
-              {formatDistanceToNow(post.createdAt.toLocaleString(), { addSuffix: true })}
+              {formatDistanceToNow(post.createdAt?.toLocaleString() || '?', { addSuffix: true })}
             </p>
           </div>
         </div>

--- a/src/types/Posts.ts
+++ b/src/types/Posts.ts
@@ -8,7 +8,7 @@ export interface Post {
   content: string;
   authorId: string;
   authorName: string;
-  createdAt: Timestamp;
+  createdAt?: Date;
   comments: number;
-  updatedAt?: Timestamp;
+  updatedAt?: Date;
 }


### PR DESCRIPTION
- 서버 (DB) 데이터가 Date로 저장이 되어있어도, Timestamp로 파싱이 가능하다고 생각했음
- 왜냐하면 내 로컬 브라우저에서는 문제없이 잘 됐기 때문...?
- 그런데 특정 유저들의 기기에서는 그게 안 되어서 아예 런타임 에러가 나버리는 상황.
- '왜 내 기기에는 문제가 없었는가?' 원인을 잘 모르겠지만, 일단 Timestamp 파싱 문제임은 알아냈기 때문에 fix를 해봅니다.