### PR TITLE
글 에디터에서 이미지를 업로드할 수 있게 된다

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-alert-dialog": "^1.1.2",
         "@radix-ui/react-avatar": "^1.1.1",
         "@radix-ui/react-label": "^2.1.0",
+        "@radix-ui/react-progress": "^1.1.1",
         "@radix-ui/react-scroll-area": "^1.2.1",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-switch": "^1.1.1",
@@ -1681,6 +1682,82 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.1.tgz",
+      "integrity": "sha512-6diOawA84f/eMxFHcWut0aE1C2kyE9dOyCTQOMRR2C/qPiXz/X0SaiA/RLbapQaXUCmy0/hLMf9meSccD1N0pA==",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.2",
     "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-progress": "^1.1.1",
     "@radix-ui/react-scroll-area": "^1.2.1",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.1",

--- a/src/components/pages/post/PostCard.tsx
+++ b/src/components/pages/post/PostCard.tsx
@@ -1,4 +1,3 @@
-import DOMPurify from 'dompurify';
 import { MessageCircle, User } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
@@ -8,6 +7,7 @@ import { Post } from '@/types/Posts';
 import { User as Author } from '@/types/User';
 import { fetchUserData } from '@/utils/userUtils';
 import { Badge } from '@/components/ui/badge';
+import { getContentPreview } from '@/utils/contentUtils';
 
 interface PostCardProps {
   post: Post;
@@ -15,13 +15,13 @@ interface PostCardProps {
 }
 
 const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
-  const sanitizedContent = DOMPurify.sanitize(post.content);
+  const contentPreview = getContentPreview(post.content);
 
   const { data: authorData, error } = useQuery<Author | null>(
     ['authorData', post.authorId],
     () => fetchUserData(post.authorId),
     {
-      staleTime: 60 * 1000, // 1 minute
+      staleTime: 60 * 1000,
     }
   );
 
@@ -61,9 +61,9 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
       <Link to={`/board/${post.boardId}/post/${post.id}`} onClick={onClick}>
         <CardContent className='cursor-pointer p-6 transition-colors duration-200 hover:bg-muted'>
           <div
-            className='line-clamp-5'
-            dangerouslySetInnerHTML={{ __html: sanitizedContent }}
-          ></div>
+            className='line-clamp-3 text-sm text-muted-foreground'
+            dangerouslySetInnerHTML={{ __html: contentPreview }}
+          />
         </CardContent>
       </Link>
       <CardFooter>

--- a/src/components/pages/post/PostCard.tsx
+++ b/src/components/pages/post/PostCard.tsx
@@ -59,11 +59,20 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
         </div>
       </CardHeader>
       <Link to={`/board/${post.boardId}/post/${post.id}`} onClick={onClick}>
-        <CardContent className='cursor-pointer p-6 transition-colors duration-200 hover:bg-muted'>
+        <CardContent className='cursor-pointer space-y-4 p-6 transition-colors duration-200 hover:bg-muted'>
           <div
             className='line-clamp-3 text-sm text-muted-foreground'
             dangerouslySetInnerHTML={{ __html: contentPreview }}
           />
+          {post.thumbnailImageURL && (
+            <div className='aspect-video w-full overflow-hidden rounded-lg bg-muted'>
+              <img
+                src={post.thumbnailImageURL}
+                alt="게시글 썸네일"
+                className='h-full w-full object-cover transition-transform duration-300 hover:scale-105'
+              />
+            </div>
+          )}
         </CardContent>
       </Link>
       <CardFooter>

--- a/src/components/pages/post/PostCard.tsx
+++ b/src/components/pages/post/PostCard.tsx
@@ -61,7 +61,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
       <Link to={`/board/${post.boardId}/post/${post.id}`} onClick={onClick}>
         <CardContent className='cursor-pointer space-y-4 p-6 transition-colors duration-200 hover:bg-muted'>
           <div
-            className='line-clamp-3 text-sm text-muted-foreground'
+            className='prose prose-lg prose-slate dark:prose-invert line-clamp-3'
             dangerouslySetInnerHTML={{ __html: contentPreview }}
           />
           {post.thumbnailImageURL && (

--- a/src/components/pages/post/PostCard.tsx
+++ b/src/components/pages/post/PostCard.tsx
@@ -30,7 +30,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
   }
 
   return (
-    <Card className='mb-4'>
+    <Card>
       <CardHeader>
         <div className='flex items-center gap-2'>
           {post.weekDaysFromFirstDay !== undefined && (
@@ -59,7 +59,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
         </div>
       </CardHeader>
       <Link to={`/board/${post.boardId}/post/${post.id}`} onClick={onClick}>
-        <CardContent className='cursor-pointer space-y-4 p-6 transition-colors duration-200 hover:bg-muted'>
+        <CardContent className='cursor-pointer p-6 transition-colors duration-200 hover:bg-muted'>
           <div
             className='prose prose-lg prose-slate dark:prose-invert line-clamp-3'
             dangerouslySetInnerHTML={{ __html: contentPreview }}
@@ -75,7 +75,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick }) => {
           )}
         </CardContent>
       </Link>
-      <CardFooter>
+      <CardFooter className='pt-2'>
         <div className='flex items-center'>
           <MessageCircle className='mr-1 size-4' />
           <p className='text-sm'>{post.countOfComments + post.countOfReplies}</p>

--- a/src/components/pages/post/PostTextEditor.tsx
+++ b/src/components/pages/post/PostTextEditor.tsx
@@ -10,7 +10,6 @@ interface PostTextEditorProps {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
-  postId?: string; // 이미지 저장 경로를 위한 postId
 }
 
 const quillStyles = `
@@ -126,11 +125,24 @@ const quillStyles = `
 }
 `;
 
+const formatDate = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+
+  return {
+    dateFolder: `${year}${month}${day}`,
+    timePrefix: `${hours}${minutes}${seconds}`
+  };
+};
+
 export function PostTextEditor({ 
   value, 
   onChange, 
   placeholder = '내용을 입력하세요...', 
-  postId = 'temp' 
 }: PostTextEditorProps) {
   const quillRef = useRef<any>(null);
   const { toast } = useToast();
@@ -174,9 +186,11 @@ export function PostTextEditor({
         // 업로드 시작 표시
         setUploadProgress(20);
 
-        // 파일명 생성
-        const fileName = `${Date.now()}_${file.name}`;
-        const storageRef = ref(storage, `postImages/${postId}/${fileName}`);
+        // 날짜 기반 파일 경로 생성
+        const now = new Date();
+        const { dateFolder, timePrefix } = formatDate(now);
+        const fileName = `${timePrefix}_${file.name}`;
+        const storageRef = ref(storage, `postImages/${dateFolder}/${fileName}`);
 
         // 파일 업로드
         setUploadProgress(40);
@@ -236,7 +250,7 @@ export function PostTextEditor({
         },
       },
     }),
-    [postId, toast]
+    [toast]
   );
 
   useEffect(() => {

--- a/src/components/pages/post/PostTextEditor.tsx
+++ b/src/components/pages/post/PostTextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef, useMemo } from 'react';
 import ReactQuill from 'react-quill-new';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { storage } from '../../../firebase';
@@ -185,21 +185,6 @@ const imageHandler = async (postId: string, quillRef: any, toast: any) => {
   };
 };
 
-const modules = (postId: string, quillRef: any, toast: any) => ({
-  toolbar: {
-    container: [
-      ['bold', 'underline', 'strike'],
-      ['blockquote'],
-      [{ 'header': 1 }, { 'header': 2 }],
-      [{ 'list': 'ordered'}, { 'list': 'bullet' }],
-      ['link', 'image'],
-    ],
-    handlers: {
-      image: () => imageHandler(postId, quillRef, toast),
-    },
-  },
-});
-
 const formats = [
   'bold', 'underline', 'strike',
   'blockquote', 'header',
@@ -214,6 +199,25 @@ export function PostTextEditor({
 }: PostTextEditorProps) {
   const quillRef = useRef<any>(null);
   const { toast } = useToast();
+
+  // modules를 useMemo로 메모이제이션
+  const modules = useMemo(
+    () => ({
+      toolbar: {
+        container: [
+          ['bold', 'underline', 'strike'],
+          ['blockquote'],
+          [{ 'header': 1 }, { 'header': 2 }],
+          [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+          ['link', 'image'],
+        ],
+        handlers: {
+          image: () => imageHandler(postId, quillRef, toast),
+        },
+      },
+    }),
+    [postId, toast] // postId와 toast가 변경될 때만 재생성
+  );
 
   useEffect(() => {
     const styleTag = document.createElement('style');
@@ -233,7 +237,7 @@ export function PostTextEditor({
         onChange={onChange}
         placeholder={placeholder}
         theme="snow"
-        modules={modules(postId, quillRef, toast)}
+        modules={modules}
         formats={formats}
         className="prose prose-lg prose-slate dark:prose-invert prose-h1:text-3xl prose-h1:font-semibold prose-h2:text-2xl prose-h2:font-semibold"
       />

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/src/types/Posts.ts
+++ b/src/types/Posts.ts
@@ -4,6 +4,7 @@ export interface Post {
   boardId: string;
   title: string;
   content: string;
+  thumbnailImageURL?: string;
   authorId: string;
   authorName: string;
   createdAt?: Date;

--- a/src/utils/contentUtils.ts
+++ b/src/utils/contentUtils.ts
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 function convertUrlsToLinks(content: string): string {
   const urlRegex =
     /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\\/%?=~_|!:,.;]*[-A-Z0-9+&@#\\/%=~_|]|\bwww\.[-A-Z0-9+&@#\\/%?=~_|!:,.;]*[-A-Z0-9+&@#\\/%=~_|]|\b[-A-Z0-9+&@#\\/%?=~_|!:,.;]+\.[A-Z]{2,4}\b)/gi;
@@ -7,4 +9,26 @@ function convertUrlsToLinks(content: string): string {
   });
 }
 
-export { convertUrlsToLinks };
+const getContentPreview = (content: string) => {
+  // 1. XSS 방지를 위한 콘텐츠 정제
+  const sanitizedContent = DOMPurify.sanitize(content);
+
+  // 2. 이미지 제거
+  const removeImages = (html: string) => {
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = html;
+
+    // 모든 이미지 태그 제거
+    const images = tempDiv.getElementsByTagName('img');
+    while (images.length > 0) {
+      images[0].parentNode?.removeChild(images[0]);
+    }
+
+    return tempDiv.innerHTML;
+  };
+
+  // 3. 정제된 콘텐츠에서 이미지 제거
+  return removeImages(sanitizedContent);
+};
+
+export { convertUrlsToLinks, getContentPreview };

--- a/src/utils/contentUtils.ts
+++ b/src/utils/contentUtils.ts
@@ -13,22 +13,36 @@ const getContentPreview = (content: string) => {
   // 1. XSS 방지를 위한 콘텐츠 정제
   const sanitizedContent = DOMPurify.sanitize(content);
 
-  // 2. 이미지 제거
-  const removeImages = (html: string) => {
+  // 2. 이미지와 제목 태그 처리
+  const processContent = (html: string) => {
     const tempDiv = document.createElement('div');
     tempDiv.innerHTML = html;
-
-    // 모든 이미지 태그 제거
+    
+    // 이미지 태그 제거
+    // - 이미지는 별도의 썸네일 영역에 표시되므로 미리보기에서는 제거
+    // - 이미지가 포함되면 미리보기의 높이가 불규칙해지는 것을 방지
     const images = tempDiv.getElementsByTagName('img');
-    while (images.length > 0) {
+    while(images.length > 0) {
       images[0].parentNode?.removeChild(images[0]);
     }
-
+    
+    // 제목 태그(h1~h6)를 p 태그로 변환
+    // - 제목 태그는 큰 여백과 큰 글자 크기를 가져 미리보기의 공간을 비효율적으로 사용
+    // - 카드 형태의 미리보기에서는 모든 텍스트가 일관된 크기로 표시되는 것이 더 깔끔
+    ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].forEach(tag => {
+      const headings = tempDiv.getElementsByTagName(tag);
+      while(headings.length > 0) {
+        const heading = headings[0];
+        const p = document.createElement('p');
+        p.innerHTML = heading.innerHTML;
+        heading.parentNode?.replaceChild(p, heading);
+      }
+    });
+    
     return tempDiv.innerHTML;
   };
 
-  // 3. 정제된 콘텐츠에서 이미지 제거
-  return removeImages(sanitizedContent);
+  return processContent(sanitizedContent);
 };
 
 export { convertUrlsToLinks, getContentPreview };

--- a/src/utils/mapDocToPost.ts
+++ b/src/utils/mapDocToPost.ts
@@ -2,8 +2,9 @@ import { Post } from "../types/Posts";
 import { QueryDocumentSnapshot, DocumentData } from "firebase/firestore";
 
 export async function mapDocToPost(docSnap: QueryDocumentSnapshot<DocumentData>): Promise<Post> {
-    const data = docSnap.data();
-    return {
+    const data = docSnap.data()
+    // convert data into Post type
+    const post: Post = {
         id: docSnap.id,
         boardId: data.boardId,
         title: data.title,
@@ -15,5 +16,7 @@ export async function mapDocToPost(docSnap: QueryDocumentSnapshot<DocumentData>)
         createdAt: data.createdAt?.toDate(),
         updatedAt: data.updatedAt?.toDate(),
         weekDaysFromFirstDay: data.weekDaysFromFirstDay,
+        thumbnailImageURL: data.thumbnailImageURL,
     };
+    return post;
 }

--- a/src/utils/postUtils.ts
+++ b/src/utils/postUtils.ts
@@ -42,6 +42,7 @@ export async function createPost(boardId: string, title: string, content: string
     boardId,
     title,
     content,
+    thumbnailImageURL: extractFirstImageUrl(content),
     authorId,
     authorName,
     countOfComments: 0,
@@ -55,6 +56,7 @@ export async function updatePost(boardId: string, postId: string, content: strin
   const docRef = doc(firestore, `boards/${boardId}/posts`, postId);
   await updateDoc(docRef, {
     content,
+    thumbnailImageURL: extractFirstImageUrl(content),
     updatedAt: serverTimestamp(),
   });
 }
@@ -71,4 +73,16 @@ export const fetchAdjacentPosts = async (boardId: string, currentPostId: string)
     prevPost: currentIndex < posts.length - 1 ? posts[currentIndex + 1].id : null,
     nextPost: currentIndex > 0 ? posts[currentIndex - 1].id : null
   };
+};
+
+export const extractFirstImageUrl = (content: string): string | undefined => {
+  try {
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = content;
+    const firstImage = tempDiv.querySelector('img');
+    return firstImage?.src || undefined;
+  } catch (error) {
+    console.error('Error extracting image URL:', error);
+    return undefined;
+  }
 };


### PR DESCRIPTION
resolve #3 

- 드디어 글과 함께 이미지를 올리는 기능 추가
- 이미지를 firebase에 업로드하고 에디터에 끼워넣어준다.
- 작성이 끝나면 '첫번째 이미지'를 썸네일로 서버에 저장
- 게시판 페이지에서는 썸네일 이미지만 카드에 보여준다.