### PR TITLE
댓글/답글 기록 쿼리 최적화 및 UI 개선

### DIFF
--- a/src/stats/components/StatsPage.tsx
+++ b/src/stats/components/StatsPage.tsx
@@ -13,6 +13,8 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/shared/ui/tabs"
 import { useCommentingStats } from "@/stats/hooks/useCommentingStats"
 import { UserPostingStatsCardList } from "@/stats/components/UserPostingStatsCardList"
 import { UserCommentStatsCardList } from "@/stats/components/UserCommentStatsCardList"
+import React from "react"
+import { Loader2 } from "lucide-react"
 
 // 통계 페이지 스크롤 영역의 고유 ID
 const STATS_SCROLL_ID = 'stats-scroll';
@@ -87,22 +89,36 @@ export default function StatsPage() {
                 <ScrollArea className="h-full" id={STATS_SCROLL_ID}>
                     <StatsNoticeBanner />
                     <Tabs value={tab} onValueChange={v => setTab(v as 'posting' | 'commenting')}>
-                        <TabsList>
-                            <TabsTrigger value="posting">글쓰기</TabsTrigger>
-                            <TabsTrigger value="commenting">댓글·답글</TabsTrigger>
+                        <TabsList className="w-full flex justify-between mb-4 rounded-lg bg-muted">
+                            <TabsTrigger value="posting" className="flex-1 data-[state=active]:bg-background data-[state=active]:shadow-sm rounded-lg text-base p-2">글쓰기</TabsTrigger>
+                            <TabsTrigger
+                                value="commenting"
+                                className="flex-1 data-[state=active]:bg-background data-[state=active]:shadow-sm rounded-lg text-base p-2 flex items-center justify-center gap-2"
+                            >
+                                댓글·답글
+                                {isLoadingCommenting && (
+                                    <Loader2 className="ml-1 h-4 w-4 animate-spin text-muted-foreground" />
+                                )}
+                            </TabsTrigger>
                         </TabsList>
-                        <TabsContent value="posting">
-                            <UserPostingStatsCardList 
+                        <div className="mt-4">
+                          <TabsContent value="posting">
+                            <React.Suspense fallback={<LoadingState />}>
+                              <UserPostingStatsCardList 
                                 stats={writingStats || []} 
                                 onCardClick={userId => navigate(`/user/${userId}`)}
-                            />
-                        </TabsContent>
-                        <TabsContent value="commenting">
-                            <UserCommentStatsCardList 
+                              />
+                            </React.Suspense>
+                          </TabsContent>
+                          <TabsContent value="commenting">
+                            <React.Suspense fallback={<LoadingState />}>
+                              <UserCommentStatsCardList 
                                 stats={commentingStats || []} 
                                 onCardClick={userId => navigate(`/user/${userId}`)}
-                            />
-                        </TabsContent>
+                              />
+                            </React.Suspense>
+                          </TabsContent>
+                        </div>
                     </Tabs>
                 </ScrollArea>
             </main>

--- a/src/stats/hooks/useCommentingStats.ts
+++ b/src/stats/hooks/useCommentingStats.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchUserCommentings, fetchUserReplyings } from '@/user/api/commenting';
+import { fetchUserCommentingsByDateRange, fetchUserReplyingsByDateRange } from '@/user/api/commenting';
 import { fetchUser } from '@/user/api/user';
 import { aggregateCommentingContributions, CommentingContribution } from '@/stats/utils/commentingContributionUtils';
 import { getRecentWorkingDays } from '@/shared/utils/dateUtils';
@@ -18,12 +18,15 @@ export type UserCommentingStats = {
 async function fetchMultipleUserCommentingStats(userIds: string[]): Promise<UserCommentingStats[]> {
   if (!userIds.length) return [];
   const workingDays = getRecentWorkingDays();
+  const start = workingDays[0];
+  const end = new Date(workingDays[workingDays.length - 1]);
+  end.setHours(23, 59, 59, 999); // 마지막 날의 끝까지 포함
 
   const statsPromises = userIds.map(async (userId) => {
     const [user, commentings, replyings] = await Promise.all([
       fetchUser(userId),
-      fetchUserCommentings(userId),
-      fetchUserReplyings(userId),
+      fetchUserCommentingsByDateRange(userId, start, end),
+      fetchUserReplyingsByDateRange(userId, start, end),
     ]);
     if (!user) return null;
     return {

--- a/src/user/api/commenting.ts
+++ b/src/user/api/commenting.ts
@@ -1,7 +1,8 @@
-import { collection, getDocs } from 'firebase/firestore';
+import { collection, getDocs, query, where } from 'firebase/firestore';
 import { firestore } from '@/firebase';
 import { Commenting } from '@/user/model/Commenting';
 import { Replying } from '@/user/model/Replying';
+import { Timestamp } from 'firebase/firestore';
 
 // 특정 유저의 commentings 서브컬렉션 전체 fetch
 export async function fetchUserCommentings(userId: string): Promise<Commenting[]> {
@@ -15,4 +16,36 @@ export async function fetchUserReplyings(userId: string): Promise<Replying[]> {
     const ref = collection(firestore, 'users', userId, 'replyings');
     const snap = await getDocs(ref);
     return snap.docs.map(doc => doc.data() as Replying);
+}
+
+// 날짜 범위로 commentings 조회
+export async function fetchUserCommentingsByDateRange(
+  userId: string,
+  start: Date,
+  end: Date
+): Promise<Commenting[]> {
+  const ref = collection(firestore, 'users', userId, 'commentings');
+  const q = query(
+    ref,
+    where('createdAt', '>=', Timestamp.fromDate(start)),
+    where('createdAt', '<', Timestamp.fromDate(end))
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map(doc => doc.data() as Commenting);
+}
+
+// 날짜 범위로 replyings 조회
+export async function fetchUserReplyingsByDateRange(
+  userId: string,
+  start: Date,
+  end: Date
+): Promise<Replying[]> {
+  const ref = collection(firestore, 'users', userId, 'replyings');
+  const q = query(
+    ref,
+    where('createdAt', '>=', Timestamp.fromDate(start)),
+    where('createdAt', '<', Timestamp.fromDate(end))
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map(doc => doc.data() as Replying);
 } 


### PR DESCRIPTION
- 전체 댓글/답글 가져오지 않고 20일 동안의 기록만 가져오게 해서 최적화
- Tabbar UI를 가로 꽉 차게 변경