### PR TITLE
게시판 메인 페이지에서 나는 에러에 대한 처리 강화

### DIFF
--- a/src/components/pages/board/BoardPage.tsx
+++ b/src/components/pages/board/BoardPage.tsx
@@ -18,17 +18,30 @@ export default function BoardPage() {
       return;
     }
 
-    // Restore scroll position
-    const savedScrollPosition = sessionStorage.getItem(`scrollPosition-${boardId}`);
-    if (savedScrollPosition) {
-      setTimeout(() => {
-        window.scrollTo(0, parseInt(savedScrollPosition, 10));
-      }, 0);
+    try {
+      const savedScrollPosition = sessionStorage.getItem(`scrollPosition-${boardId}`);
+      if (savedScrollPosition) {
+        window.requestAnimationFrame(() => {
+          try {
+            window.scrollTo({
+              top: parseInt(savedScrollPosition, 10),
+              behavior: 'instant'
+            });
+          } catch (error) {
+            console.error('Scroll restoration failed:', error);
+          }
+        });
+      }
+    } catch (error) {
+      console.error('Session storage access failed:', error);
     }
 
     return () => {
-      // Save scroll position
-      sessionStorage.setItem(`scrollPosition-${boardId}`, window.scrollY.toString());
+      try {
+        sessionStorage.setItem(`scrollPosition-${boardId}`, window.scrollY.toString());
+      } catch (error) {
+        console.error('Failed to save scroll position:', error);
+      }
     };
   }, [boardId]);
 

--- a/src/components/pages/board/BoardPage.tsx
+++ b/src/components/pages/board/BoardPage.tsx
@@ -55,6 +55,23 @@ export default function BoardPage() {
     setSelectedAuthorId(authorId === selectedAuthorId ? null : authorId);
   };
 
+  if (!boardId) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-red-600">게시판을 찾을 수 없습니다.</h1>
+          <p className="mt-4 text-lg text-muted-foreground">존재하지 않는 게시판이거나 잘못된 경로입니다.</p>
+          <Button
+            onClick={() => navigate('/')}
+            className="mt-6 px-4 py-2 bg-primary text-primary-foreground rounded-lg"
+          >
+            홈으로 돌아가기
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className='min-h-screen bg-background'>
       <BoardHeader boardId={boardId} />

--- a/src/components/pages/board/BoardPage.tsx
+++ b/src/components/pages/board/BoardPage.tsx
@@ -1,53 +1,24 @@
 import { Plus } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 
 import AuthorList from './AuthorList';
 import BoardHeader from './BoardHeader';
 import PostCardList from './PostCardList';
 import { Button } from '../../ui/button';
+import { useScrollRestoration } from '@/hooks/useScrollRestoration';
 
 export default function BoardPage() {
   const { boardId } = useParams<{ boardId: string }>();
   const navigate = useNavigate();
   const [selectedAuthorId, setSelectedAuthorId] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!boardId) {
-      console.error('No boardId provided');
-      return;
-    }
-
-    try {
-      const savedScrollPosition = sessionStorage.getItem(`scrollPosition-${boardId}`);
-      if (savedScrollPosition) {
-        window.requestAnimationFrame(() => {
-          try {
-            window.scrollTo({
-              top: parseInt(savedScrollPosition, 10),
-              behavior: 'instant'
-            });
-          } catch (error) {
-            console.error('Scroll restoration failed:', error);
-          }
-        });
-      }
-    } catch (error) {
-      console.error('Session storage access failed:', error);
-    }
-
-    return () => {
-      try {
-        sessionStorage.setItem(`scrollPosition-${boardId}`, window.scrollY.toString());
-      } catch (error) {
-        console.error('Failed to save scroll position:', error);
-      }
-    };
-  }, [boardId]);
+  const { saveScrollPosition } = useScrollRestoration({
+    key: boardId || '',
+    enabled: !!boardId
+  });
 
   const handlePostClick = (postId: string) => {
-    // Save scroll position before navigating
-    sessionStorage.setItem(`scrollPosition-${boardId}`, window.scrollY.toString());
+    saveScrollPosition();
     navigate(`/post/${postId}`);
   };
 

--- a/src/hooks/useScrollRestoration.ts
+++ b/src/hooks/useScrollRestoration.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+
+interface UseScrollRestorationProps {
+  key: string;
+  enabled?: boolean;
+}
+
+export const useScrollRestoration = ({ key, enabled = true }: UseScrollRestorationProps) => {
+  useEffect(() => {
+    if (!enabled || !key) return;
+
+    try {
+      const savedScrollPosition = sessionStorage.getItem(`scrollPosition-${key}`);
+      if (savedScrollPosition) {
+        window.requestAnimationFrame(() => {
+          try {
+            window.scrollTo({
+              top: parseInt(savedScrollPosition, 10),
+              behavior: 'instant'
+            });
+          } catch (error) {
+            console.error('Scroll restoration failed:', error);
+          }
+        });
+      }
+    } catch (error) {
+      console.error('Session storage access failed:', error);
+    }
+
+    return () => {
+      try {
+        sessionStorage.setItem(`scrollPosition-${key}`, window.scrollY.toString());
+      } catch (error) {
+        console.error('Failed to save scroll position:', error);
+      }
+    };
+  }, [key, enabled]);
+
+  const saveScrollPosition = () => {
+    if (!enabled || !key) return;
+    
+    try {
+      sessionStorage.setItem(`scrollPosition-${key}`, window.scrollY.toString());
+    } catch (error) {
+      console.error('Failed to save scroll position:', error);
+    }
+  };
+
+  return { saveScrollPosition };
+};


### PR DESCRIPTION
- 별다른 정보 없이 TypeError: Load failed 라는 에러가 날 때가 있는데, ([센트리](https://bumgeun-song.sentry.io/issues/6139686118?groupId=6139686118&pageEnd=2024-12-28T00%3A16%3A54.148&pageStart=2024-12-27T00%3A16%3A54.148&project=4508460981747712&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&source=issue_details&stream_index=0)) 이에 대한 의심되는 부분이 세션 스토리지와 boardId 없이 들어왔을 때여서, 이에 대한 에러 핸들링을 추가해준다.