### PR TITLE
글(Post)의 댓글/답글 갯수를 최신으로 업데이트하는 배치 프로세싱 추가

### DIFF
--- a/functions/src/notifications/updateCommentRepliesCounts.ts
+++ b/functions/src/notifications/updateCommentRepliesCounts.ts
@@ -1,44 +1,120 @@
 import * as admin from 'firebase-admin';
 import { onRequest } from 'firebase-functions/https';
 
-// 이 함수는 모든 게시판의 모든 게시글의 모든 댓글의 모든 대댓글의 개수를 가장 최신 상태로 업데이트합니다.
-export const updateCommentRepliesCounts = onRequest(async (req, res) => {
-    const everyBoardDocs = (await admin.firestore().collection('boards').get()).docs;
+const BATCH_SIZE = 100;
+const FUNCTION_TIMEOUT = 540000; // 9분
 
-    for (const boardDoc of everyBoardDocs) {
-        const boardId = boardDoc.id;
-        await updatePostCounts(boardId, boardDoc);
-    }
+interface BatchStats {
+  processedBoards: number;
+  processedPosts: number;
+  errors: string[];
+  startTime: number;
+}
 
-    res.send('Comment/Reply counts updated successfully');
+// 배치 처리 상태 관리
+const createStats = (): BatchStats => ({
+  processedBoards: 0,
+  processedPosts: 0,
+  errors: [],
+  startTime: Date.now()
 });
 
-async function updatePostCounts(boardId: string, boardDoc: FirebaseFirestore.QueryDocumentSnapshot) {
-    const everyPostDocs = (await boardDoc.ref.collection('posts').get()).docs;
-    for (const postDoc of everyPostDocs) {
-        const postId = postDoc.id;
-        await updateCommentAndReplyCounts(boardId, postId, postDoc);
+export const updateCommentRepliesCounts = onRequest(async (req, res) => {
+  const stats = createStats();
+  const db = admin.firestore();
+
+  try {
+    const boardsSnapshot = await db.collection('boards').get();
+
+    for (const boardDoc of boardsSnapshot.docs) {
+      await processBoard(boardDoc, stats);
+      stats.processedBoards++;
+
+      // 타임아웃 체크
+      if (Date.now() - stats.startTime > FUNCTION_TIMEOUT) {
+        throw new Error('Function timeout approaching');
+      }
     }
-}
 
-async function updateCommentAndReplyCounts(boardId: string, postId: string, postDoc: FirebaseFirestore.QueryDocumentSnapshot) {
-    const everyCommentDocs = (await postDoc.ref.collection('comments').get()).docs;
-    const commentCount = everyCommentDocs.length;
+    res.json({
+      success: true,
+      stats: {
+        ...stats,
+        executionTime: `${(Date.now() - stats.startTime) / 1000} seconds`
+      }
+    });
 
-    for (const commentDoc of everyCommentDocs) {
-        const repliesCount = await getRepliesCount(commentDoc);
+  } catch (error) {
+    console.error('Error in updateCommentRepliesCounts:', error);
+    res.status(500).json({
+      success: false,
+      error: error,
+      stats: {
+        ...stats,
+        executionTime: `${(Date.now() - stats.startTime) / 1000} seconds`
+      }
+    });
+  }
+});
+
+async function processBoard(
+  boardDoc: FirebaseFirestore.QueryDocumentSnapshot,
+  stats: BatchStats
+) {
+  const db = admin.firestore();
+  let lastDoc = null;
+
+  do {
+    // 배치 크기만큼 게시물 조회
+    let query = boardDoc.ref.collection('posts')
+      .orderBy('createdAt')
+      .limit(BATCH_SIZE);
+    
+    if (lastDoc) {
+      query = query.startAfter(lastDoc);
+    }
+
+    const postsSnapshot = await query.get();
+    if (postsSnapshot.empty) break;
+
+    // 트랜잭션으로 배치 처리
+    await db.runTransaction(async (transaction) => {
+      for (const postDoc of postsSnapshot.docs) {
         try {
-            await admin.firestore().doc(`boards/${boardId}/posts/${postId}`).update({
-                countOfComments: commentCount,
-                countOfReplies: repliesCount
-            });
+          const counts = await getCommentAndReplyCounts(postDoc.ref, transaction);
+          
+          transaction.update(postDoc.ref, {
+            countOfComments: counts.commentCount,
+            countOfReplies: counts.replyCount,
+            updatedAt: admin.firestore.FieldValue.serverTimestamp()
+          });
+
+          stats.processedPosts++;
         } catch (error) {
-            console.error(`Error updating comment/reply counts on post ${postId} of board ${boardId}:`, error);
+          stats.errors.push(`Error processing post ${postDoc.id}: ${error}`);
+          console.error(`Error processing post ${postDoc.id}:`, error);
         }
-    }
+      }
+    });
+
+    lastDoc = postsSnapshot.docs[postsSnapshot.docs.length - 1];
+    console.log(`Processed ${stats.processedPosts} posts in board ${boardDoc.id}`);
+
+  } while (lastDoc);
 }
 
-async function getRepliesCount(commentDoc: FirebaseFirestore.QueryDocumentSnapshot): Promise<number> {
-    const everyReplyDocs = (await commentDoc.ref.collection('replies').get()).docs;
-    return everyReplyDocs.length;
+async function getCommentAndReplyCounts(
+  postRef: FirebaseFirestore.DocumentReference,
+  transaction: FirebaseFirestore.Transaction
+): Promise<{ commentCount: number; replyCount: number }> {
+  const commentsSnapshot = await transaction.get(postRef.collection('comments'));
+  const commentCount = commentsSnapshot.size;
+
+  let totalReplyCount = 0;
+  await Promise.all(commentsSnapshot.docs.map(async (commentDoc) => {
+    const replySnapshot = await transaction.get(commentDoc.ref.collection('reply'));
+    totalReplyCount += replySnapshot.size;
+  }));
+
+  return { commentCount, replyCount: totalReplyCount };
 }

--- a/functions/src/notifications/updateCommentRepliesCounts.ts
+++ b/functions/src/notifications/updateCommentRepliesCounts.ts
@@ -124,7 +124,7 @@ async function getCommentAndReplyCounts(
     // 1. 모든 읽기 작업을 배열로 수집
     const commentsSnapshot = await transaction.get(postRef.collection('comments'));
     const replyReads = commentsSnapshot.docs.map(commentDoc => 
-      transaction.get(commentDoc.ref.collection('reply'))
+      transaction.get(commentDoc.ref.collection('replies'))
     );
     
     // 2. 모든 읽기 작업을 한번에 실행

--- a/src/utils/mapDocToPost.ts
+++ b/src/utils/mapDocToPost.ts
@@ -1,11 +1,8 @@
 import { Post } from "../types/Posts";
-import { QueryDocumentSnapshot, DocumentData, collection, getDocs } from "firebase/firestore";
-import { firestore } from "@/firebase";
+import { QueryDocumentSnapshot, DocumentData } from "firebase/firestore";
 
 export async function mapDocToPost(docSnap: QueryDocumentSnapshot<DocumentData>): Promise<Post> {
     const data = docSnap.data();
-    const countOfComments = data.countOfComments ? data.countOfComments : await getCommentsCount(data.boardId, docSnap.id);
-    const countOfReplies = data.countOfReplies ? data.countOfReplies : await getRepliesCount(data.boardId, docSnap.id);
     return {
         id: docSnap.id,
         boardId: data.boardId,
@@ -13,27 +10,10 @@ export async function mapDocToPost(docSnap: QueryDocumentSnapshot<DocumentData>)
         content: data.content,
         authorId: data.authorId,
         authorName: data.authorName,
-        countOfComments: countOfComments,
-        countOfReplies: countOfReplies,
+        countOfComments: data.countOfComments,
+        countOfReplies: data.countOfReplies,
         createdAt: data.createdAt?.toDate(),
         updatedAt: data.updatedAt?.toDate(),
         weekDaysFromFirstDay: data.weekDaysFromFirstDay,
     };
-}
-
-// get comment count in the post
-async function getCommentsCount(boardId: string, postId: string): Promise<number> {
-    const commentsSnapshot = await getDocs(collection(firestore, `boards/${boardId}/posts/${postId}/comments`));
-    return commentsSnapshot.docs.length
-}
-
-// get replies count of every comment in the post
-async function getRepliesCount(boardId: string, postId: string): Promise<number> {
-    const repliesSnapshot = await getDocs(collection(firestore, `boards/${boardId}/posts/${postId}/comments`));
-    const repliesCount = await Promise.all(
-        repliesSnapshot.docs.map(async (reply) => {
-            return Number(reply.exists());
-        }),
-    );
-    return repliesCount.reduce((acc, curr) => acc + curr, 0);
 }


### PR DESCRIPTION
- 서버에서 한꺼번에 DB를 업데이트해야할 로직이 있었는데, 중간에 에러가 나면 잘 알수가 없고, 끊기게 된다.
- 에러가 나면 중간에 정확한 리포팅이 되고, 배치 크기별로 나눠서 수행하는 배치 프로세싱 로직을 추가한다.
- transaction을 사용해서 DB 정합성을 보장.
- transaction 안에서는 모든 읽기가 모든 쓰기 앞에 일어나야해서 해당 로직을 보강.
- 업데이트가 잘 끝나서, 클라이언트에 있던 로직은 삭제