### PR TITLE
기록 탭의 초기 로딩 성능을 개선한다

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,15 +1,15 @@
 import { onCommentCreated } from './notifications/commentOnPost';
+import { decrementCommentCountOnCommentDeleted, incrementCommentCountOnCommentCreated } from './notifications/incrementCommentCount';
+import { decrementRepliesCountOnReplyDeleted, incrementRepliesCountOnReplyCreated } from './notifications/incrementRepliesCount';
 import { onReplyCreatedOnComment } from './notifications/replyOnComment';
 import { onReplyCreatedOnPost } from './notifications/replyOnPost';
 import { onNotificationCreated } from './notifications/sendMessageOnNotification';
-import { updatePostDaysFromFirstDay } from './notifications/updateDaysFromFirstDay';
 import { updateCommentRepliesCounts } from './notifications/updateCommentRepliesCounts';
-import { decrementCommentCountOnCommentDeleted, incrementCommentCountOnCommentCreated } from './notifications/incrementCommentCount';
-import { decrementRepliesCountOnReplyDeleted, incrementRepliesCountOnReplyCreated } from './notifications/incrementRepliesCount';
-import { updateWritingHistoryByBatch } from './writingHistory/updateWritingHistoryByBatch';
-import { getWritingStats } from './writingHistory/getWritingStats';
+import { updatePostDaysFromFirstDay } from './notifications/updateDaysFromFirstDay';
 import { createWritingHistoryOnPostCreated } from './writingHistory/createWritingHistoryOnPostCreated';
 import { deleteWritingHistoryOnPostDeleted } from './writingHistory/deleteWritingHistoryOnPostDeleted';
+import { getWritingStats } from './writingHistory/getWritingStats';
+import { updateWritingHistoryByBatch } from './writingHistory/updateWritingHistoryByBatch';
 export {
   onCommentCreated,
   onReplyCreatedOnComment,

--- a/functions/src/notifications/commentOnPost.ts
+++ b/functions/src/notifications/commentOnPost.ts
@@ -1,11 +1,11 @@
-import admin from "../admin";
 import { Timestamp } from "firebase-admin/firestore";
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
+import admin from "../admin";
+import { generateMessage } from "./messageGenerator";
+import { shouldGenerateNotification } from "./shouldGenerateNotification";
 import { Comment } from "../types/Comment";
 import { Notification, NotificationType } from "../types/Notification";
 import { Post } from "../types/Post";
-import { generateMessage } from "./messageGenerator";
-import { shouldGenerateNotification } from "./shouldGenerateNotification";
 
 export const onCommentCreated = onDocumentCreated(
     "boards/{boardId}/posts/{postId}/comments/{commentId}",

--- a/functions/src/notifications/replyOnComment.ts
+++ b/functions/src/notifications/replyOnComment.ts
@@ -1,11 +1,11 @@
-import admin from "../admin";
 import { Timestamp } from "firebase-admin/firestore";
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
-import { Reply } from "../types/Reply";
-import { Comment } from "../types/Comment";
-import { Notification, NotificationType } from "../types/Notification";
+import admin from "../admin";
 import { generateMessage } from "./messageGenerator";
 import { shouldGenerateNotification } from "./shouldGenerateNotification";
+import { Comment } from "../types/Comment";
+import { Notification, NotificationType } from "../types/Notification";
+import { Reply } from "../types/Reply";
 
 export const onReplyCreatedOnComment = onDocumentCreated(
   "boards/{boardId}/posts/{postId}/comments/{commentId}/replies/{replyId}",

--- a/functions/src/notifications/replyOnPost.ts
+++ b/functions/src/notifications/replyOnPost.ts
@@ -1,11 +1,11 @@
-import { onDocumentCreated } from "firebase-functions/firestore";
-import { Reply } from "../types/Reply";
-import { Notification, NotificationType } from "../types/Notification";
 import { Timestamp } from "firebase-admin/firestore";
-import { Post } from "../types/Post";
+import { onDocumentCreated } from "firebase-functions/firestore";
 import admin from "../admin";
 import { generateMessage } from "./messageGenerator";
 import { shouldGenerateNotification } from "./shouldGenerateNotification";
+import { Notification, NotificationType } from "../types/Notification";
+import { Post } from "../types/Post";
+import { Reply } from "../types/Reply";
 
 export const onReplyCreatedOnPost = onDocumentCreated(
     "boards/{boardId}/posts/{postId}/comments/{commentId}/replies/{replyId}",

--- a/functions/src/notifications/sendMessageOnNotification.ts
+++ b/functions/src/notifications/sendMessageOnNotification.ts
@@ -1,9 +1,9 @@
 import { onDocumentCreated } from "firebase-functions/firestore";
 import admin from "../admin";
-import { Notification, NotificationType } from "../types/Notification";
-import { User } from "../types/User";
 import { FirebaseMessagingToken } from "../types/FirebaseMessagingToken";
+import { Notification, NotificationType } from "../types/Notification";
 import { Post } from "../types/Post";
+import { User } from "../types/User";
 
 // Send cloud message via FCM tokens to user when notification is created
 // firebase messaging token is subcollection of users

--- a/functions/src/notifications/updateDaysFromFirstDay.ts
+++ b/functions/src/notifications/updateDaysFromFirstDay.ts
@@ -1,11 +1,11 @@
 // update post daysFromFirstDay when post is created based on board's firstDay
 
+import { Timestamp } from 'firebase-admin/firestore';
 import { onDocumentCreated } from 'firebase-functions/v2/firestore';
 import admin from '../admin';
-import { Board } from '../types/Board';
 import { isWorkingDay } from '../dateUtils';
-import { Timestamp } from 'firebase-admin/firestore';
 import { TimeZone } from '../dateUtils';
+import { Board } from '../types/Board';
 
 export const updatePostDaysFromFirstDay = onDocumentCreated('/boards/{boardId}/posts/{postId}', async (event) => {
   const postId = event.params.postId;

--- a/functions/src/writingHistory/createBadges.ts
+++ b/functions/src/writingHistory/createBadges.ts
@@ -1,5 +1,5 @@
-import { WritingHistory } from "../types/WritingHistory";
 import { isSameDay, TimeZone } from "../dateUtils";
+import { WritingHistory } from "../types/WritingHistory";
 
 interface WritingBadge {
     name: string

--- a/functions/src/writingHistory/createContributions.ts
+++ b/functions/src/writingHistory/createContributions.ts
@@ -1,5 +1,5 @@
-import { WritingHistory } from "../types/WritingHistory";
 import { isSameDay, TimeZone } from "../dateUtils";   
+import { WritingHistory } from "../types/WritingHistory";
 
 type Contribution = {
     createdAt: string;

--- a/functions/src/writingHistory/createWritingHistoryOnPostCreated.ts
+++ b/functions/src/writingHistory/createWritingHistoryOnPostCreated.ts
@@ -1,7 +1,7 @@
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
-import { Post } from "../types/Post";
 import { createWritingHistoryData } from "./updateWritingHistoryByBatch";
 import admin from "../admin";
+import { Post } from "../types/Post";
 
 export const createWritingHistoryOnPostCreated = onDocumentCreated(
     "boards/{boardId}/posts/{postId}",

--- a/functions/src/writingHistory/deleteWritingHistoryOnPostDeleted.ts
+++ b/functions/src/writingHistory/deleteWritingHistoryOnPostDeleted.ts
@@ -1,6 +1,6 @@
 import { onDocumentDeleted } from "firebase-functions/v2/firestore";
-import { Post } from "../types/Post";
 import admin from "../admin";
+import { Post } from "../types/Post";
 
 export const deleteWritingHistoryOnPostDeleted = onDocumentDeleted(
     "boards/{boardId}/posts/{postId}",

--- a/functions/src/writingHistory/getWritingStats.ts
+++ b/functions/src/writingHistory/getWritingStats.ts
@@ -129,7 +129,13 @@ const fetchUserWritingHistory = async (
     userData: UserData;
     histories: WritingHistory[];
 }> => {
-    const histories = await userDoc.ref.collection('writingHistories').get();
+    // 현재 기록은 최근 영업일 20일 이내만 보여주므로 글쓰기 기록도 최대 30일 이내만 조회
+    const limit = 30;
+    const histories = await userDoc.ref
+        .collection('writingHistories')
+        .orderBy('createdAt', 'desc')
+        .limit(limit)
+        .get();
     const userData = createUserProfile(userDoc.id, userDoc.data());
 
     return {

--- a/functions/src/writingHistory/getWritingStats.ts
+++ b/functions/src/writingHistory/getWritingStats.ts
@@ -23,52 +23,73 @@ interface WritingStats {
     badges: WritingBadge[];
 }
 
-export const getWritingStats = onRequest(
-    { cors: true },
-    async (req, res) => {
-        if (req.method !== 'GET') {
-            res.status(405).json({
-                status: 'error',
-                message: 'Method not allowed'
-            });
-            return;
-        }
+interface CachedStats {
+    lastUpdated: Date;
+    stats: WritingStats[];
+}
 
+export const getWritingStats = onRequest(
+    { 
+        cors: true,
+        timeoutSeconds: 30
+    },
+    async (req, res) => {
         try {
             const db = admin.firestore();
+            const cachedStatsRef = db.collection('cachedStats').doc('writingStats');
+            const cachedStats = await cachedStatsRef.get();
+            
+            if (cachedStats.exists) {
+                const data = cachedStats.data() as CachedStats;
+                const cacheAge = Date.now() - data.lastUpdated.getTime();
+                
+                // 캐시가 1분 이내라면 캐시된 데이터 반환
+                if (cacheAge < 1000 * 60 * 1) {
+                    res.status(200).json({
+                        status: 'success',
+                        data: {
+                            writingStats: data.stats
+                        }
+                    });
+                    return;
+                }
+            }
+
+            // 캐시가 없거나 만료된 경우 새로 계산
             const workingDays = getRecentWorkingDays(20);
-
-            // 1. 사용자 데이터 조회
             const usersSnapshot = await db.collection('users').get();
-
-            // 2. 각 사용자의 기록 조회
             const usersData = await Promise.all(
                 usersSnapshot.docs.map(fetchUserWritingHistory)
             );
 
-            // 3. WritingStats 생성
             const writingStatsWithMeta = usersData
                 .map(({ userData, histories }) =>
                     createUserWritingStats(userData, histories, workingDays)
                 )
                 .filter((stats): stats is WritingStatsWithMeta => stats !== null);
 
-            // 4. 정렬 및 최종 데이터 형식 변환
-            const filteredStats = sortWritingStats(writingStatsWithMeta);
+            const sortedStats = sortWritingStats(writingStatsWithMeta);
+
+            // 결과 캐시 저장
+            await cachedStatsRef.set({
+                lastUpdated: admin.firestore.Timestamp.now(),
+                stats: sortedStats
+            });
 
             res.status(200).json({
                 status: 'success',
                 data: {
-                    writingStats: filteredStats
+                    writingStats: sortedStats
                 }
             });
-
+            return;
         } catch (error) {
             console.error('Error getting writing stats:', error);
             res.status(500).json({
                 status: 'error',
                 message: error instanceof Error ? error.message : 'Unknown error'
             });
+            return;
         }
     }
 );

--- a/functions/src/writingHistory/getWritingStats.ts
+++ b/functions/src/writingHistory/getWritingStats.ts
@@ -1,9 +1,9 @@
 import { onRequest } from "firebase-functions/v2/https";
 import admin from "../admin";
-import { WritingHistory } from "../types/WritingHistory";
 import { getRecentWorkingDays } from "../dateUtils";
-import { createContributions, Contribution } from "./createContributions";
 import { createBadges, calculateRecentStreak, WritingBadge } from "./createBadges";
+import { createContributions, Contribution } from "./createContributions";
+import { WritingHistory } from "../types/WritingHistory";
 interface UserData {
     id: string;
     nickname: string | null;

--- a/functions/src/writingHistory/updateWritingHistoryByBatch.ts
+++ b/functions/src/writingHistory/updateWritingHistoryByBatch.ts
@@ -1,8 +1,8 @@
+import { Request, Response } from 'express';
 import * as admin from 'firebase-admin';
 import { onRequest } from 'firebase-functions/v2/https';
 import { Post } from '../types/Post';
 import { WritingHistory } from '../types/WritingHistory';
-import { Request, Response } from 'express';
 
 export const updateWritingHistoryByBatch = onRequest(async (req, res) => {
     try {

--- a/functions/tsconfig.dev.json
+++ b/functions/tsconfig.dev.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": [
     "src",
-    "jest.config.ts"
+    "jest.config.ts",
+    ".eslintrc.js"
   ]
 }

--- a/functions/tsconfig.dev.json
+++ b/functions/tsconfig.dev.json
@@ -1,5 +1,7 @@
 {
+  "extends": "./tsconfig.json",
   "include": [
-    ".eslintrc.js"
+    "src",
+    "jest.config.ts"
   ]
 }

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -8,10 +8,12 @@
     "strict": true,
     "target": "es2017",
     "types": ["jest", "node"],
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "compileOnSave": true,
   "include": [
-    "src"
+    "src",
+    "jest.config.ts"
   ]
 }

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -14,6 +14,7 @@
   "compileOnSave": true,
   "include": [
     "src",
-    "jest.config.ts"
+    "jest.config.ts",
+    ".eslintrc.js"
   ]
 }

--- a/src/hooks/useWritingStats.ts
+++ b/src/hooks/useWritingStats.ts
@@ -73,7 +73,7 @@ export const useWritingStats = () => {
         queryKey: ['writingStats'],
         queryFn: fetchWritingStats,
         staleTime: 1000 * 60 * 1, // 1 minute
-        cacheTime: 1000 * 60 * 3, // 3 minutes,
+        cacheTime: 1000 * 60 * 10, // 10 minutes,
         retry: 1, // 실패시 1번만 재시도
     });
 


### PR DESCRIPTION
resolve #130 

- cacheTime을 10분으로 변경
- 서버에서 1분 동안 응답 캐싱하기
- 글쓰기 기록 조회를 최근 30일것만 하기