### PR TITLE
무한 스크롤 내릴 때 scroll을 복원하는 버그 해결

### DIFF
--- a/src/components/pages/board/PostCardList.tsx
+++ b/src/components/pages/board/PostCardList.tsx
@@ -34,11 +34,16 @@ const PostCardList: React.FC<PostCardListProps> = ({ boardId, onPostClick, selec
   };
 
   useEffect(() => {
-    restoreScrollPosition();
     if (inView && hasNextPage) {
       fetchNextPage();
     }
   }, [inView, hasNextPage, fetchNextPage]);
+
+  useEffect(() => {
+    if (boardId) {
+      restoreScrollPosition();
+    }
+  }, [boardId]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
- scroll 복원 함수를 'inView, hasNextPage, fetchNextPage' 가 바뀔 때마다 실행되는 useEffect에 넣는 실수.
- 별도의 useEffect로 분리했다.