### PR TITLE
공유 시 타이틀이 두 번 노출되던 것 수정

### DIFF
--- a/src/post/components/PostDetailHeader.tsx
+++ b/src/post/components/PostDetailHeader.tsx
@@ -28,7 +28,6 @@ export function PostDetailHeader({
       if (navigator.share) {
         navigator.share({
           title: post.title,
-          text: post.title,
           url: window.location.href,
         });
       } else {


### PR DESCRIPTION
공유 모듈에서 복사가 아닌 다른 앱 클릭 시, "타이틀 - 타이틀 URL" 이런 식으로 반복해서 나오는 것 수정함. 

authorName 을 같이 보여줄까 하다가, 그건 따로 수정하지 않음. 