### PR TITLE
스크롤 복원 로직 작동 안하던 문제 해결

### DIFF
--- a/src/components/pages/board/BoardPage.tsx
+++ b/src/components/pages/board/BoardPage.tsx
@@ -12,9 +12,12 @@ export default function BoardPage() {
   const { boardId } = useParams<{ boardId: string }>();
   const navigate = useNavigate();
   const [selectedAuthorId, setSelectedAuthorId] = useState<string | null>(null);
+  const [posts, setPosts] = useState([]);
+
   const { saveScrollPosition } = useScrollRestoration({
     key: boardId || '',
-    enabled: !!boardId
+    enabled: !!boardId,
+    deps: [posts]
   });
 
   const handlePostClick = (postId: string) => {
@@ -54,6 +57,7 @@ export default function BoardPage() {
           boardId={boardId!}
           onPostClick={handlePostClick}
           selectedAuthorId={selectedAuthorId}
+          onPostsLoad={setPosts}
         />
       </main>
       <Link

--- a/src/components/pages/board/BoardPage.tsx
+++ b/src/components/pages/board/BoardPage.tsx
@@ -6,22 +6,13 @@ import AuthorList from './AuthorList';
 import BoardHeader from './BoardHeader';
 import PostCardList from './PostCardList';
 import { Button } from '../../ui/button';
-import { useScrollRestoration } from '@/hooks/useScrollRestoration';
 
 export default function BoardPage() {
   const { boardId } = useParams<{ boardId: string }>();
   const navigate = useNavigate();
   const [selectedAuthorId, setSelectedAuthorId] = useState<string | null>(null);
-  const [posts, setPosts] = useState([]);
-
-  const { saveScrollPosition } = useScrollRestoration({
-    key: boardId || '',
-    enabled: !!boardId,
-    deps: [posts]
-  });
 
   const handlePostClick = (postId: string) => {
-    saveScrollPosition();
     navigate(`/post/${postId}`);
   };
 
@@ -57,7 +48,6 @@ export default function BoardPage() {
           boardId={boardId!}
           onPostClick={handlePostClick}
           selectedAuthorId={selectedAuthorId}
-          onPostsLoad={setPosts}
         />
       </main>
       <Link

--- a/src/components/pages/board/PostCardList.tsx
+++ b/src/components/pages/board/PostCardList.tsx
@@ -4,7 +4,7 @@ import StatusMessage from '../../common/StatusMessage';
 import { usePosts } from '@/hooks/usePosts';
 import { useInView } from 'react-intersection-observer';
 import PostCardSkeleton from '@/components/ui/PostCardSkeleton';
-
+import { useScrollRestoration } from '@/hooks/useScrollRestoration';
 interface PostCardListProps {
   boardId: string;
   onPostClick: (postId: string) => void;
@@ -26,11 +26,15 @@ const PostCardList: React.FC<PostCardListProps> = ({ boardId, onPostClick, selec
 
   const allPosts = postPages?.pages.flatMap((page) => page) || [];
 
+  const { saveScrollPosition, restoreScrollPosition } = useScrollRestoration(`${boardId}-posts`);
+
   const handlePostClick = (postId: string) => {
     onPostClick(postId);
+    saveScrollPosition();
   };
 
   useEffect(() => {
+    restoreScrollPosition();
     if (inView && hasNextPage) {
       fetchNextPage();
     }

--- a/src/components/pages/board/PostCardList.tsx
+++ b/src/components/pages/board/PostCardList.tsx
@@ -24,6 +24,12 @@ const PostCardList: React.FC<PostCardListProps> = ({ boardId, onPostClick, selec
     isFetchingNextPage,
   } = usePosts(boardId, selectedAuthorId, limitCount);
 
+  const allPosts = postPages?.pages.flatMap((page) => page) || [];
+
+  const handlePostClick = (postId: string) => {
+    onPostClick(postId);
+  };
+
   useEffect(() => {
     if (inView && hasNextPage) {
       fetchNextPage();
@@ -44,8 +50,6 @@ const PostCardList: React.FC<PostCardListProps> = ({ boardId, onPostClick, selec
     return <StatusMessage error errorMessage="글을 불러오는 중에 문제가 생겼어요. 잠시 후 다시 시도해주세요." />;
   }
 
-  const allPosts = postPages?.pages.flatMap((page) => page) || [];
-
   if (allPosts.length === 0) {
     return <StatusMessage error errorMessage="글이 하나도 없어요." />;
   }
@@ -53,7 +57,11 @@ const PostCardList: React.FC<PostCardListProps> = ({ boardId, onPostClick, selec
   return (
     <div className='space-y-6'>
       {allPosts.map((post) => (
-        <PostCard key={post.id} post={post} onClick={() => onPostClick(post.id)} />
+        <PostCard 
+          key={post.id} 
+          post={post} 
+          onClick={() => handlePostClick(post.id)} 
+        />
       ))}
       <div ref={inViewRef} />
       {isFetchingNextPage && (


### PR DESCRIPTION
- 100ms 정도 여유를 두고 scroll 하도록 변경
- 언마운트 시 자동으로 스크롤 위치를 저장하는 코드를 제거
- beforeunload: 페이지를 떠날 때 스크롤 위치 저장
- popstate: 브라우저 뒤로가기/앞으로가기 시 스크롤 위치 저장