### PR TITLE
cors 설정 비활성화

### DIFF
--- a/functions/src/writingHistory/getWritingStats.ts
+++ b/functions/src/writingHistory/getWritingStats.ts
@@ -31,11 +31,7 @@ const calculateTotalContributions = (contributions: Contribution[]): number => {
 
 export const getWritingStats = onRequest(
     { 
-        cors: [
-            'http://localhost:5173',
-            'https://www.dailywritingfriends.com',
-            'https://dailywritingfriends.com'
-        ] 
+        cors: true
     },
     async (req, res) => {
         if (req.method !== 'GET') {


### PR DESCRIPTION
- 글쓰기 기록 지표를 가져오는 API에서 cors 설정을 비활성화한다.
- 어떤 도메인에서 요청해도 서버에서 막지 않는다.