### PR TITLE
바텀 탭바의 하단 패딩을 2 늘린다

### DIFF
--- a/src/components/pages/BottomTabsNavigator.tsx
+++ b/src/components/pages/BottomTabsNavigator.tsx
@@ -12,7 +12,7 @@ export default function BottomTabsNavigator() {
   const location = useLocation();
 
   return (
-    <nav className='fixed inset-x-0 bottom-0 border-t border-border bg-background safe-area-pb'>
+    <nav className='fixed inset-x-0 bottom-0 border-t border-border bg-background pb-2'>
       <div className='flex justify-around'>
         {tabs.map((tab) => (
           <Link

--- a/src/components/pages/BottomTabsNavigator.tsx
+++ b/src/components/pages/BottomTabsNavigator.tsx
@@ -10,9 +10,10 @@ const tabs = [
 
 export default function BottomTabsNavigator() {
   const location = useLocation();
+  const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
 
   return (
-    <nav className='fixed inset-x-0 bottom-0 border-t border-border bg-background pb-2'>
+    <nav className={`fixed inset-x-0 bottom-0 border-t border-border bg-background ${isIOS ? 'pb-2' : ''}`}>
       <div className='flex justify-around'>
         {tabs.map((tab) => (
           <Link

--- a/src/components/pages/BottomTabsNavigator.tsx
+++ b/src/components/pages/BottomTabsNavigator.tsx
@@ -12,7 +12,7 @@ export default function BottomTabsNavigator() {
   const location = useLocation();
 
   return (
-    <nav className='fixed inset-x-0 bottom-0 border-t border-border bg-background'>
+    <nav className='fixed inset-x-0 bottom-0 border-t border-border bg-background safe-area-pb'>
       <div className='flex justify-around'>
         {tabs.map((tab) => (
           <Link

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -141,29 +141,53 @@ export default {
     function({ addUtilities }) {
       addUtilities({
         '.safe-area': {
-          paddingTop: 'env(safe-area-inset-top)',
-          paddingRight: 'env(safe-area-inset-right)',
-          paddingBottom: 'env(safe-area-inset-bottom)',
-          paddingLeft: 'env(safe-area-inset-left)',
+          'padding-top': ['env(safe-area-inset-top)', 'constant(safe-area-inset-top)'],
+          'padding-right': ['env(safe-area-inset-right)', 'constant(safe-area-inset-right)'],
+          'padding-bottom': ['env(safe-area-inset-bottom)', 'constant(safe-area-inset-bottom)'],
+          'padding-left': ['env(safe-area-inset-left)', 'constant(safe-area-inset-left)'],
+          '@supports (padding: max(0px))': {
+            'padding-top': 'max(env(safe-area-inset-top), 0px)',
+            'padding-right': 'max(env(safe-area-inset-right), 0px)',
+            'padding-bottom': 'max(env(safe-area-inset-bottom), 0px)',
+            'padding-left': 'max(env(safe-area-inset-left), 0px)',
+          }
         },
         '.safe-area-pt': {
-          paddingTop: 'env(safe-area-inset-top)',
+          'padding-top': ['env(safe-area-inset-top)', 'constant(safe-area-inset-top)'],
+          '@supports (padding: max(0px))': {
+            'padding-top': 'max(env(safe-area-inset-top), 0px)',
+          }
         },
         '.safe-area-pr': {
-          paddingRight: 'env(safe-area-inset-right)',
+          'padding-right': ['env(safe-area-inset-right)', 'constant(safe-area-inset-right)'],
+          '@supports (padding: max(0px))': {
+            'padding-right': 'max(env(safe-area-inset-right), 0px)',
+          }
         },
         '.safe-area-pb': {
-          paddingBottom: 'env(safe-area-inset-bottom)',
+          'padding-bottom': ['env(safe-area-inset-bottom)', 'constant(safe-area-inset-bottom)'],
+          '@supports (padding: max(0px))': {
+            'padding-bottom': 'max(env(safe-area-inset-bottom), 0px)',
+          }
         },
         '.safe-area-pl': {
-          paddingLeft: 'env(safe-area-inset-left)',
+          'padding-left': ['env(safe-area-inset-left)', 'constant(safe-area-inset-left)'],
+          '@supports (padding: max(0px))': {
+            'padding-left': 'max(env(safe-area-inset-left), 0px)',
+          }
         },
         '.-mt-safe': {
-          marginTop: 'calc(env(safe-area-inset-top) * -1)',
+          'margin-top': ['calc(env(safe-area-inset-top) * -1)', 'calc(constant(safe-area-inset-top) * -1)'],
+          '@supports (margin: max(0px))': {
+            'margin-top': 'calc(max(env(safe-area-inset-top), 0px) * -1)',
+          }
         },
         '.-mb-safe': {
-          marginBottom: 'calc(env(safe-area-inset-bottom) * -1)',
-        },
+          'margin-bottom': ['calc(env(safe-area-inset-bottom) * -1)', 'calc(constant(safe-area-inset-bottom) * -1)'],
+          '@supports (margin: max(0px))': {
+            'margin-bottom': 'calc(max(env(safe-area-inset-bottom), 0px) * -1)',
+          }
+        }
       })
     }
   ]

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -57,6 +57,10 @@ export default {
       },
       spacing: {
         '12': '3rem',
+        'safe-top': 'env(safe-area-inset-top)',
+        'safe-bottom': 'env(safe-area-inset-bottom)',
+        'safe-left': 'env(safe-area-inset-left)',
+        'safe-right': 'env(safe-area-inset-right)',
       },
       typography: (theme) => ({
         DEFAULT: {
@@ -130,6 +134,38 @@ export default {
       }),
     },
   },
-  plugins: [tailwindcssAnimate, typography, safeArea],
+  plugins: [
+    tailwindcssAnimate,
+    typography,
+    safeArea,
+    function({ addUtilities }) {
+      addUtilities({
+        '.safe-area': {
+          paddingTop: 'env(safe-area-inset-top)',
+          paddingRight: 'env(safe-area-inset-right)',
+          paddingBottom: 'env(safe-area-inset-bottom)',
+          paddingLeft: 'env(safe-area-inset-left)',
+        },
+        '.safe-area-pt': {
+          paddingTop: 'env(safe-area-inset-top)',
+        },
+        '.safe-area-pr': {
+          paddingRight: 'env(safe-area-inset-right)',
+        },
+        '.safe-area-pb': {
+          paddingBottom: 'env(safe-area-inset-bottom)',
+        },
+        '.safe-area-pl': {
+          paddingLeft: 'env(safe-area-inset-left)',
+        },
+        '.-mt-safe': {
+          marginTop: 'calc(env(safe-area-inset-top) * -1)',
+        },
+        '.-mb-safe': {
+          marginBottom: 'calc(env(safe-area-inset-bottom) * -1)',
+        },
+      })
+    }
+  ]
 };
 


### PR DESCRIPTION
- 아이폰에서 홈 인디케이터와 겹치는 탭바 문제가 있는데, safe-area를 아무리 적용해봐도 레이아웃이 바뀌지 않음..
- 일단 iOS만 고정 패딩을 2px 늘리는 것으로 대응. 나중에 제대로 고쳐야겠다.