### PR TITLE
글 수정 중에 커서 변경/탭 전환 시 데이터 다시 불러오지 않기

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,37 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  fallback: ReactNode | ((error: Error) => ReactNode);
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      if (typeof this.props.fallback === 'function') {
+        return this.props.fallback(this.state.error!);
+      }
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+} 

--- a/src/components/pages/post/PostEditPage.tsx
+++ b/src/components/pages/post/PostEditPage.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, Save } from 'lucide-react';
-import React, { useState } from 'react';
+import React, { useState, Suspense } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 
@@ -11,40 +11,73 @@ import { PostTextEditor } from './PostTextEditor';
 import { PostTitleEditor } from './PostTitleEditor';
 import { PostBackButton } from './PostBackButton';
 import { toast } from '@/hooks/use-toast';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 
+// 메인 컴포넌트
 export default function PostEditPage() {
   const { postId, boardId } = useParams<{ postId: string; boardId: string }>();
+  
+  if (!boardId || !postId) {
+    return <ErrorState error={new Error('게시판 또는 게시물 ID가 없습니다.')} />;
+  }
+
+  return (
+    <ErrorBoundary fallback={(error) => <ErrorState error={error} boardId={boardId} />}>
+      <Suspense fallback={<LoadingState />}>
+        <PostEditForm boardId={boardId} postId={postId} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+
+// 로딩 상태 컴포넌트
+function LoadingState() {
+  return (
+    <div className='mx-auto max-w-4xl px-6 sm:px-8 lg:px-12 py-8'>
+      <Skeleton className='mb-4 h-12 w-3/4' />
+      <Skeleton className='mb-2 h-4 w-full' />
+      <Skeleton className='mb-2 h-4 w-full' />
+      <Skeleton className='h-4 w-2/3' />
+    </div>
+  );
+}
+
+// 에러 상태 컴포넌트
+function ErrorState({ error, boardId }: { error: Error; boardId?: string }) {
   const navigate = useNavigate();
   
-  // 편집 상태를 관리하는 객체
-  const [editState, setEditState] = useState<{
-    initialized: boolean;
-    title: string;
-    content: string;
-  }>({
-    initialized: false,
-    title: '',
-    content: ''
-  });
+  return (
+    <div className='mx-auto max-w-4xl px-6 sm:px-8 lg:px-12 py-8 text-center'>
+      <h1 className='mb-4 text-2xl font-bold'>게시물을 찾을 수 없습니다.</h1>
+      <p className='mb-4 text-red-500'>{error.message}</p>
+      <Button onClick={() => navigate(`/board/${boardId}`)}>
+        <ChevronLeft className='mr-2 size-4' /> 피드로 돌아가기
+      </Button>
+    </div>
+  );
+}
 
-  // 데이터 가져오기
-  const { data: post, isLoading, error } = useQuery(
+// 게시물 편집 폼 컴포넌트
+function PostEditForm({ boardId, postId }: { boardId: string; postId: string }) {
+  const navigate = useNavigate();
+  
+  // React Query의 suspense 모드 사용
+  const { data: post } = useQuery(
     ['post', boardId, postId],
-    () => fetchPost(boardId!, postId!),
+    () => fetchPost(boardId, postId),
     {
-      enabled: !!boardId && !!postId,
-      refetchOnWindowFocus: false,
-      onSuccess: (fetchedPost) => {
-        if (!editState.initialized && fetchedPost) {
-          setEditState({
-            initialized: true,
-            title: fetchedPost.title,
-            content: fetchedPost.content
-          });
-        }
-      }
+      suspense: true, // Suspense 모드 활성화
+      useErrorBoundary: true, // 에러를 ErrorBoundary로 전파
+      refetchOnWindowFocus: false
     }
   );
+
+  // 편집 상태를 관리하는 객체
+  const [editState, setEditState] = useState({
+    title: post?.title || '',
+    content: post?.content || ''
+  });
 
   // 제목 변경 핸들러
   const setTitle = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -65,10 +98,10 @@ export default function PostEditPage() {
   // 폼 제출 핸들러
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!editState.title.trim() || !editState.content.trim() || !postId) return;
+    if (!editState.title.trim() || !editState.content.trim()) return;
     
     try {
-      await updatePost(boardId!, postId!, editState.title, editState.content);
+      await updatePost(boardId, postId, editState.title, editState.content);
       navigate(`/board/${boardId}/post/${postId}`);
     } catch (error) {
       console.error('Error updating post:', error);
@@ -79,28 +112,6 @@ export default function PostEditPage() {
       });
     }
   };
-
-  if (isLoading) {
-    return (
-      <div className='mx-auto max-w-4xl px-6 sm:px-8 lg:px-12 py-8'>
-        <Skeleton className='mb-4 h-12 w-3/4' />
-        <Skeleton className='mb-2 h-4 w-full' />
-        <Skeleton className='mb-2 h-4 w-full' />
-        <Skeleton className='h-4 w-2/3' />
-      </div>
-    );
-  }
-
-  if (error || !post) {
-    return (
-      <div className='mx-auto max-w-4xl px-6 sm:px-8 lg:px-12 py-8 text-center'>
-        <h1 className='mb-4 text-2xl font-bold'>게시물을 찾을 수 없습니다.</h1>
-        <Button onClick={() => navigate(`/board/${boardId}`)}>
-          <ChevronLeft className='mr-2 size-4' /> 피드로 돌아가기
-        </Button>
-      </div>
-    );
-  }
 
   return (
     <div className='mx-auto max-w-4xl px-6 sm:px-8 lg:px-12 py-8'>
@@ -114,7 +125,7 @@ export default function PostEditPage() {
             />
             <div className='flex items-center justify-between text-sm text-muted-foreground'>
               <p>
-                작성자: {post.authorName} | 작성일: {post.createdAt?.toLocaleString() || '?'}
+                작성자: {post?.authorName || '?'} | 작성일: {post?.createdAt?.toLocaleString() || '?'}
               </p>
             </div>
           </CardHeader>
@@ -135,4 +146,3 @@ export default function PostEditPage() {
     </div>
   );
 }
-


### PR DESCRIPTION
- staleTime: Infinity를 제거하고 refetchOnWindowFocus: false만 유지하면 
- 페이지 방문 시 항상 데이터를 가져오면서도 탭 전환 시 재요청을 방지할 수 있음