### PR TITLE
게시글을 읽을 때는 저장된 스크롤 상관없이 항상 제목부터 볼 수 있도록 변경

### DIFF
--- a/src/post/components/PostDetailPage.tsx
+++ b/src/post/components/PostDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 import Comments from '@/comment/components/Comments';
@@ -25,6 +26,11 @@ export default function PostDetailPage() {
   );
 
   const { nickname: authorNickname } = useUserNickname(post?.authorId ?? null);
+
+  // 게시글 상세 페이지는 항상 맨 위부터 시작
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  }, [postId]);
 
   if (isLoading) return <PostDetailSkeleton />;
   if (error || !post) return <PostDetailError boardId={boardId} />;

--- a/src/post/components/PostDetailPage.tsx
+++ b/src/post/components/PostDetailPage.tsx
@@ -29,7 +29,7 @@ export default function PostDetailPage() {
 
   // 게시글 상세 페이지는 항상 맨 위부터 시작
   useEffect(() => {
-    window.scrollTo({ top: 0, behavior: 'instant' });
+    window.scrollTo({ top: 0, behavior: 'auto' });
   }, [postId]);
 
   if (isLoading) return <PostDetailSkeleton />;


### PR DESCRIPTION
### 문제 
게시판 스크롤 위치가 글을 읽을 때도 반영되었다. 그래서 조금 밑의 글을 읽으면 게시글 중간이나 댓글부터 보임 

### 해결 
글 상세에서는 항상 위부터 시작하도록 변경. 
그래도 게시판에서는 위치가 그대로 유지됨. 