### PR TITLE
onStreak -> onStreak 일 때 streak 정보가 업데이트 되지 않던 문제 해결

### DIFF
--- a/functions/src/recoveryStatus/StreakInfo.ts
+++ b/functions/src/recoveryStatus/StreakInfo.ts
@@ -3,7 +3,11 @@ import { Timestamp } from "firebase-admin/firestore";
 /**
  * Recovery status types for the 3-state system
  */
-export type RecoveryStatusType = 'onStreak' | 'eligible' | 'missed';
+export enum RecoveryStatusType {
+  ON_STREAK = 'onStreak',
+  ELIGIBLE = 'eligible', 
+  MISSED = 'missed'
+}
 
 /**
  * Status information for recovery system

--- a/functions/src/recoveryStatus/stateTransitions.ts
+++ b/functions/src/recoveryStatus/stateTransitions.ts
@@ -5,8 +5,7 @@ import {
   countPostsOnDate,
   formatDateString,
   isDateAfter,
-  getOrCreateStreakInfo,
-  updateStreakInfo
+  getOrCreateStreakInfo
 } from "./streakUtils";
 import { RecoveryStatusType } from "./StreakInfo";
 import { DBUpdate, addStreakCalculations, validateUserState, createBaseUpdate } from "./transitionHelpers";
@@ -312,80 +311,6 @@ async function calculateMidnightStreakUpdate(userId: string, _currentDate: Date)
   }
 }
 
-// ===== LEGACY WRAPPER FUNCTIONS =====
-
-export async function handleOnStreakToEligible(userId: string, currentDate: Date): Promise<boolean> {
-  const dbUpdate = await calculateOnStreakToEligible(userId, currentDate);
-  if (!dbUpdate) return false;
-  
-  await updateStreakInfo(userId, dbUpdate.updates);
-  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
-  return true;
-}
-
-export async function handleEligibleToMissed(userId: string, currentDate: Date): Promise<boolean> {
-  const dbUpdate = await calculateEligibleToMissed(userId, currentDate);
-  if (!dbUpdate) return false;
-  
-  await updateStreakInfo(userId, dbUpdate.updates);
-  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
-  return true;
-}
-
-export async function handleEligibleToOnStreak(userId: string, postDate: Date): Promise<boolean> {
-  const dbUpdate = await calculateEligibleToOnStreak(userId, postDate);
-  if (!dbUpdate) return false;
-  
-  await updateStreakInfo(userId, dbUpdate.updates);
-  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
-  
-  return dbUpdate.reason.includes('recovery completed');
-}
-
-export async function handleMissedToOnStreak(userId: string, postDate: Date): Promise<boolean> {
-  const dbUpdate = await calculateMissedToOnStreak(userId, postDate);
-  if (!dbUpdate) return false;
-  
-  await updateStreakInfo(userId, dbUpdate.updates);
-  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
-  return true;
-}
-
-export async function handleOnStreakToOnStreak(userId: string, postDate: Date): Promise<boolean> {
-  const dbUpdate = await calculateOnStreakToOnStreak(userId, postDate);
-  if (!dbUpdate) return false;
-  
-  await updateStreakInfo(userId, dbUpdate.updates);
-  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
-  return true;
-}
-
-export async function processMidnightTransitions(userId: string, currentDate: Date): Promise<void> {
-  try {
-    const transitionedToEligible = await handleOnStreakToEligible(userId, currentDate);
-    
-    if (!transitionedToEligible) {
-      await handleEligibleToMissed(userId, currentDate);
-    }
-  } catch (error) {
-    console.error(`[StateTransition] Error processing midnight transitions for user ${userId}:`, error);
-    throw error;
-  }
-}
-
-export async function processPostingTransitions(userId: string, postDate: Date): Promise<void> {
-  try {
-    const dbUpdate = await calculatePostingTransitions(userId, postDate);
-    
-    if (dbUpdate) {
-      await updateStreakInfo(userId, dbUpdate.updates);
-      console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
-    }
-  } catch (error) {
-    console.error(`[StateTransition] Error processing posting transitions for user ${userId}:`, error);
-    throw error;
-  }
-}
 
 // ===== BATCH PROCESSING UTILITIES =====
 

--- a/functions/src/recoveryStatus/stateTransitions.ts
+++ b/functions/src/recoveryStatus/stateTransitions.ts
@@ -1,4 +1,3 @@
-import { Timestamp } from "firebase-admin/firestore";
 import { toSeoulDate } from "../shared/dateUtils";
 import { 
   didUserMissYesterday, 
@@ -9,322 +8,195 @@ import {
   getOrCreateStreakInfo,
   updateStreakInfo
 } from "./streakUtils";
-import { StreakInfo } from "./StreakInfo";
-import { calculateUserStreaks, calculateStreaksAfterNewPosting } from "./streakCalculations";
+import { RecoveryStatusType } from "./StreakInfo";
+import { DBUpdate, addStreakCalculations, validateUserState, createBaseUpdate } from "./transitionHelpers";
 
-export interface DBUpdate {
-  userId: string;
-  updates: Partial<StreakInfo> & { lastCalculated: Timestamp };
-  reason: string;
-}
+// Re-export DBUpdate for backward compatibility
+export { DBUpdate } from "./transitionHelpers";
 
-/**
- * Helper function to add streak calculations to DB updates
- */
-async function addStreakCalculations(
-  userId: string, 
-  baseUpdates: Partial<StreakInfo> & { lastCalculated: Timestamp },
-  isNewPosting = false
-): Promise<Partial<StreakInfo> & { lastCalculated: Timestamp }> {
-  try {
-    const { data: currentStreakInfo } = await getOrCreateStreakInfo(userId);
-    
-    let streakData;
-    if (isNewPosting && currentStreakInfo) {
-      // Optimized calculation for new postings
-      streakData = await calculateStreaksAfterNewPosting(
-        userId,
-        currentStreakInfo.currentStreak || 0,
-        currentStreakInfo.longestStreak || 0
-      );
-    } else {
-      // Full recalculation
-      streakData = await calculateUserStreaks(userId);
-    }
-    
-    return {
-      ...baseUpdates,
-      currentStreak: streakData.currentStreak,
-      longestStreak: streakData.longestStreak,
-      ...(streakData.lastContributionDate && {
-        lastContributionDate: streakData.lastContributionDate
-      })
-    };
-  } catch (error) {
-    console.error(`[StreakCalculation] Error calculating streaks for user ${userId}:`, error);
-    // Return base updates without streak data if calculation fails
-    return baseUpdates;
-  }
-}
+// ===== CORE TRANSITION CALCULATORS (PURE FUNCTIONS) =====
 
 /**
- * 1. onStreak → eligible : at midnight after user missed a working day (PURE)
+ * Calculate onStreak → eligible transition
  */
 export async function calculateOnStreakToEligible(userId: string, currentDate: Date): Promise<DBUpdate | null> {
   const { data: streakInfo } = await getOrCreateStreakInfo(userId);
   
-  if (!streakInfo || streakInfo.status.type !== 'onStreak') {
+  if (!validateUserState(streakInfo, RecoveryStatusType.ON_STREAK)) {
     return null;
   }
   
-  // Check if user missed yesterday (working day)
   const missedYesterday = await didUserMissYesterday(userId, currentDate);
-  
   if (!missedYesterday) {
     return null;
   }
   
-  // Calculate recovery requirement
   const seoulDate = toSeoulDate(currentDate);
   const yesterday = new Date(seoulDate);
   yesterday.setDate(yesterday.getDate() - 1);
   
   const recoveryReq = calculateRecoveryRequirement(yesterday, seoulDate);
+  const baseUpdate = createBaseUpdate(userId, `onStreak → eligible (missed ${recoveryReq.missedDate})`);
   
-  // Return DB update instead of performing it
   return {
-    userId,
+    ...baseUpdate,
     updates: {
+      ...baseUpdate.updates,
       status: {
-        type: 'eligible',
+        type: RecoveryStatusType.ELIGIBLE,
         postsRequired: recoveryReq.postsRequired,
         currentPosts: recoveryReq.currentPosts,
         deadline: recoveryReq.deadline,
         missedDate: recoveryReq.missedDate
-      },
-      lastCalculated: Timestamp.now()
-    },
-    reason: `onStreak → eligible (missed ${recoveryReq.missedDate})`
+      }
+    }
   };
 }
 
 /**
- * 1. onStreak → eligible : at midnight after user missed a working day (LEGACY)
- */
-export async function handleOnStreakToEligible(userId: string, currentDate: Date): Promise<boolean> {
-  const dbUpdate = await calculateOnStreakToEligible(userId, currentDate);
-  
-  if (!dbUpdate) {
-    return false;
-  }
-  
-  await updateStreakInfo(userId, dbUpdate.updates);
-  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
-  return true;
-}
-
-/**
- * 2. eligible → missed : at midnight of recovery deadline without recovery (PURE)
+ * Calculate eligible → missed transition
  */
 export async function calculateEligibleToMissed(userId: string, currentDate: Date): Promise<DBUpdate | null> {
   const { data: streakInfo } = await getOrCreateStreakInfo(userId);
   
-  if (!streakInfo || streakInfo.status.type !== 'eligible') {
+  if (!validateUserState(streakInfo, RecoveryStatusType.ELIGIBLE)) {
     return null;
   }
   
   const seoulDate = toSeoulDate(currentDate);
   const currentDateString = formatDateString(seoulDate);
   
-  // Check if deadline has passed
-  // Note: We use isDateAfter to check if current date is AFTER the deadline
-  // This means posts written ON the deadline day are still valid
-  if (!streakInfo.status.deadline || !isDateAfter(currentDateString, streakInfo.status.deadline)) {
+  if (!streakInfo!.status.deadline || !isDateAfter(currentDateString, streakInfo!.status.deadline)) {
     return null;
   }
   
-  // Return DB update instead of performing it
+  const baseUpdate = createBaseUpdate(userId, `eligible → missed (deadline ${streakInfo!.status.deadline} passed)`);
+  
   return {
-    userId,
+    ...baseUpdate,
     updates: {
+      ...baseUpdate.updates,
       status: {
-        type: 'missed'
-      },
-      lastCalculated: Timestamp.now()
-    },
-    reason: `eligible → missed (deadline ${streakInfo.status.deadline} passed)`
+        type: RecoveryStatusType.MISSED
+      }
+    }
   };
 }
 
 /**
- * 2. eligible → missed : at midnight of recovery deadline without recovery (LEGACY)
- */
-export async function handleEligibleToMissed(userId: string, currentDate: Date): Promise<boolean> {
-  const dbUpdate = await calculateEligibleToMissed(userId, currentDate);
-  
-  if (!dbUpdate) {
-    return false;
-  }
-  
-  await updateStreakInfo(userId, dbUpdate.updates);
-  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
-  return true;
-}
-
-/**
- * 3. eligible → onStreak : when user writes required number of posts (PURE)
+ * Calculate eligible → onStreak transition
  */
 export async function calculateEligibleToOnStreak(userId: string, postDate: Date): Promise<DBUpdate | null> {
   const { data: streakInfo } = await getOrCreateStreakInfo(userId);
   
-  if (!streakInfo || streakInfo.status.type !== 'eligible') {
+  if (!validateUserState(streakInfo, RecoveryStatusType.ELIGIBLE)) {
     return null;
   }
   
-  if (!streakInfo.status.postsRequired) {
+  if (!streakInfo!.status.postsRequired) {
     console.error(`[StateTransition] User ${userId} eligible status missing postsRequired`);
     return null;
   }
   
-  // Count posts written today
   const seoulDate = toSeoulDate(postDate);
   const todayPostCount = await countPostsOnDate(userId, seoulDate);
   
-  // Check if required posts completed
-  if (todayPostCount < streakInfo.status.postsRequired) {
-    // Return progress update
+  // Return progress update if not yet completed
+  if (todayPostCount < streakInfo!.status.postsRequired) {
+    const baseUpdate = createBaseUpdate(userId, `eligible progress updated (${todayPostCount}/${streakInfo!.status.postsRequired})`);
+    
     return {
-      userId,
+      ...baseUpdate,
       updates: {
+        ...baseUpdate.updates,
         status: {
-          ...streakInfo.status,
+          ...streakInfo!.status,
           currentPosts: todayPostCount
-        },
-        lastCalculated: Timestamp.now()
-      },
-      reason: `eligible progress updated (${todayPostCount}/${streakInfo.status.postsRequired})`
+        }
+      }
     };
   }
   
-  // Recovery completed! Return onStreak update with streak calculations
+  // Recovery completed
+  const baseUpdate = createBaseUpdate(userId, `eligible → onStreak (recovery completed with ${todayPostCount} posts)`);
   const baseUpdates = {
+    ...baseUpdate.updates,
     lastContributionDate: formatDateString(seoulDate),
     status: {
-      type: 'onStreak' as const
-    },
-    lastCalculated: Timestamp.now()
+      type: RecoveryStatusType.ON_STREAK
+    }
   };
   
   const updatesWithStreaks = await addStreakCalculations(userId, baseUpdates, true);
   
   return {
-    userId,
-    updates: updatesWithStreaks,
-    reason: `eligible → onStreak (recovery completed with ${todayPostCount} posts)`
+    ...baseUpdate,
+    updates: updatesWithStreaks
   };
 }
 
 /**
- * 3. eligible → onStreak : when user writes required number of posts (LEGACY)
- */
-export async function handleEligibleToOnStreak(userId: string, postDate: Date): Promise<boolean> {
-  const dbUpdate = await calculateEligibleToOnStreak(userId, postDate);
-  
-  if (!dbUpdate) {
-    return false;
-  }
-  
-  await updateStreakInfo(userId, dbUpdate.updates);
-  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
-  
-  // Return true only if fully recovered (not just progress update)
-  return dbUpdate.reason.includes('recovery completed');
-}
-
-/**
- * 4. missed → onStreak : when user writes a post (starts new streak) (PURE)
+ * Calculate missed → onStreak transition
  */
 export async function calculateMissedToOnStreak(userId: string, postDate: Date): Promise<DBUpdate | null> {
   const { data: streakInfo } = await getOrCreateStreakInfo(userId);
   
-  if (!streakInfo || streakInfo.status.type !== 'missed') {
+  if (!validateUserState(streakInfo, RecoveryStatusType.MISSED)) {
     return null;
   }
   
   const seoulDate = toSeoulDate(postDate);
-  
-  // Any post starts a fresh streak with updated streak calculations
+  const baseUpdate = createBaseUpdate(userId, 'missed → onStreak (fresh start)');
   const baseUpdates = {
+    ...baseUpdate.updates,
     lastContributionDate: formatDateString(seoulDate),
     status: {
-      type: 'onStreak' as const
-    },
-    lastCalculated: Timestamp.now()
+      type: RecoveryStatusType.ON_STREAK
+    }
   };
   
   const updatesWithStreaks = await addStreakCalculations(userId, baseUpdates, true);
   
   return {
-    userId,
-    updates: updatesWithStreaks,
-    reason: 'missed → onStreak (fresh start)'
+    ...baseUpdate,
+    updates: updatesWithStreaks
   };
 }
 
 /**
- * 4. missed → onStreak : when user writes a post (starts new streak) (LEGACY)
- */
-export async function handleMissedToOnStreak(userId: string, postDate: Date): Promise<boolean> {
-  const dbUpdate = await calculateMissedToOnStreak(userId, postDate);
-  
-  if (!dbUpdate) {
-    return false;
-  }
-  
-  await updateStreakInfo(userId, dbUpdate.updates);
-  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
-  return true;
-}
-
-/**
- * 5. onStreak → onStreak : when user writes another post while on streak (PURE)
+ * Calculate onStreak → onStreak transition (maintain streak)
  */
 export async function calculateOnStreakToOnStreak(userId: string, postDate: Date): Promise<DBUpdate | null> {
   const { data: streakInfo } = await getOrCreateStreakInfo(userId);
   
-  if (!streakInfo || streakInfo.status.type !== 'onStreak') {
+  if (!validateUserState(streakInfo, RecoveryStatusType.ON_STREAK)) {
     return null;
   }
   
   const seoulDate = toSeoulDate(postDate);
-  
-  // Update lastContributionDate and recalculate streaks
+  const baseUpdate = createBaseUpdate(userId, 'onStreak → onStreak (streak maintained)');
   const baseUpdates = {
+    ...baseUpdate.updates,
     lastContributionDate: formatDateString(seoulDate),
     status: {
-      type: 'onStreak' as const
-    },
-    lastCalculated: Timestamp.now()
+      type: RecoveryStatusType.ON_STREAK
+    }
   };
   
   const updatesWithStreaks = await addStreakCalculations(userId, baseUpdates, true);
   
   return {
-    userId,
-    updates: updatesWithStreaks,
-    reason: 'onStreak → onStreak (streak maintained)'
+    ...baseUpdate,
+    updates: updatesWithStreaks
   };
 }
 
-/**
- * 5. onStreak → onStreak : when user writes another post while on streak (LEGACY)
- */
-export async function handleOnStreakToOnStreak(userId: string, postDate: Date): Promise<boolean> {
-  const dbUpdate = await calculateOnStreakToOnStreak(userId, postDate);
-  
-  if (!dbUpdate) {
-    return false;
-  }
-  
-  await updateStreakInfo(userId, dbUpdate.updates);
-  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
-  return true;
-}
+// ===== ORCHESTRATOR FUNCTIONS =====
 
 /**
- * Calculate streak updates for midnight recalculation (PURE)
+ * Calculate all possible posting transitions using switch statement
  */
-export async function calculateMidnightStreakUpdate(userId: string, _currentDate: Date): Promise<DBUpdate | null> {
+export async function calculatePostingTransitions(userId: string, postDate: Date): Promise<DBUpdate | null> {
   try {
     const { data: streakInfo } = await getOrCreateStreakInfo(userId);
     
@@ -332,62 +204,63 @@ export async function calculateMidnightStreakUpdate(userId: string, _currentDate
       return null;
     }
     
-    // Calculate updated streaks
-    const streakData = await calculateUserStreaks(userId);
-    
-    // Only create update if streaks have changed
-    if (streakData.currentStreak !== streakInfo.currentStreak || 
-        streakData.longestStreak !== streakInfo.longestStreak) {
-      
-      return {
-        userId,
-        updates: {
-          currentStreak: streakData.currentStreak,
-          longestStreak: streakData.longestStreak,
-          ...(streakData.lastContributionDate && {
-            lastContributionDate: streakData.lastContributionDate
-          }),
-          lastCalculated: Timestamp.now()
-        },
-        reason: `midnight streak update (current: ${streakData.currentStreak}, longest: ${streakData.longestStreak})`
-      };
+    switch (streakInfo.status.type) {
+      case RecoveryStatusType.ELIGIBLE:
+        return await calculateEligibleToOnStreak(userId, postDate);
+        
+      case RecoveryStatusType.MISSED:
+        return await calculateMissedToOnStreak(userId, postDate);
+        
+      case RecoveryStatusType.ON_STREAK:
+        return await calculateOnStreakToOnStreak(userId, postDate);
+        
+      default:
+        console.warn(`[StateTransition] Unknown status type: ${streakInfo.status.type}`);
+        return null;
     }
-    
-    return null;
-    
   } catch (error) {
-    console.error(`[StreakCalculation] Error calculating midnight streaks for user ${userId}:`, error);
-    return null;
+    console.error(`[StateTransition] Error calculating posting transitions for user ${userId}:`, error);
+    throw error;
   }
 }
 
 /**
- * Calculate all state transitions for midnight update (PURE)
+ * Calculate all possible midnight transitions using switch statement
  */
 export async function calculateMidnightTransitions(userId: string, currentDate: Date): Promise<DBUpdate | null> {
   try {
-    // Try onStreak → eligible first
-    const eligibleUpdate = await calculateOnStreakToEligible(userId, currentDate);
+    const { data: streakInfo } = await getOrCreateStreakInfo(userId);
     
-    if (eligibleUpdate) {
-      // Add streak calculations to the status transition
-      const updatesWithStreaks = await addStreakCalculations(userId, eligibleUpdate.updates);
-      return {
-        ...eligibleUpdate,
-        updates: updatesWithStreaks
-      };
+    if (!streakInfo) {
+      return null;
     }
     
-    // If not transitioned to eligible, check eligible → missed
-    const missedUpdate = await calculateEligibleToMissed(userId, currentDate);
-    
-    if (missedUpdate) {
-      // Add streak calculations to the status transition
-      const updatesWithStreaks = await addStreakCalculations(userId, missedUpdate.updates);
-      return {
-        ...missedUpdate,
-        updates: updatesWithStreaks
-      };
+    switch (streakInfo.status.type) {
+      case RecoveryStatusType.ON_STREAK: {
+        const eligibleUpdate = await calculateOnStreakToEligible(userId, currentDate);
+        if (eligibleUpdate) {
+          const updatesWithStreaks = await addStreakCalculations(userId, eligibleUpdate.updates);
+          return { ...eligibleUpdate, updates: updatesWithStreaks };
+        }
+        break;
+      }
+      
+      case RecoveryStatusType.ELIGIBLE: {
+        const missedUpdate = await calculateEligibleToMissed(userId, currentDate);
+        if (missedUpdate) {
+          const updatesWithStreaks = await addStreakCalculations(userId, missedUpdate.updates);
+          return { ...missedUpdate, updates: updatesWithStreaks };
+        }
+        break;
+      }
+      
+      case RecoveryStatusType.MISSED:
+        // No automatic transitions from missed state at midnight
+        break;
+        
+      default:
+        console.warn(`[StateTransition] Unknown status type: ${streakInfo.status.type}`);
+        return null;
     }
     
     // If no status transitions, check if streak updates are needed
@@ -400,79 +273,122 @@ export async function calculateMidnightTransitions(userId: string, currentDate: 
 }
 
 /**
- * Process all state transitions for midnight update (LEGACY)
+ * Calculate streak updates for midnight recalculation
  */
+async function calculateMidnightStreakUpdate(userId: string, _currentDate: Date): Promise<DBUpdate | null> {
+  try {
+    const { data: streakInfo } = await getOrCreateStreakInfo(userId);
+    
+    if (!streakInfo) {
+      return null;
+    }
+    
+    const streakData = await calculateUserStreaks(userId);
+    
+    // Only create update if streaks have changed
+    if (streakData.currentStreak !== streakInfo.currentStreak || 
+        streakData.longestStreak !== streakInfo.longestStreak) {
+      
+      const baseUpdate = createBaseUpdate(userId, `midnight streak update (current: ${streakData.currentStreak}, longest: ${streakData.longestStreak})`);
+      
+      return {
+        ...baseUpdate,
+        updates: {
+          ...baseUpdate.updates,
+          currentStreak: streakData.currentStreak,
+          longestStreak: streakData.longestStreak,
+          ...(streakData.lastContributionDate && {
+            lastContributionDate: streakData.lastContributionDate
+          })
+        }
+      };
+    }
+    
+    return null;
+    
+  } catch (error) {
+    console.error(`[StreakCalculation] Error calculating midnight streaks for user ${userId}:`, error);
+    return null;
+  }
+}
+
+// ===== LEGACY WRAPPER FUNCTIONS =====
+
+export async function handleOnStreakToEligible(userId: string, currentDate: Date): Promise<boolean> {
+  const dbUpdate = await calculateOnStreakToEligible(userId, currentDate);
+  if (!dbUpdate) return false;
+  
+  await updateStreakInfo(userId, dbUpdate.updates);
+  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
+  return true;
+}
+
+export async function handleEligibleToMissed(userId: string, currentDate: Date): Promise<boolean> {
+  const dbUpdate = await calculateEligibleToMissed(userId, currentDate);
+  if (!dbUpdate) return false;
+  
+  await updateStreakInfo(userId, dbUpdate.updates);
+  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
+  return true;
+}
+
+export async function handleEligibleToOnStreak(userId: string, postDate: Date): Promise<boolean> {
+  const dbUpdate = await calculateEligibleToOnStreak(userId, postDate);
+  if (!dbUpdate) return false;
+  
+  await updateStreakInfo(userId, dbUpdate.updates);
+  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
+  
+  return dbUpdate.reason.includes('recovery completed');
+}
+
+export async function handleMissedToOnStreak(userId: string, postDate: Date): Promise<boolean> {
+  const dbUpdate = await calculateMissedToOnStreak(userId, postDate);
+  if (!dbUpdate) return false;
+  
+  await updateStreakInfo(userId, dbUpdate.updates);
+  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
+  return true;
+}
+
+export async function handleOnStreakToOnStreak(userId: string, postDate: Date): Promise<boolean> {
+  const dbUpdate = await calculateOnStreakToOnStreak(userId, postDate);
+  if (!dbUpdate) return false;
+  
+  await updateStreakInfo(userId, dbUpdate.updates);
+  console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
+  return true;
+}
+
 export async function processMidnightTransitions(userId: string, currentDate: Date): Promise<void> {
   try {
-    // Try onStreak → eligible first
     const transitionedToEligible = await handleOnStreakToEligible(userId, currentDate);
     
     if (!transitionedToEligible) {
-      // If not transitioned to eligible, check eligible → missed
       await handleEligibleToMissed(userId, currentDate);
     }
-    
   } catch (error) {
     console.error(`[StateTransition] Error processing midnight transitions for user ${userId}:`, error);
     throw error;
   }
 }
 
-/**
- * Calculate all state transitions for posting creation (PURE)
- */
-export async function calculatePostingTransitions(userId: string, postDate: Date): Promise<DBUpdate | null> {
-  try {
-    // Try eligible → onStreak first
-    const eligibleUpdate = await calculateEligibleToOnStreak(userId, postDate);
-    
-    if (eligibleUpdate) {
-      return eligibleUpdate;
-    }
-    
-    // If not in eligible state, check missed → onStreak
-    const missedUpdate = await calculateMissedToOnStreak(userId, postDate);
-    
-    if (missedUpdate) {
-      return missedUpdate;
-    }
-    
-    // If not in missed state, check onStreak → onStreak (maintain streak)
-    const onStreakUpdate = await calculateOnStreakToOnStreak(userId, postDate);
-    
-    return onStreakUpdate;
-    
-  } catch (error) {
-    console.error(`[StateTransition] Error calculating posting transitions for user ${userId}:`, error);
-    throw error;
-  }
-}
-
-/**
- * Process state transitions triggered by posting creation (LEGACY)
- */
 export async function processPostingTransitions(userId: string, postDate: Date): Promise<void> {
   try {
-    // Try eligible → onStreak first
-    const recoveryCompleted = await handleEligibleToOnStreak(userId, postDate);
+    const dbUpdate = await calculatePostingTransitions(userId, postDate);
     
-    if (!recoveryCompleted) {
-      // If not in eligible state, check missed → onStreak  
-      const freshStart = await handleMissedToOnStreak(userId, postDate);
-      
-      if (!freshStart) {
-        // If not in missed state, check onStreak → onStreak (maintain streak)
-        await handleOnStreakToOnStreak(userId, postDate);
-      }
+    if (dbUpdate) {
+      await updateStreakInfo(userId, dbUpdate.updates);
+      console.log(`[StateTransition] User ${userId}: ${dbUpdate.reason}`);
     }
-    
   } catch (error) {
     console.error(`[StateTransition] Error processing posting transitions for user ${userId}:`, error);
     throw error;
   }
 }
 
-// Re-export batch processing types and interfaces for convenience
+// ===== BATCH PROCESSING UTILITIES =====
+
 export interface BatchProcessingResult {
   updates: DBUpdate[];
   processedCount: number;
@@ -484,9 +400,6 @@ export interface UserTransitionResult {
   update: DBUpdate | null;
 }
 
-/**
- * Pure function to process a single user's transition with error wrapping
- */
 export async function processUserTransitionSafe<T extends Date>(
   userId: string, 
   date: T,
@@ -500,9 +413,6 @@ export async function processUserTransitionSafe<T extends Date>(
   }
 }
 
-/**
- * Pure function to collect results from Promise.allSettled for any transition type
- */
 export function collectTransitionResults(results: PromiseSettledResult<UserTransitionResult>[]): BatchProcessingResult {
   const updates: DBUpdate[] = [];
   let processedCount = 0;
@@ -522,3 +432,6 @@ export function collectTransitionResults(results: PromiseSettledResult<UserTrans
 
   return { updates, processedCount, errorCount };
 }
+
+// Re-export the missing function that may be needed elsewhere
+import { calculateUserStreaks } from "./streakCalculations";

--- a/functions/src/recoveryStatus/streakUtils.ts
+++ b/functions/src/recoveryStatus/streakUtils.ts
@@ -1,7 +1,7 @@
 import { Timestamp } from "firebase-admin/firestore";
 import admin from "../shared/admin";
 import { toSeoulDate, isWorkingDay } from "../shared/dateUtils";
-import { RecoveryRequirement, StreakInfo } from "./StreakInfo";
+import { RecoveryRequirement, StreakInfo, RecoveryStatusType } from "./StreakInfo";
 
 /**
  * Format date to YYYY-MM-DD string
@@ -184,7 +184,7 @@ export async function getOrCreateStreakInfo(userId: string): Promise<{ doc: Fire
       lastContributionDate: formatDateString(new Date()),
       lastCalculated: Timestamp.now(),
       status: {
-        type: 'onStreak'
+        type: RecoveryStatusType.ON_STREAK
       },
       currentStreak: 0,
       longestStreak: 0

--- a/functions/src/recoveryStatus/transitionHelpers.ts
+++ b/functions/src/recoveryStatus/transitionHelpers.ts
@@ -1,0 +1,75 @@
+import { Timestamp } from "firebase-admin/firestore";
+import { StreakInfo, RecoveryStatusType } from "./StreakInfo";
+import { calculateUserStreaks, calculateStreaksAfterNewPosting } from "./streakCalculations";
+import { getOrCreateStreakInfo } from "./streakUtils";
+
+export interface DBUpdate {
+  userId: string;
+  updates: Partial<StreakInfo> & { lastCalculated: Timestamp };
+  reason: string;
+}
+
+/**
+ * Helper function to add streak calculations to DB updates
+ */
+export async function addStreakCalculations(
+  userId: string, 
+  baseUpdates: Partial<StreakInfo> & { lastCalculated: Timestamp },
+  isNewPosting = false
+): Promise<Partial<StreakInfo> & { lastCalculated: Timestamp }> {
+  try {
+    const { data: currentStreakInfo } = await getOrCreateStreakInfo(userId);
+    
+    let streakData;
+    if (isNewPosting && currentStreakInfo) {
+      // Optimized calculation for new postings
+      streakData = await calculateStreaksAfterNewPosting(
+        userId,
+        currentStreakInfo.currentStreak || 0,
+        currentStreakInfo.longestStreak || 0
+      );
+    } else {
+      // Full recalculation
+      streakData = await calculateUserStreaks(userId);
+    }
+    
+    return {
+      ...baseUpdates,
+      currentStreak: streakData.currentStreak,
+      longestStreak: streakData.longestStreak,
+      ...(streakData.lastContributionDate && {
+        lastContributionDate: streakData.lastContributionDate
+      })
+    };
+  } catch (error) {
+    console.error(`[StreakCalculation] Error calculating streaks for user ${userId}:`, error);
+    // Return base updates without streak data if calculation fails
+    return baseUpdates;
+  }
+}
+
+/**
+ * Helper to validate user is in expected state
+ */
+export function validateUserState(
+  streakInfo: StreakInfo | null, 
+  expectedState: RecoveryStatusType
+): boolean {
+  return streakInfo?.status.type === expectedState;
+}
+
+/**
+ * Helper to create base status update
+ */
+export function createBaseUpdate(
+  userId: string,
+  reason: string
+): Pick<DBUpdate, 'userId' | 'reason'> & { updates: { lastCalculated: Timestamp } } {
+  return {
+    userId,
+    reason,
+    updates: {
+      lastCalculated: Timestamp.now()
+    }
+  };
+}


### PR DESCRIPTION
- onStreak에서 onStreak로 갈 때 연속 일수와 상태가 업데이트되지 않고 있었음
- 유닛 테스트 추가
- 리팩토링