### PR TITLE
Fix: 답글 갯수 카운트 안되는 문제 수정

### DIFF
--- a/src/components/pages/reply/Replies.tsx
+++ b/src/components/pages/reply/Replies.tsx
@@ -1,4 +1,3 @@
-import { collection, onSnapshot } from 'firebase/firestore';
 import React, { useState, useEffect } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -6,7 +5,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { addReplyToComment } from '@/utils/commentUtils';
 import ReplyInput from './ReplyInput';
 import ReplyList from './ReplyList';
-import { firestore } from '../../../firebase';
+import { fetchReplyCount } from '@/utils/replyUtils';
 
 interface RepliesProps {
   boardId: string;
@@ -32,13 +31,9 @@ const Replies: React.FC<RepliesProps> = ({ boardId, postId, commentId }) => {
   };
 
   useEffect(() => {
-    const repliesRef = collection(firestore, 'posts', postId, 'comments', commentId, 'replies');
-    const unsubscribe = onSnapshot(repliesRef, (snapshot) => {
-      setReplyCount(snapshot.size);
-    });
-
+    const unsubscribe = fetchReplyCount(boardId, postId, commentId, setReplyCount);
     return () => unsubscribe();
-  }, [postId, commentId]);
+  }, [boardId, postId, commentId]);
 
   const handleReply = () => {
     setReplyingTo(replyingTo === commentId ? null : commentId);

--- a/src/utils/replyUtils.ts
+++ b/src/utils/replyUtils.ts
@@ -13,4 +13,12 @@ export function fetchReplies(boardId: string, postId: string, commentId: string,
   });
   return unsubscribe;
 }
+
+export function fetchReplyCount(boardId: string, postId: string, commentId: string, setReplyCount: (count: number) => void) {
+  const repliesRef = collection(firestore, `boards/${boardId}/posts/${postId}/comments/${commentId}/replies`);
+  const unsubscribe = onSnapshot(repliesRef, (snapshot) => {
+    setReplyCount(snapshot.size);
+  });
+  return unsubscribe;
+}
     


### PR DESCRIPTION
- 얼마전 Post 위치를 마이그레이션하고 나서, 모두다 수정했다고 생각했는데, 답글 카운트하는 로직의 DB 주소가 잘못되어있었습니다.
- 수정합니다.
- Util 함수로 추출되어있지 않고 컴포넌트에 들어있어서 놓쳤던 것이므로, Util 함수로 추출도 합니다.