### PR TITLE
답글/댓글 생성 시 글쓴이의 프로필 이미지와 닉네임을 auth가 아닌 firestore 기준으로 변경

### DIFF
--- a/src/comment/hooks/useCreateComment.ts
+++ b/src/comment/hooks/useCreateComment.ts
@@ -1,10 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createComment, updateCommentToPost, deleteCommentToPost } from '@/comment/api/comment';
 import { useAuth } from '@/shared/hooks/useAuth';
+import { useUser } from '@/user/hooks/useUser';
 
 export function useCreateComment(boardId: string, postId: string) {
   const { currentUser } = useAuth();
   const queryClient = useQueryClient();
+  const { userData } = useUser(currentUser?.uid);
 
   return useMutation(
     async (content: string) => {
@@ -14,15 +16,15 @@ export function useCreateComment(boardId: string, postId: string) {
         postId,
         content,
         currentUser.uid,
-        currentUser.displayName,
-        currentUser.photoURL,
+        userData?.nickname ?? currentUser.displayName,
+        userData?.profilePhotoURL ?? currentUser.photoURL,
       );
     },
     {
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: ['comments', boardId, postId] });
       },
-    }
+    },
   );
 }
 
@@ -34,18 +36,15 @@ export function useEditComment(boardId: string, postId: string, commentId: strin
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: ['comments', boardId, postId] });
       },
-    }
+    },
   );
 }
 
 export function useDeleteComment(boardId: string, postId: string, commentId: string) {
   const queryClient = useQueryClient();
-  return useMutation(
-    () => deleteCommentToPost(boardId, postId, commentId),
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ['comments', boardId, postId] });
-      },
-    }
-  );
-} 
+  return useMutation(() => deleteCommentToPost(boardId, postId, commentId), {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', boardId, postId] });
+    },
+  });
+}

--- a/src/comment/hooks/useCreateReply.ts
+++ b/src/comment/hooks/useCreateReply.ts
@@ -1,10 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createReply, updateReplyToComment, deleteReplyToComment } from '@/comment/api/reply';
 import { useAuth } from '@/shared/hooks/useAuth';
+import { useUser } from '@/user/hooks/useUser';
 
 export function useCreateReply(boardId: string, postId: string, commentId: string) {
   const { currentUser } = useAuth();
   const queryClient = useQueryClient();
+  const { userData } = useUser(currentUser?.uid);
 
   return useMutation(
     async (content: string) => {
@@ -15,8 +17,8 @@ export function useCreateReply(boardId: string, postId: string, commentId: strin
         commentId,
         content,
         currentUser.uid,
-        currentUser.displayName,
-        currentUser.photoURL,
+        userData?.nickname ?? currentUser.displayName,
+        userData?.profilePhotoURL ?? currentUser.photoURL,
       );
     },
     {
@@ -24,7 +26,7 @@ export function useCreateReply(boardId: string, postId: string, commentId: strin
         queryClient.invalidateQueries({ queryKey: ['replies', boardId, postId, commentId] });
         queryClient.invalidateQueries({ queryKey: ['replyCount', boardId, postId, commentId] });
       },
-    }
+    },
   );
 }
 
@@ -37,19 +39,21 @@ export function useEditReply(boardId: string, postId: string, commentId: string,
         queryClient.invalidateQueries({ queryKey: ['replies', boardId, postId, commentId] });
         queryClient.invalidateQueries({ queryKey: ['replyCount', boardId, postId, commentId] });
       },
-    }
+    },
   );
 }
 
-export function useDeleteReply(boardId: string, postId: string, commentId: string, replyId: string) {
+export function useDeleteReply(
+  boardId: string,
+  postId: string,
+  commentId: string,
+  replyId: string,
+) {
   const queryClient = useQueryClient();
-  return useMutation(
-    () => deleteReplyToComment(boardId, postId, commentId, replyId),
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ['replies', boardId, postId, commentId] });
-        queryClient.invalidateQueries({ queryKey: ['replyCount', boardId, postId, commentId] });
-      },
-    }
-  );
-} 
+  return useMutation(() => deleteReplyToComment(boardId, postId, commentId, replyId), {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['replies', boardId, postId, commentId] });
+      queryClient.invalidateQueries({ queryKey: ['replyCount', boardId, postId, commentId] });
+    },
+  });
+}


### PR DESCRIPTION
- currentUser를 직접 써서 실제 유저의 프로필 사진이 안 나오고 있었음.