### PR TITLE
알림의 메시지를 클라이언트 사이드에서 포맷팅한다

### DIFF
--- a/src/components/pages/notification/NotificationItem.tsx
+++ b/src/components/pages/notification/NotificationItem.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Notification, NotificationType } from '@/types/Notification';
-import { MessageSquare } from 'lucide-react';
-import { Timestamp } from 'firebase/firestore';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
-
+import { fetchPostTitle } from '@/utils/postUtils';
+import { fetchUserNickname } from '@/utils/userUtils';
 interface NotificationItemProps {
   notification: Notification;
 }
@@ -14,29 +13,57 @@ function getNotificationLink(notification: Notification): string {
 }
 
 export const NotificationItem = ({ notification }: NotificationItemProps) => {
-    return (
-      <Link to={getNotificationLink(notification)}>
-        <div
-          className={`flex cursor-pointer items-start gap-3 border-b px-4 py-3 transition-all hover:bg-accent/50 ${
-            !notification.read ? 'bg-accent/30' : ''
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    generateMessage(notification).then(setMessage);
+  }, [notification]);
+
+  return (
+    <Link to={getNotificationLink(notification)}>
+      <div
+        className={`flex cursor-pointer items-start gap-3 border-b px-4 py-3 transition-all hover:bg-accent/50 ${!notification.read ? 'bg-accent/30' : ''
           }`}
-        >
-          <Avatar>
-            <AvatarImage src={notification.fromUserProfileImage} alt="User Avatar" />
-            <AvatarFallback>
-              {notification.fromUserId.slice(0, 2).toUpperCase()}
-            </AvatarFallback>
-          </Avatar>
-          <div className='flex-1 space-y-1'>
-            <p className='text-sm font-medium leading-tight text-foreground'>
-              {notification.message}
-            </p>
-            <span className='text-[11px] text-muted-foreground/80'>
-              {notification.timestamp.toDate().toLocaleString()}
-            </span>
-          </div>
+      >
+        <Avatar>
+          <AvatarImage src={notification.fromUserProfileImage} alt="User Avatar" />
+          <AvatarFallback>
+            {notification.fromUserId.slice(0, 2).toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+        <div className='flex-1 space-y-1'>
+          <p className='text-sm font-medium leading-tight text-foreground'>
+            {message}
+          </p>
+          <span className='text-[11px] text-muted-foreground/80'>
+            {notification.timestamp.toDate().toLocaleString()}
+          </span>
         </div>
-      </Link>
-    );
-  };
-  
+      </div>
+    </Link>
+  );
+};
+
+
+const generateMessage = async (notification: Notification) => {
+  const postTitle = await fetchPostTitle(notification.boardId, notification.postId);
+  const postTitleSnippet = generateTitleSnippet(postTitle || '');
+
+  const userNickName = await fetchUserNickname(notification.fromUserId);
+
+  switch (notification.type) {
+    case NotificationType.COMMENT_ON_POST:
+      return `${userNickName}님이 ${postTitleSnippet} 글에 댓글을 달았어요.`;
+    case NotificationType.REPLY_ON_COMMENT:
+      return `${userNickName}님이 ${postTitleSnippet} 댓글에 답글을 달았어요.`;
+    case NotificationType.REPLY_ON_POST:
+      return `${userNickName}님이 ${postTitleSnippet} 글에 답글을 달았어요.`;
+  }
+}
+
+const generateTitleSnippet = (contentTitle: string) => {
+  if (contentTitle.length > 12) {
+    return contentTitle.slice(0, 12) + "...";
+  }
+  return contentTitle;
+}

--- a/src/components/pages/notification/NotificationMessage.tsx
+++ b/src/components/pages/notification/NotificationMessage.tsx
@@ -1,0 +1,37 @@
+import { NotificationType } from "@/types/Notification";
+
+interface NotificationMessageProps {
+    userNickName: string;
+    postTitle: string;
+    notificationType: NotificationType;
+}
+
+export const NotificationMessage = ({ userNickName, postTitle, notificationType }: NotificationMessageProps) => {
+  switch (notificationType) {
+      case NotificationType.COMMENT_ON_POST:
+        return (
+          <>
+            {userNickName}님이 <strong>'{postTitleSnippet(postTitle)}'</strong> 글에 댓글을 달았어요.
+          </>
+        );
+      case NotificationType.REPLY_ON_COMMENT:
+        return (
+          <>
+            {userNickName}님이 <strong>'{postTitleSnippet(postTitle)}'</strong> 댓글에 답글을 달았어요.
+          </>
+        );
+      case NotificationType.REPLY_ON_POST:
+        return (
+          <>
+            {userNickName}님이 <strong>'{postTitleSnippet(postTitle)}'</strong> 글에 답글을 달았어요.
+          </>
+        );
+    }
+  };
+  
+  const postTitleSnippet = (contentTitle: string) => {
+    if (contentTitle.length > 24) {
+      return contentTitle.slice(0, 24) + "...";
+    }
+    return contentTitle;
+  };

--- a/src/utils/postUtils.ts
+++ b/src/utils/postUtils.ts
@@ -28,6 +28,11 @@ export const fetchPost = async (boardId: string, postId: string): Promise<Post |
   return mapDocToPost(docSnap, boardId);
 };
 
+export const fetchPostTitle = async (boardId: string, postId: string): Promise<string | undefined> => {
+  const post = await fetchPost(boardId, postId);
+  return post?.title
+}
+
 export async function fetchPosts(boardId: string, selectedAuthorId: string | null): Promise<Post[]> {
   let q = query(
     collection(firestore, `boards/${boardId}/posts`),


### PR DESCRIPTION
- 알림에 메시지를 직접 넣기보다는, postId, userId 등을 사용해서 직접 클라이언트 사이드에서 메시지를 조합해서 만드는 게 낫겠다고 판단
- 수정하는 김에 제목을 최대 12자로 했다가 너무 짧은 거 같아 24자로 늘림.
- 글 제목에 bold 추가