### PR TITLE
푸시 알림 설정 시 푸시 지원 여부를 판단해서 안내를 해준다

### DIFF
--- a/src/components/pages/BottomTabsNavigator.tsx
+++ b/src/components/pages/BottomTabsNavigator.tsx
@@ -1,3 +1,4 @@
+import { useSafeArea } from '@/hooks/useSafeArea';
 import { Home, Bell, User } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 
@@ -9,9 +10,13 @@ const tabs = [
 
 export default function BottomTabsNavigator() {
   const location = useLocation();
+  const { bottom: safeAreaBottom } = useSafeArea();
 
   return (
-    <nav className='fixed inset-x-0 bottom-0 border-t border-border bg-background'>
+    <nav 
+    className='fixed inset-x-0 bottom-0 border-t border-border bg-background'
+    style={{ paddingBottom: `${safeAreaBottom}px` }}
+    >
       <div className='flex justify-around'>
         {tabs.map((tab) => (
           <Link

--- a/src/hooks/usePushSupport.ts
+++ b/src/hooks/usePushSupport.ts
@@ -1,0 +1,56 @@
+import { useState, useEffect } from 'react';
+
+interface PushSupportState {
+  isIOSSafari: boolean;
+  isPWA: boolean;
+  isPushSupported: boolean;
+}
+
+export const usePushSupport = (): PushSupportState => {
+  const [isIOSSafari, setIsIOSSafari] = useState(false);
+  const [isPWA, setIsPWA] = useState(false);
+  const [isPushSupported, setIsPushSupported] = useState(false);
+
+  useEffect(() => {
+    // 푸시 알림 지원 여부 확인
+    const checkPushSupport = () => {
+      return 'Notification' in window && 
+             'serviceWorker' in navigator && 
+             'PushManager' in window;
+    };
+
+    // iOS Safari 체크
+    const checkIOSSafari = () => {
+      const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+      const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+      return isIOS && isSafari;
+    };
+
+    // PWA 체크
+    const checkPWA = () => {
+      return window.matchMedia('(display-mode: standalone)').matches;
+    };
+
+    setIsIOSSafari(checkIOSSafari());
+    setIsPWA(checkPWA());
+    setIsPushSupported(checkPushSupport());
+
+    // PWA 상태 변경 감지
+    const mediaQuery = window.matchMedia('(display-mode: standalone)');
+    const handleChange = (e: MediaQueryListEvent) => {
+      setIsPWA(e.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  return {
+    isIOSSafari,
+    isPWA,
+    isPushSupported,
+  };
+};

--- a/src/hooks/useSafeArea.ts
+++ b/src/hooks/useSafeArea.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+
+interface SafeArea {
+  top: number;
+  bottom: number;
+}
+
+export function useSafeArea(): SafeArea {
+  const [safeArea, setSafeArea] = useState<SafeArea>({ top: 0, bottom: 0 });
+
+  useEffect(() => {
+    const updateSafeArea = () => {
+      const windowHeight = window.innerHeight;
+      const documentHeight = document.documentElement.clientHeight;
+      const topPadding = (window as any).screenTop ?? 0;
+      const bottomPadding = Math.max((windowHeight - documentHeight - topPadding), 0);
+
+      setSafeArea({
+        top: topPadding,
+        bottom: bottomPadding,
+      });
+    };
+
+    updateSafeArea();
+    window.addEventListener('resize', updateSafeArea);
+    return () => window.removeEventListener('resize', updateSafeArea);
+  }, []);
+
+  return safeArea;
+}
+


### PR DESCRIPTION
- iOS 사파리인 경우, 홈에 PWA 앱 형태로 추가를 해야함.
- 그 외에도 아예 푸시가 지원이 안되는 브라우저가 있음.
- 해당 사항을 알림 설정 페이지에 안내함.