### PR TITLE
메시징 객체 불러오기 전에 navigator 여부를 체크해주기

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -11,13 +11,15 @@ const firebaseConfig = {
 };
 
 firebase.initializeApp(firebaseConfig);
-try {
-    const messaging = firebase.messaging();
-    messaging.onBackgroundMessage((payload) => {
-        console.log('[firebase-messaging-sw.js] Received background message', payload);
-        const { title, body, icon } = payload.notification;
-        self.registration.showNotification(title, { body, icon });
-    });
-} catch (error) {
-    console.error('Firebase messaging is not supported in this browser in sw');
+if (typeof window !== "undefined" && typeof window.navigator !== "undefined") {
+    try {
+        const messaging = firebase.messaging();
+        messaging.onBackgroundMessage((payload) => {
+            console.log('[firebase-messaging-sw.js] Received background message', payload);
+            const { title, body, icon } = payload.notification;
+            self.registration.showNotification(title, { body, icon });
+        });
+    } catch (error) {
+        console.error('Firebase messaging is not supported in this browser in sw');
+    }
 }

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -6,7 +6,9 @@ import { FirebaseApp } from "firebase/app";
 export function initializeMessaging(app: FirebaseApp): Messaging | null {
     let messaging: Messaging | null = null;
     try {
-        messaging = getMessaging(app);
+        if (typeof window !== "undefined" && typeof window.navigator !== "undefined") {
+            messaging = getMessaging(app);
+        }
         if (messaging) {
             onMessage(messaging, onMessageInForeground);
         }


### PR DESCRIPTION
- https://velog.io/@drrobot409/next.js-fcm-%EC%9B%B9-%ED%91%B8%EC%8B%9C-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0#1-1-messagingunsupported-browser-%EC%97%90%EB%9F%AC
- 같은 에러를 해결했다는 글을 보아서 시도해봄