### PR TITLE
기록 계산을 클라이언트로 옮겨 로딩을 빠르게 한다.

### DIFF
--- a/firestore_schema.txt
+++ b/firestore_schema.txt
@@ -40,6 +40,15 @@ Firestore Database Schema
     - Document ID: {firebaseMessagingTokenId}
     - Fields: (Not explicitly defined)
 
+  - postings
+    - Document ID: {postingId}
+    - Fields:
+      - board.id (string)
+      - post.id (string)
+      - post.title (string)
+      - post.contentLength (number)
+      - createdAt (Timestamp)
+
 2. boards Collection
 - Document ID: {boardId}
 - Fields:

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -7,7 +7,7 @@
       "name": "functions",
       "dependencies": {
         "firebase-admin": "^12.7.0",
-        "firebase-functions": "^6.0.1"
+        "firebase-functions": "^6.3.2"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -3602,9 +3602,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3625,7 +3625,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -3640,6 +3640,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -3890,9 +3894,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.1.1.tgz",
-      "integrity": "sha512-q+4zsQhX04YJUz6hqaiH/j5kixljPj0PMxkm8KN3juYp3I4NC6CZ4qfy5JRfwvV8VfXM2KkJrZuyJtLyZr97aw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.3.2.tgz",
+      "integrity": "sha512-FC3A1/nhqt1ZzxRnj5HZLScQaozAcFSD/vSR8khqSoFNOfxuXgwJS6ZABTB7+v+iMD5z6Mmxw6OfqITUBuI7OQ==",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "^4.17.21",
@@ -6477,9 +6481,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -20,7 +20,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^12.7.0",
-    "firebase-functions": "^6.0.1"
+    "firebase-functions": "^6.3.2"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,10 +6,13 @@ import { onReplyCreatedOnPost } from './notifications/replyOnPost';
 import { onNotificationCreated } from './notifications/sendMessageOnNotification';
 import { updateCommentRepliesCounts } from './notifications/updateCommentRepliesCounts';
 import { updatePostDaysFromFirstDay } from './notifications/updateDaysFromFirstDay';
+import { createPosting } from './postings/createPosting';
+import { updatePosting } from './postings/updatePosting';
 import { createWritingHistoryOnPostCreated } from './writingHistory/createWritingHistoryOnPostCreated';
 import { deleteWritingHistoryOnPostDeleted } from './writingHistory/deleteWritingHistoryOnPostDeleted';
 import { getWritingStats } from './writingHistory/getWritingStats';
 import { updateWritingHistoryByBatch } from './writingHistory/updateWritingHistoryByBatch';
+
 export {
   onCommentCreated,
   onReplyCreatedOnComment,
@@ -24,5 +27,7 @@ export {
   updateWritingHistoryByBatch,
   getWritingStats,
   createWritingHistoryOnPostCreated,
-  deleteWritingHistoryOnPostDeleted
+  deleteWritingHistoryOnPostDeleted,
+  createPosting,
+  updatePosting
 };

--- a/functions/src/notifications/sendMessageOnNotification.ts
+++ b/functions/src/notifications/sendMessageOnNotification.ts
@@ -1,10 +1,10 @@
+import { Message } from "firebase-admin/lib/messaging/messaging-api";
 import { onDocumentCreated } from "firebase-functions/firestore";
 import admin from "../admin";
 import { FirebaseMessagingToken } from "../types/FirebaseMessagingToken";
 import { Notification, NotificationType } from "../types/Notification";
 import { Post } from "../types/Post";
 import { User } from "../types/User";
-import { Message } from "firebase-admin/lib/messaging/messaging-api";
 
 // Send cloud message via FCM tokens to user when notification is created
 // firebase messaging token is subcollection of users

--- a/functions/src/postings/createPosting.ts
+++ b/functions/src/postings/createPosting.ts
@@ -1,8 +1,8 @@
+import { Timestamp } from "firebase-admin/firestore";
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
 import admin from "../admin";
 import { Post } from "../types/Post";
 import { Posting } from "../types/Posting";
-import { Timestamp } from "firebase-admin/firestore";
 
 export const createPosting = onDocumentCreated(
   'boards/{boardId}/posts/{postId}',

--- a/functions/src/postings/updatePosting.ts
+++ b/functions/src/postings/updatePosting.ts
@@ -12,7 +12,9 @@ export const updatePosting = onRequest(async (req, res) => {
     // Accept boardId as a query parameter (or in the request body)
     const boardId = req.query.boardId || req.body.boardId;
     if (!boardId) {
-      res.status(400).send("Missing boardId parameter.");
+      res.status(400).json({ 
+        error: "Missing boardId parameter." 
+      });
       return;
     }
   
@@ -70,9 +72,18 @@ export const updatePosting = onRequest(async (req, res) => {
       }
   
       console.log(`Migration completed for board ${boardId}: ${processedCount} post(s) processed, ${errorCount} error(s).`);
-      res.status(200).send(`Migration completed for board ${boardId}: ${processedCount} post(s) processed, ${errorCount} error(s).`);
+      res.status(200).json({
+        message: `Migration completed for board ${boardId}`,
+        stats: {
+          processed: processedCount,
+          errors: errorCount
+        }
+      });
     } catch (error) {
       console.error(`Error during migration for board ${boardId}:`, error);
-      res.status(500).send(`Error during migration for board ${boardId}: ${error}`);
+      res.status(500).json({
+        error: `Error during migration for board ${boardId}`,
+        details: error instanceof Error ? error.message : String(error)
+      });
     }
   });

--- a/functions/src/writingHistory/getWritingStats.ts
+++ b/functions/src/writingHistory/getWritingStats.ts
@@ -1,8 +1,8 @@
+import { info, debug, warn, error as errorLog } from "firebase-functions/logger";
 import { onRequest } from "firebase-functions/v2/https";
 import admin from "../admin";
 import { getRecentWorkingDays } from "../dateUtils";
 import { createBadges, calculateRecentStreak, WritingBadge } from "./createBadges";
-import { info, debug, warn, error as errorLog } from "firebase-functions/logger";
 import { createContributions, Contribution } from "./createContributions";
 import { WritingHistory } from "../types/WritingHistory";
 interface UserData {

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -7,14 +7,17 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2017",
-    "types": ["jest", "node"],
+    "types": ["node"],
     "esModuleInterop": true,
     "skipLibCheck": true
   },
   "compileOnSave": true,
   "include": [
-    "src",
-    "jest.config.ts",
-    ".eslintrc.js"
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib",
+    "**/*.test.ts"
   ]
 }

--- a/src/components/pages/stats/StatsPage.tsx
+++ b/src/components/pages/stats/StatsPage.tsx
@@ -1,20 +1,43 @@
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { UserStatsCard } from "./UserStatsCard"
-import { useWritingStats } from "@/hooks/useWritingStats"
+import { useWritingStatsV2 } from "@/hooks/useWritingStatsV2"
 import StatsHeader from "./StatsHeader"
 import { StatsNoticeBanner } from "./StatsNoticeBanner"
 import { usePerformanceMonitoring } from "@/hooks/usePerformanceMonitoring"
+import { useQuery } from "@tanstack/react-query"
+import { fetchAllUserData } from "@/utils/userUtils"
 
 export default function StatsPage() {
     usePerformanceMonitoring('StatsPage');
-    const { writingStats, isLoading, error } = useWritingStats()
+    
+    // 1. 모든 사용자 데이터 가져오기
+    const { 
+        data: users, 
+        isLoading: isLoadingUsers, 
+        error: usersError 
+    } = useQuery({
+        queryKey: ['users'],
+        queryFn: fetchAllUserData
+    });
+    
+    // 2. 사용자 ID 배열로 통계 가져오기
+    const { 
+        data: writingStats, 
+        isLoading: isLoadingStats, 
+        error: statsError 
+    } = useWritingStatsV2(
+        users?.map(user => user.uid) || []
+    );
+    
+    const isLoading = isLoadingUsers || isLoadingStats;
+    const error = usersError || statsError;
     
     if (isLoading) {
         return <LoadingState />
     }
 
     if (error) {
-        return <ErrorState error={error} />
+        return <ErrorState error={error instanceof Error ? error : new Error('Unknown error')} />
     }
     
     return (
@@ -34,7 +57,7 @@ export default function StatsPage() {
     )
 }
 
-// LoadingState와 ErrorState 컴포넌트도 StatsHeader를 사용하도록 수정
+// LoadingState와 ErrorState 컴포넌트는 그대로 유지
 function LoadingState() {
     return (
         <div className="min-h-screen flex flex-col bg-background">
@@ -46,19 +69,13 @@ function LoadingState() {
                         {[...Array(5)].map((_, index) => (
                             <div key={index} className="w-full bg-card rounded-lg">
                                 <div className="flex items-start gap-4 p-4">
-                                    {/* Left section with avatar and user info */}
                                     <div className="flex flex-1 items-start gap-4">
-                                        {/* Avatar skeleton */}
                                         <div className="h-12 w-12 bg-muted rounded-full" />
-                                        
-                                        {/* User info skeleton */}
                                         <div className="flex flex-col gap-2">
                                             <div className="h-5 w-24 bg-muted rounded" />
                                             <div className="h-4 w-32 bg-muted rounded" />
                                         </div>
                                     </div>
-
-                                    {/* Right section with contribution graph */}
                                     <div className="flex flex-col items-end gap-2">
                                         <div className="w-24 grid grid-rows-4 grid-flow-col gap-1">
                                             {[...Array(20)].map((_, i) => (
@@ -88,7 +105,7 @@ function ErrorState({ error }: { error: Error }) {
                     Error: {error.message}
                 </h2>
                 <p className="text-muted-foreground">
-                    We couldn't load the data. Please try again later.
+                    데이터를 불러올 수 없습니다. 나중에 다시 시도해주세요.
                 </p>
             </main>
         </div>

--- a/src/components/pages/stats/StatsPage.tsx
+++ b/src/components/pages/stats/StatsPage.tsx
@@ -5,28 +5,28 @@ import StatsHeader from "./StatsHeader"
 import { StatsNoticeBanner } from "./StatsNoticeBanner"
 import { usePerformanceMonitoring } from "@/hooks/usePerformanceMonitoring"
 import { useQuery } from "@tanstack/react-query"
-import { fetchAllUserData } from "@/utils/userUtils"
+import { fetchAllUserDataWithBoardPermission } from "@/utils/userUtils"
+
+const ACTIVE_BOARD_ID: string[] = ['Qs8RNvGqMBFLmIAkiLUS', 'AyvgJGwmf4MnOmAvz0xH']
 
 export default function StatsPage() {
     usePerformanceMonitoring('StatsPage');
-    
-    // 1. 모든 사용자 데이터 가져오기
     const { 
-        data: users, 
+        data: activeUsers, 
         isLoading: isLoadingUsers, 
         error: usersError 
     } = useQuery({
-        queryKey: ['users'],
-        queryFn: fetchAllUserData
+        queryKey: ['activeUsers', ACTIVE_BOARD_ID],
+        queryFn: () => fetchAllUserDataWithBoardPermission(ACTIVE_BOARD_ID),
     });
-    
+
     // 2. 사용자 ID 배열로 통계 가져오기
     const { 
         data: writingStats, 
         isLoading: isLoadingStats, 
         error: statsError 
     } = useWritingStatsV2(
-        users?.map(user => user.uid) || []
+        activeUsers?.map(user => user.uid) || []
     );
     
     const isLoading = isLoadingUsers || isLoadingStats;

--- a/src/hooks/useAuthors.ts
+++ b/src/hooks/useAuthors.ts
@@ -24,7 +24,7 @@ export const useAuthors = (boardId: string) => {
   const { data: authors, isLoading, error } = useQuery<User[], Error>({
     queryKey: ['authors', boardId, currentHour],
     queryFn: async () => {
-      const authorData = await fetchAllUserDataWithBoardPermission(boardId);
+      const authorData = await fetchAllUserDataWithBoardPermission([boardId]);
       const seed = getHourBasedSeed();
       return shuffleArray(authorData, seed);
     },

--- a/src/hooks/useWritingStatsV2.ts
+++ b/src/hooks/useWritingStatsV2.ts
@@ -19,6 +19,12 @@ export function useWritingStatsV2(userIds: string[]) {
         queryKey: ['writingStatsV2', userIds],
         queryFn: () => fetchMultipleUserStats(userIds),
         enabled: userIds.length > 0,
+        // 캐시 설정
+        staleTime: 1 * 60 * 1000, // 5분 동안 데이터를 'fresh'하게 유지
+        cacheTime: 30 * 60 * 1000, // 30분 동안 캐시 유지
+        // 실시간 업데이트를 위한 주기적 리프레시
+        refetchInterval: 5 * 60 * 1000, // 5분마다 리프레시
+        refetchOnWindowFocus: true, // 윈도우 포커스 시 리프레시
     });
 }
 

--- a/src/hooks/useWritingStatsV2.ts
+++ b/src/hooks/useWritingStatsV2.ts
@@ -29,11 +29,32 @@ async function fetchMultipleUserStats(userIds: string[]): Promise<WritingStats[]
     try {
         const statsPromises = userIds.map(fetchSingleUserStats);
         const results = await Promise.all(statsPromises);
-        return results.filter((result): result is WritingStats => result !== null);
+        return sort(results.filter((result): result is WritingStats => result !== null));
     } catch (error) {
         console.error('Error fetching multiple user stats:', error);
         throw error;
     }
+}
+function sort(writingStats: WritingStats[]): WritingStats[] {
+    return writingStats.sort((a, b) => {
+        // 1. sort by recentStreak
+        if (b.recentStreak !== a.recentStreak) {
+            return b.recentStreak - a.recentStreak;
+        }
+
+        // 2. if recentStreak is same, sort by number of contributions
+        const aContributions = a.contributions.length;
+        const bContributions = b.contributions.length;
+
+        // 3. if number of contributions is same, sort by sum of contentLength
+        if (bContributions !== aContributions) {
+            return bContributions - aContributions;
+        }
+
+        const aContentLengthSum = a.contributions.reduce((sum, contribution) => sum + (contribution.contentLength ?? 0), 0);
+        const bContentLengthSum = b.contributions.reduce((sum, contribution) => sum + (contribution.contentLength ?? 0), 0);
+        return bContentLengthSum - aContentLengthSum;
+    });
 }
 
 // 단일 사용자의 통계 가져오기

--- a/src/hooks/useWritingStatsV2.ts
+++ b/src/hooks/useWritingStatsV2.ts
@@ -132,6 +132,11 @@ function createUserInfo(user: User) {
 
 function createStreakBadge(streak: number): WritingBadge[] {
     if (streak < 2) return [];
+    if (streak > 20) return [{
+        name: `연속 20일 이상`,
+        emoji: '🔥'
+    }];
+
     return [{
         name: `연속 ${streak}일차`,
         emoji: '🔥'

--- a/src/hooks/useWritingStatsV2.ts
+++ b/src/hooks/useWritingStatsV2.ts
@@ -4,7 +4,7 @@
 // 3. return stats
 
 import { useQuery } from '@tanstack/react-query';
-import { collection, getDocs, query, orderBy } from 'firebase/firestore';
+import { collection, getDocs, query, orderBy, Timestamp } from 'firebase/firestore';
 import { firestore } from '@/firebase';
 import { WritingStats, Contribution, WritingBadge } from '@/types/WritingStats';
 import { Posting } from '@/types/Posting';
@@ -12,6 +12,7 @@ import { User } from '@/types/User';
 import { fetchUserData } from '@/utils/userUtils';
 import { getRecentWorkingDays } from '@/utils/dateUtils';
 import { calculateCurrentStreak } from '@/utils/streakUtils';
+import { getDateKey, getUserTimeZone } from '@/utils/streakUtils';
 
 export function useWritingStatsV2(userIds: string[]) {
     return useQuery({
@@ -68,50 +69,94 @@ async function fetchSingleUserStats(userId: string): Promise<WritingStats | null
         }
 
         const postings = await fetchPostingData(userId);
-        return calculateWritingStats(userData, postings);
+        const stats = calculateWritingStats(userData, postings);
+        if (stats.user.id === 'jB2TGQWG7WgPpQTwhKhrsWFrQYG2') {
+            console.log(`postings of ${userData.nickname}`, postings);
+            console.log(`stats of ${userData.nickname}`, stats);
+        }
+        return stats;
+        
     } catch (error) {
         console.error(`Error processing user ${userId}:`, error);
         return null;
     }
 }
 
-// 포스팅 데이터 가져오기
+// 포스팅 데이터 가져오기 함수 업데이트
 async function fetchPostingData(userId: string): Promise<Posting[]> {
     try {
         const postingsRef = collection(firestore, 'users', userId, 'postings');
         const q = query(postingsRef, orderBy('createdAt', 'desc'));
         const querySnapshot = await getDocs(q);
-        return querySnapshot.docs.map(doc => doc.data() as Posting);
+        
+        return querySnapshot.docs.map(doc => {
+            const data = doc.data() as Posting;
+            // createdAt 필드를 Timestamp로 확실히 변환
+            // converted된 결과가 다를 때만 로깅을 한다.
+            const converted = ensureTimestamp(data.createdAt);
+            if (data.createdAt !== converted) {
+                console.log('Original createdAt:', data.createdAt);
+                console.log('Converted createdAt:', converted);
+            }
+            data.createdAt = converted;
+            return data;
+        });
     } catch (error) {
         console.error('Error fetching posting data:', error);
         throw error;
     }
 }
 
+// Timestamp 변환 헬퍼 함수
+function ensureTimestamp(value: any): Timestamp {
+    // 1. 이미 Timestamp 인스턴스인 경우
+    if (value instanceof Timestamp) {
+        return value;
+    }
+
+    // 2. seconds와 nanoseconds를 가진 객체인 경우
+    if (value && 
+        typeof value.seconds === "number" && 
+        typeof value.nanoseconds === "number") {
+        return new Timestamp(value.seconds, value.nanoseconds);
+    }
+
+    // 3. 유효하지 않은 값인 경우
+    console.warn("Missing or invalid timestamp detected. Using current time as fallback.", value);
+    return Timestamp.now();
+}
+
 // 기여도 배열 생성
 function createContributions(postings: Posting[], workingDays: Date[]): Contribution[] {
-    // Helper function to get a date key in YYYY-MM-DD format.
-    const getDateKey = (date: Date): string => date.toISOString().split('T')[0];
-
-    // Build a map where the key is the date string and the value is the total contentLength.
+    const userTimeZone = getUserTimeZone();
+    
     const postingMap = new Map<string, number>();
 
+    // Debug logging
+    console.log('User TimeZone:', userTimeZone);
+    console.log('Processing postings for contributions:');
+    
     for (const posting of postings) {
-        // Convert the Firebase Timestamp to a Date. (Assuming Timestamp has a toDate() method)
         const postingDate = posting.createdAt.toDate();
-        const key = getDateKey(postingDate);
+        const key = getDateKey(postingDate, userTimeZone);
+        
+        // Debug logging
+        console.log(`Posting:`, {
+            date: postingDate.toISOString(),
+            timeZone: userTimeZone,
+            dateKey: key,
+            contentLength: posting.post.contentLength
+        });
+        
         const currentSum = postingMap.get(key) || 0;
         postingMap.set(key, currentSum + posting.post.contentLength);
     }
 
-    // Build contributions for each working day.
     return workingDays.map(day => {
-        const key = getDateKey(day);
-        // If no posting, contentLength is null. Otherwise, sum the content lengths.
-        const totalContentLength = postingMap.has(key) ? postingMap.get(key)! : null;
+        const key = getDateKey(day, userTimeZone);
         return {
             createdAt: key,
-            contentLength: totalContentLength,
+            contentLength: postingMap.has(key) ? postingMap.get(key)! : null
         };
     });
 }

--- a/src/hooks/useWritingStatsV2.ts
+++ b/src/hooks/useWritingStatsV2.ts
@@ -1,0 +1,83 @@
+// TODO:
+// 1. get posting data of certain user from firestore 
+// 2. calculate WritingStats from posting data
+// 3. return stats
+
+import { useQuery } from '@tanstack/react-query';
+import { collection, getDocs, query, orderBy } from 'firebase/firestore';
+import { firestore } from '@/firebase';
+import { WritingStats, Contribution, WritingBadge } from '@/types/WritingStats';
+import { Posting } from '@/types/Posting';
+import { User } from '@/types/User';
+import { fetchUserData } from '@/utils/userUtils';
+import { calculateCurrentStreak } from '@/utils/streakUtils';
+
+export function useWritingStatsV2(userId: string) {    
+    return useQuery({
+        queryKey: ['writingStatsV2', userId],
+        queryFn: async (): Promise<WritingStats> => {
+            if (!userId) {
+                throw new Error('User ID is required');
+            }
+
+            // 1. 사용자 정보 가져오기
+            const userData = await fetchUserData(userId);
+
+            if (!userData) {
+                throw new Error('User not found');
+            }
+
+            // 2. 포스팅 데이터 가져오기
+            const postings = await fetchPostingData(userId);
+
+            // 3. WritingStats 계산
+            return calculateWritingStats(userData, postings);
+        },
+        enabled: !!userId,
+    });
+}
+
+async function fetchPostingData(userId: string): Promise<Posting[]> {
+    try {
+        const postingsRef = collection(firestore, 'users', userId, 'postings');
+        const q = query(postingsRef, orderBy('createdAt', 'desc'));
+        const querySnapshot = await getDocs(q);
+        return querySnapshot.docs.map(doc => doc.data() as Posting);
+    } catch (error) {
+        console.error('Error fetching posting data:', error);
+        throw error;
+    }
+}
+
+function calculateWritingStats(user: User, postings: Posting[]): WritingStats {
+
+    // 3. Contributions 배열 생성
+    const contributions: Contribution[] = postings.map(posting => ({
+        createdAt: posting.createdAt.toDate().toISOString(),
+        contentLength: posting.post.contentLength
+    }));
+
+    const streak = calculateCurrentStreak(postings);
+    const badges = createStreakBadge(streak);
+    // 4. WritingStats 객체 반환
+    return {
+        user: {
+            id: user.uid,
+            nickname: user.nickname || null,
+            realname: user.realName || null,
+            profilePhotoURL: user.profilePhotoURL || null,
+            bio: user.bio || null
+        },
+        contributions,
+        badges: badges
+    };
+}   
+
+function createStreakBadge(streak: number): WritingBadge[] {
+    if (streak < 2) return [];
+    
+    return [{
+        name: `연속 ${streak}일차`,
+        emoji: '🔥'
+    }];
+}

--- a/src/types/Posting.ts
+++ b/src/types/Posting.ts
@@ -1,0 +1,14 @@
+import { Timestamp } from "firebase/firestore";
+
+export interface Posting {
+    board: {
+      id: string;
+    };
+    post: {
+      id: string;
+      title: string;
+      contentLength: number;
+    };
+    createdAt: Timestamp;
+  }
+  

--- a/src/types/WritingBadge.ts
+++ b/src/types/WritingBadge.ts
@@ -1,0 +1,4 @@
+export interface WritingBadge {
+    name: string
+    emoji: string
+}

--- a/src/types/WritingStats.ts
+++ b/src/types/WritingStats.ts
@@ -8,6 +8,7 @@ export interface WritingStats {
     }
     contributions: Contribution[];
     badges: WritingBadge[];
+    recentStreak: number;
 }
 
 export type Contribution = {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,45 @@
+
+const HOLIDAYS: Date[] = [
+    new Date('2024-12-31T00:00:00Z'),
+    new Date('2025-01-01T00:00:00Z'),
+    new Date('2025-01-28T00:00:00Z'),
+    new Date('2025-01-29T00:00:00Z'),
+    new Date('2025-01-30T00:00:00Z')
+];
+
+// functions to get 20 recent working days (return value's length should be 20
+export function getRecentWorkingDays(): Date[] {
+    const workingDays: Date[] = [];
+    const currentDate = new Date();
+    while (workingDays.length < 20) {
+        if (isWorkingDay(currentDate)) {
+            workingDays.push(new Date(currentDate));
+        }
+        currentDate.setDate(currentDate.getDate() - 1);
+    }
+    return workingDays.reverse();
+}
+
+export function isWorkingDay(date: Date): boolean {
+    // if it's weekend or holiday based on user's timezone, return false 
+    const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (isWeekend(date, userTimeZone) || isHoliday(date, userTimeZone)) {
+        return false;
+    }
+    return true;
+}
+
+function isWeekend(date: Date, timeZone: string): boolean {
+    const dateInTimeZone = new Date(date.toLocaleString('en-US', { timeZone }));
+    const day = dateInTimeZone.getDay();
+    return day === 0 || day === 6;
+}
+
+function isHoliday(date: Date, timeZone: string): boolean {
+    const dateInTimeZone = new Date(date.toLocaleString('en-US', { timeZone }));
+    return HOLIDAYS.some(holiday =>
+        dateInTimeZone.getFullYear() === holiday.getFullYear() &&
+        dateInTimeZone.getMonth() === holiday.getMonth() &&
+        dateInTimeZone.getDate() === holiday.getDate()
+    );
+}

--- a/src/utils/streakUtils.ts
+++ b/src/utils/streakUtils.ts
@@ -1,0 +1,50 @@
+import { Posting } from '@/types/Posting';
+
+// pure function to calculate current streak
+export function calculateCurrentStreak(postings: Posting[]): number {
+    if (!postings.length) {
+        return 0;
+    }
+
+    // 날짜별로 포스팅을 그룹화
+    const postingDates = postings.map(posting => 
+        posting.createdAt.toDate().toISOString().split('T')[0]
+    );
+    const uniqueDates = [...new Set(postingDates)].sort().reverse(); // 최신 날짜순
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    
+    const lastPostDate = new Date(uniqueDates[0]);
+    lastPostDate.setHours(0, 0, 0, 0);
+
+    // 어제까지 포스팅이 없으면 스트릭은 0
+    if (lastPostDate.getTime() < yesterday.getTime()) {
+        return 0;
+    }
+
+    let streak = 1; // 최소 1일
+    let currentDate = lastPostDate;
+
+    // 연속된 날짜 확인
+    for (let i = 1; i < uniqueDates.length; i++) {
+        const prevDate = new Date(uniqueDates[i]);
+        prevDate.setHours(0, 0, 0, 0);
+
+        const diffDays = Math.floor(
+            (currentDate.getTime() - prevDate.getTime()) / (1000 * 60 * 60 * 24)
+        );
+
+        if (diffDays === 1) {
+            streak++;
+            currentDate = prevDate;
+        } else {
+            break; // 연속이 끊기면 중단
+        }
+    }
+
+    return streak;
+}

--- a/src/utils/streakUtils.ts
+++ b/src/utils/streakUtils.ts
@@ -34,7 +34,7 @@ function hasPostingOnDate(date: Date, postingDays: Set<string>, timeZone: string
 
 // Pure function that calculates the current streak given today's date, a postingDays set, 
 // and an isWorkingDay predicate.
-function calculateStreakFromDate(
+export function calculateStreakFromDate(
     startDate: Date,
     postingDays: Set<string>,
     timeZone: string,
@@ -64,7 +64,6 @@ export function calculateCurrentStreak(postings: Posting[]): number {
     const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const postingDays = buildPostingDaysSet(postings, userTimeZone);
     const today = new Date();
-
     return calculateStreakFromDate(today, postingDays, userTimeZone, isWorkingDay);
 }
 

--- a/src/utils/streakUtils.ts
+++ b/src/utils/streakUtils.ts
@@ -1,9 +1,7 @@
 import { isWorkingDay } from '@/utils/dateUtils';
 import { Posting } from '@/types/Posting';
-import { Timestamp } from 'firebase/firestore';
-// Helper: Converts a Date to a YYYY-MM-DD string in the given timezone.
+
 export function getDateKey(date: Date, timeZone?: string): string {
-    // timeZone이 제공되지 않으면 사용자의 타임존 사용
     const userTimeZone = timeZone || getUserTimeZone();
     
     const formatter = new Intl.DateTimeFormat('en-US', {
@@ -81,19 +79,3 @@ export function getUserTimeZone(): string {
         return 'Asia/Seoul'; // 기본값으로 KST 사용
     }
 }
-
-// 디버깅을 위한 테스트 함수
-function testDateConversion(timestamp: Timestamp) {
-    const date = timestamp.toDate();
-    const userTimeZone = getUserTimeZone();
-    
-    console.log('Original Date:', date.toISOString());
-    console.log('User TimeZone:', userTimeZone);
-    console.log('Local Date Key:', getDateKey(date)); // 사용자 타임존
-    console.log('KST Date Key:', getDateKey(date, 'Asia/Seoul'));
-    console.log('UTC Date Key:', getDateKey(date, 'UTC'));
-}
-
-// 사용 예시:
-const timestamp = new Timestamp(1739525815, 673000000); // 2025-01-16 in KST
-testDateConversion(timestamp);


### PR DESCRIPTION
resolve #143 
- 기록 탭의 로딩이 너무 느린데, firebase의 functions 응답을 쓰기 때문이었음.
- firebase functions는 트래픽이 많지 않으면 cold start 를 겪고 그 시간이 7초 이상임.
- 따라서 차라리 firestore에 직접 저장을 하고, computation은 API 호출 시점이 아닌 데이터베이스 업데이트 시점에 한다.
- 그리고 필요한 계산 로직을 클라이언트에서 처리한다. 
- 그 결과 훨씬 로딩이 빨라짐!
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/0f79e060-0c45-41ed-a11a-766f4f3753a4" />
