### PR TITLE
이미지가 없을 때 글을 생성할 수 없는 문제 해결

### DIFF
--- a/src/types/Posts.ts
+++ b/src/types/Posts.ts
@@ -4,7 +4,7 @@ export interface Post {
   boardId: string;
   title: string;
   content: string;
-  thumbnailImageURL?: string;
+  thumbnailImageURL: string | null;
   authorId: string;
   authorName: string;
   createdAt?: Date;

--- a/src/utils/postUtils.ts
+++ b/src/utils/postUtils.ts
@@ -6,8 +6,6 @@ import {
   serverTimestamp,
   updateDoc,
   getDocs,
-  DocumentData,
-  QueryDocumentSnapshot,
   query,
   orderBy
 } from 'firebase/firestore';
@@ -75,14 +73,14 @@ export const fetchAdjacentPosts = async (boardId: string, currentPostId: string)
   };
 };
 
-export const extractFirstImageUrl = (content: string): string | undefined => {
+export const extractFirstImageUrl = (content: string): string | null => {
   try {
     const tempDiv = document.createElement('div');
     tempDiv.innerHTML = content;
     const firstImage = tempDiv.querySelector('img');
-    return firstImage?.src || undefined;
+    return firstImage?.src || null;
   } catch (error) {
     console.error('Error extracting image URL:', error);
-    return undefined;
+    return null;
   }
 };


### PR DESCRIPTION
- 이미지가 없으면 undefined 로 올라가게 되어있었다.
- firebase에서는 undefined를 받아주지 않으므로, 데이터가 없으면 null로 올린다.
- Optional property 는 string or undefined다. null이 될 수 없다.