### PR TITLE
fix: 카카오톡에서 메시징이 지원되지 않는 문제 해결

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -9,8 +9,7 @@ import {
 } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
-import { getMessaging, onMessage } from "firebase/messaging";
-import onMessageInForeground from "./messaging/foregroundMessage";
+import { initializeMessaging } from './messaging';
 const firebaseConfig = {
   apiKey: process.env.VITE_FIREBASE_API_KEY as string,
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN as string,
@@ -27,7 +26,7 @@ const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const firestore = getFirestore(app);
 const storage = getStorage(app);
-const messaging = getMessaging(app);
+const messaging = initializeMessaging(app);
 
 // Google Auth Provider
 const provider = new GoogleAuthProvider();
@@ -52,8 +51,6 @@ const signOutUser = (): Promise<void> => {
       throw error;
     });
 };
-
-onMessage(messaging, onMessageInForeground);
 
 
 export { auth, firestore, signInWithGoogle, signOutUser, storage, messaging };

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -1,0 +1,16 @@
+import { getMessaging, Messaging, onMessage } from "firebase/messaging";
+import onMessageInForeground from "./messaging/foregroundMessage";
+import { FirebaseApp } from "firebase/app";
+
+// handle error if browser doesn't support firebase messaging  
+export function initializeMessaging(app: FirebaseApp): Messaging | null {
+    let messaging: Messaging | null = null;
+    try {
+        messaging = getMessaging(app);
+        onMessage(messaging, onMessageInForeground);
+    } catch (error) {
+        console.error('Firebase messaging은 이 브라우저에서 지원되지 않습니다:', error);
+        messaging = null;
+    }
+    return messaging;
+}

--- a/src/messaging/requestPermission.ts
+++ b/src/messaging/requestPermission.ts
@@ -6,9 +6,13 @@ export async function checkExistingPermission(): Promise<void> {
     const permission = Notification.permission;
     if (permission === "granted") {
         // user already granted permission in the past
-        const token = await requestFirebaseToken();
-        if (token) {
-            console.log("Existing token:", token);
+        try {
+            const token = await requestFirebaseToken();
+            if (token) {
+                console.log("Existing token:", token);
+            }
+        } catch (error) {
+            console.error("Error getting token:", error);
         }
     }
 }
@@ -32,6 +36,9 @@ export async function requestPermission(userId: string): Promise<void> {
 
 
 export async function requestFirebaseToken(): Promise<string | null> {
+    if (!messaging) { 
+        throw new Error('Firebase messaging is not supported in this browser');
+    }
     try {
         const vapidKey = import.meta.env.VITE_FIREBASE_VAPID_KEY as string;
         const token = await getToken(messaging, { vapidKey });


### PR DESCRIPTION
- sentry로 추적해보니 다음과 같은 에러가 떠있었다.
> Messaging: This browser doesn't support the API's required to use the Firebase SDK. (messaging/unsupported-browser
- 카카오톡 브라우저는 Firebase SDK가 지원되지 않나보다.
- 이런 경우 에러를 던진다면 그냥 messaging을 초기화하지 않는 것으로 하고 기능을 비활성화