### PR TITLE
빈 게시판 상태에서 게시판 이름이 보이도록 레이아웃 조정

### DIFF
--- a/src/board/components/PostCardList.tsx
+++ b/src/board/components/PostCardList.tsx
@@ -92,7 +92,7 @@ const PostCardList: React.FC<PostCardListProps> = ({ boardId, onPostClick, onCli
 
   if (allPosts.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center p-8 text-center">
+      <div className="flex flex-col items-center justify-start p-8 text-center pt-16">
         <div className="text-6xl mb-4 text-muted-foreground">
           텅~
         </div>


### PR DESCRIPTION
- justify-center를 justify-start로 변경하여 컨텐츠를 상단에 배치
- pt-16으로 적절한 상단 여백 추가
- 빈 상태에서도 게시판 제목이 화면에 표시되도록 개선

🤖 Generated with [Claude Code](https://claude.ai/code)