### PR TITLE
원래 streak를 저장해두었다가 복구할 때 더하는 기능 추가

### DIFF
--- a/functions/src/recoveryStatus/StreakInfo.ts
+++ b/functions/src/recoveryStatus/StreakInfo.ts
@@ -18,6 +18,7 @@ export interface RecoveryStatus {
   currentPosts?: number;     // Only for 'eligible' status  
   deadline?: string;         // Only for 'eligible' status (YYYY-MM-DD format)
   missedDate?: string;       // Only for 'eligible' status (YYYY-MM-DD format)
+  originalStreak?: number;   // Only for 'eligible' status - stores the pre-miss streak value
 }
 
 /**


### PR DESCRIPTION
- onStreak 상태로만 바꾸고, 원래 streak가 살지 않고 있었음.