### PR TITLE
비로그인 유저가 board로 들어가서 무한 리다이렉트 일어나는 문제 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,20 +19,22 @@ const BoardListPage = lazy(() => import('./components/pages/board/BoardListPage'
 
 export default function App() {
   const { currentUser } = useAuth();
+  
   return (
     <Routes>
-      {currentUser ? (
-        <Route path='/login' element={<LazyRoute element={LoginPage} />} />
-      ) : (
-        <Route path='/login' element={<Navigate to='/boards' />} />
-      )}
-      <Route
-        element={
-          <ProtectedRoute>
-            <AfterLoginLayout />
-          </ProtectedRoute>
-        }
-      >
+      <Route path='/login' element={
+        !currentUser ? (
+          <LazyRoute element={LoginPage} />
+        ) : (
+          <Navigate to='/boards' replace />
+        )
+      } />
+      
+      <Route element={
+        <ProtectedRoute>
+          <AfterLoginLayout />
+        </ProtectedRoute>
+      }>
         <Route path='/boards' element={<LazyRoute element={RecentBoard} />} />
         <Route path='/boards/list' element={<LazyRoute element={BoardListPage} />} />
         <Route path='/board/:boardId' element={<LazyRoute element={BoardPage} />} />
@@ -44,8 +46,16 @@ export default function App() {
         <Route path='/account' element={<LazyRoute element={AccountPage} />} />
         <Route path='/account/edit' element={<LazyRoute element={EditAccountPage} />} />
       </Route>
-      <Route path='/' element={<Navigate to='/boards' />} />
-      <Route path='*' element={<Navigate to='/' />} />
+
+      <Route path='/' element={
+        currentUser ? (
+          <Navigate to='/boards' replace />
+        ) : (
+          <Navigate to='/login' replace />
+        )
+      } />
+      
+      <Route path='*' element={<Navigate to='/' replace />} />
     </Routes>
   );
 }


### PR DESCRIPTION
- 로직 반전:
로그인 페이지는 비로그인 사용자만 접근 가능
로그인된 사용자는 /boards로 리다이렉트

- replace 속성 추가:
replace prop을 사용하여 브라우저 히스토리 스택이 쌓이는 것을 방지

- 루트 경로 처리 개선:
로그인 상태에 따라 적절한 페이지로 리다이렉트
- 명확한 조건부 리다이렉션:
각 라우트의 리다이렉션 조건을 명확하게 정의