### PR TITLE
Fix: setState 가 useEffect 바깥에서 불려서 워닝있던 문제 해결

### DIFF
--- a/src/components/route/ProtectedRoute.tsx
+++ b/src/components/route/ProtectedRoute.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { Navigate, useLocation } from 'react-router-dom';
 
@@ -5,18 +6,21 @@ export const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
   const { currentUser, redirectPathAfterLogin, setRedirectPathAfterLogin } = useAuth();
   const location = useLocation();
 
-  // If the user is not logged in, redirect to login and store the current path
+  useEffect(() => {
+    if (!currentUser) {
+      setRedirectPathAfterLogin(location.pathname);
+    } else if (redirectPathAfterLogin) {
+      setRedirectPathAfterLogin(null);
+    }
+  }, [currentUser, location.pathname, redirectPathAfterLogin, setRedirectPathAfterLogin]);
+
   if (!currentUser) {
-    setRedirectPathAfterLogin(location.pathname);
     return <Navigate to="/login" />;
   }
 
-  // If the user is logged in but has a redirect path, navigate to it
-  if (currentUser && redirectPathAfterLogin) {
-    const redirectTo = redirectPathAfterLogin;
-    setRedirectPathAfterLogin(null);
-    return <Navigate to={redirectTo} />;
+  if (redirectPathAfterLogin) {
+    return <Navigate to={redirectPathAfterLogin} />;
   }
 
-  return children;
+  return <>{children}</>;
 };


### PR DESCRIPTION
- 컴포넌트가 렌더링되던 중에, state를 업데이트하려고 하면 에러가 납니다.
- state의 업데이트는 반드시 렌더링이 되고 나서 호출되도록 합니다.
- useEffect 를 사용한 뒤 그 안에 setState 관련 call을 넣어줍니다.