### PR TITLE
기록 정렬 시 콘텐츠 길이의 합으로 비교하기

### DIFF
--- a/src/hooks/useWritingStatsV2.ts
+++ b/src/hooks/useWritingStatsV2.ts
@@ -46,13 +46,6 @@ function sort(writingStats: WritingStats[]): WritingStats[] {
             return b.recentStreak - a.recentStreak;
         }
 
-        const aContributions = a.contributions.length;
-        const bContributions = b.contributions.length;
-
-        if (bContributions !== aContributions) {
-            return bContributions - aContributions;
-        }
-
         const aContentLengthSum = a.contributions.reduce((sum, contribution) => sum + (contribution.contentLength ?? 0), 0);
         const bContentLengthSum = b.contributions.reduce((sum, contribution) => sum + (contribution.contentLength ?? 0), 0);
         return bContentLengthSum - aContentLengthSum;


### PR DESCRIPTION
- 배열 길이는 다 똑같음 (안 쓴날도 null로 들어가있기 때문에)
- contribution 배열 길이는 기준에서 빼기