### PR TITLE
잔디 그래프 버그 수정 및 테스트 추가

### DIFF
--- a/src/stats/components/ContributionGraph.tsx
+++ b/src/stats/components/ContributionGraph.tsx
@@ -1,82 +1,42 @@
-import { useMemo } from "react"
-import { cn } from "@/shared/utils/cn"
-import { ContributionItem } from "@/stats/components/ContributionItem"
-import { Contribution } from "@/stats/model/WritingStats"
-import { CommentingContribution } from '@/stats/utils/commentingContributionUtils'
+import { useMemo } from 'react';
+import { cn } from '@/shared/utils/cn';
+import { ContributionItem } from '@/stats/components/ContributionItem';
+import { Contribution } from '@/stats/model/WritingStats';
+import { CommentingContribution } from '@/stats/utils/commentingContributionUtils';
 import {
-  createEmptyMatrices,
-  getTimeRange,
-  filterContributionsInTimeRange,
-  placeContributionInGrid,
+  processPostingContributions,
+  processCommentingContributions,
   WEEKS_TO_DISPLAY,
-  type GridResult
-} from '@/stats/utils/contributionGridUtils'
-
-// Type-specific contribution handlers
-function processPostingContributions(contributions: Contribution[]): GridResult {
-  const matrices = createEmptyMatrices()
-  const { weeksAgo, today } = getTimeRange()
-  
-  const recentContributions = filterContributionsInTimeRange(contributions, weeksAgo, today)
-  
-  recentContributions.forEach(contribution => {
-    placeContributionInGrid(
-      contribution,
-      (c) => (c as Contribution).contentLength ?? 0,
-      matrices,
-      weeksAgo
-    )
-  })
-  
-  const maxValue = Math.max(...contributions.map(c => c.contentLength ?? 0), 0)
-  
-  return {
-    matrix: matrices.matrix,
-    weeklyContributions: matrices.weeklyContributions,
-    maxValue
-  }
-}
-
-function processCommentingContributions(contributions: CommentingContribution[]): GridResult {
-  const matrices = createEmptyMatrices()
-  const { weeksAgo, today } = getTimeRange()
-  
-  const recentContributions = filterContributionsInTimeRange(contributions, weeksAgo, today)
-  
-  recentContributions.forEach(contribution => {
-    placeContributionInGrid(
-      contribution,
-      (c) => (c as CommentingContribution).countOfCommentAndReplies ?? 0,
-      matrices,
-      weeksAgo
-    )
-  })
-  
-  const maxValue = Math.max(...contributions.map(c => c.countOfCommentAndReplies ?? 0), 0)
-  
-  return {
-    matrix: matrices.matrix,
-    weeklyContributions: matrices.weeklyContributions,
-    maxValue
-  }
-}
+} from '@/stats/utils/contributionGridUtils';
 
 // Main component props
 export type ContributionGraphProps =
-  | { type: 'posting'; contributions: Contribution[]; className?: string }
-  | { type: 'commenting'; contributions: CommentingContribution[]; className?: string }
+  | { type: 'posting'; contributions: Contribution[]; className?: string; userId?: string }
+  | {
+      type: 'commenting';
+      contributions: CommentingContribution[];
+      className?: string;
+    };
 
 export function ContributionGraph(props: ContributionGraphProps) {
-  const { matrix, maxValue, weeklyContributions } = useMemo(() => {
+  // Use useMemo to prevent unnecessary recalculations
+  const result = useMemo(() => {
     return props.type === 'posting'
       ? processPostingContributions(props.contributions as Contribution[])
-      : processCommentingContributions(props.contributions as CommentingContribution[])
-  }, [props])
+      : processCommentingContributions(props.contributions as CommentingContribution[]);
+  }, [props.type, props.contributions]);
+
+  const { matrix, maxValue, weeklyContributions } = result;
 
   return (
-    <div className={cn(`w-full grid grid-rows-${WEEKS_TO_DISPLAY} grid-flow-col gap-1`, props.className)}>
+    <div
+      className={cn(
+        `w-full grid grid-rows-${WEEKS_TO_DISPLAY} grid-flow-col gap-1`,
+        props.className,
+      )}
+    >
       {matrix.map((row, rowIndex) => (
-        <div key={rowIndex} className="flex gap-1">
+        <div key={rowIndex} className='flex gap-1'>
           {row.map((value, colIndex) => {
             // Get contribution data from the weekly contributions matrix
             const contribution = weeklyContributions[rowIndex][colIndex] || undefined;

--- a/src/stats/components/ContributionGraph.tsx
+++ b/src/stats/components/ContributionGraph.tsx
@@ -3,106 +3,75 @@ import { cn } from "@/shared/utils/cn"
 import { ContributionItem } from "@/stats/components/ContributionItem"
 import { Contribution } from "@/stats/model/WritingStats"
 import { CommentingContribution } from '@/stats/utils/commentingContributionUtils'
+import {
+  createEmptyMatrices,
+  getTimeRange,
+  filterContributionsInTimeRange,
+  placeContributionInGrid,
+  WEEKS_TO_DISPLAY,
+  type GridResult
+} from '@/stats/utils/contributionGridUtils'
 
-// Constants for grid layout
-const WEEKS_TO_DISPLAY = 4
-const WEEKDAYS_COUNT = 5
-const DAYS_PER_WEEK = 7
-const SUNDAY = 0
-const SATURDAY = 6
-const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24
-
-// Helper function to filter contributions within time range
-function filterContributionsInTimeRange<T extends { createdAt: any }>(
-  contributions: T[],
-  startDate: Date,
-  endDate: Date
-): T[] {
-  return contributions.filter(c => {
-    const contributionDate = new Date(c.createdAt);
-    return contributionDate >= startDate && contributionDate <= endDate;
-  });
+// Type-specific contribution handlers
+function processPostingContributions(contributions: Contribution[]): GridResult {
+  const matrices = createEmptyMatrices()
+  const { weeksAgo, today } = getTimeRange()
+  
+  const recentContributions = filterContributionsInTimeRange(contributions, weeksAgo, today)
+  
+  recentContributions.forEach(contribution => {
+    placeContributionInGrid(
+      contribution,
+      (c) => (c as Contribution).contentLength ?? 0,
+      matrices,
+      weeksAgo
+    )
+  })
+  
+  const maxValue = Math.max(...contributions.map(c => c.contentLength ?? 0), 0)
+  
+  return {
+    matrix: matrices.matrix,
+    weeklyContributions: matrices.weeklyContributions,
+    maxValue
+  }
 }
 
-// 도메인별 union props
+function processCommentingContributions(contributions: CommentingContribution[]): GridResult {
+  const matrices = createEmptyMatrices()
+  const { weeksAgo, today } = getTimeRange()
+  
+  const recentContributions = filterContributionsInTimeRange(contributions, weeksAgo, today)
+  
+  recentContributions.forEach(contribution => {
+    placeContributionInGrid(
+      contribution,
+      (c) => (c as CommentingContribution).countOfCommentAndReplies ?? 0,
+      matrices,
+      weeksAgo
+    )
+  })
+  
+  const maxValue = Math.max(...contributions.map(c => c.countOfCommentAndReplies ?? 0), 0)
+  
+  return {
+    matrix: matrices.matrix,
+    weeklyContributions: matrices.weeklyContributions,
+    maxValue
+  }
+}
+
+// Main component props
 export type ContributionGraphProps =
   | { type: 'posting'; contributions: Contribution[]; className?: string }
   | { type: 'commenting'; contributions: CommentingContribution[]; className?: string }
 
 export function ContributionGraph(props: ContributionGraphProps) {
   const { matrix, maxValue, weeklyContributions } = useMemo(() => {
-    // Create grid matrix: weeks (rows) x weekdays (columns: Mon-Fri)
-    const matrix: (number | null)[][] = Array.from({ length: WEEKS_TO_DISPLAY }, () => Array(WEEKDAYS_COUNT).fill(null));
-    // Create matching matrix to store contribution data for each cell
-    const weeklyContributions: (Contribution | CommentingContribution | null)[][] = Array.from({ length: WEEKS_TO_DISPLAY }, () => Array(WEEKDAYS_COUNT).fill(null));
-    
-    if (props.type === 'posting') {
-      const contributions = props.contributions as Contribution[];
-      
-      // Calculate weeks ago from today to define our time range
-      const today = new Date();
-      const weeksAgo = new Date(today);
-      weeksAgo.setDate(today.getDate() - (WEEKS_TO_DISPLAY * DAYS_PER_WEEK - 1));
-      
-      // Filter contributions within the last weeks
-      const recentContributions = filterContributionsInTimeRange(contributions, weeksAgo, today);
-      
-      // Place each contribution in the correct week/weekday position
-      recentContributions.forEach(contribution => {
-        const date = new Date(contribution.createdAt);
-        const dayOfWeek = date.getDay(); // 0=Sunday, 1=Monday, ..., 6=Saturday
-        
-        // Skip weekends (Sunday and Saturday)
-        if (dayOfWeek === SUNDAY || dayOfWeek === SATURDAY) return;
-        
-        // Convert to Monday=0, Tuesday=1, ..., Friday=4
-        const weekdayColumn = dayOfWeek - 1;
-        
-        // Calculate which week this contribution belongs to (0=oldest week, newest=WEEKS_TO_DISPLAY-1)
-        const daysDifference = Math.floor((date.getTime() - weeksAgo.getTime()) / MILLISECONDS_PER_DAY);
-        const weekRow = Math.floor(daysDifference / DAYS_PER_WEEK);
-        
-        // Ensure we're within bounds
-        if (weekRow >= 0 && weekRow < WEEKS_TO_DISPLAY && weekdayColumn >= 0 && weekdayColumn < WEEKDAYS_COUNT) {
-          matrix[weekRow][weekdayColumn] = contribution.contentLength;
-          weeklyContributions[weekRow][weekdayColumn] = contribution;
-        }
-      });
-      
-      // Find maximum value for intensity calculation
-      const maxValue = Math.max(...contributions.map(c => c.contentLength ?? 0), 0);
-      return { matrix, maxValue, weeklyContributions };
-      
-    } else {
-      // Handle commenting contributions with same weekly logic
-      const contributions = props.contributions as CommentingContribution[];
-      
-      const today = new Date();
-      const weeksAgo = new Date(today);
-      weeksAgo.setDate(today.getDate() - (WEEKS_TO_DISPLAY * DAYS_PER_WEEK - 1));
-      
-      const recentContributions = filterContributionsInTimeRange(contributions, weeksAgo, today);
-      
-      recentContributions.forEach(contribution => {
-        const date = new Date(contribution.createdAt);
-        const dayOfWeek = date.getDay();
-        
-        if (dayOfWeek === SUNDAY || dayOfWeek === SATURDAY) return;
-        
-        const weekdayColumn = dayOfWeek - 1;
-        const daysDifference = Math.floor((date.getTime() - weeksAgo.getTime()) / MILLISECONDS_PER_DAY);
-        const weekRow = Math.floor(daysDifference / DAYS_PER_WEEK);
-        
-        if (weekRow >= 0 && weekRow < WEEKS_TO_DISPLAY && weekdayColumn >= 0 && weekdayColumn < WEEKDAYS_COUNT) {
-          matrix[weekRow][weekdayColumn] = contribution.countOfCommentAndReplies;
-          weeklyContributions[weekRow][weekdayColumn] = contribution;
-        }
-      });
-      
-      const maxValue = Math.max(...contributions.map(c => c.countOfCommentAndReplies ?? 0), 0);
-      return { matrix, maxValue, weeklyContributions };
-    }
-  }, [props]);
+    return props.type === 'posting'
+      ? processPostingContributions(props.contributions as Contribution[])
+      : processCommentingContributions(props.contributions as CommentingContribution[])
+  }, [props])
 
   return (
     <div className={cn(`w-full grid grid-rows-${WEEKS_TO_DISPLAY} grid-flow-col gap-1`, props.className)}>

--- a/src/stats/components/UserCommentStatsCard.tsx
+++ b/src/stats/components/UserCommentStatsCard.tsx
@@ -1,44 +1,40 @@
-import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar'
-import { Card, CardContent } from '@/shared/ui/card'
-import { UserCommentingStats } from "@/stats/hooks/useCommentingStats"
-import { ContributionGraph } from "./ContributionGraph"
+import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
+import { Card, CardContent } from '@/shared/ui/card';
+import { UserCommentingStats } from '@/stats/hooks/useCommentingStats';
+import { ContributionGraph } from './ContributionGraph';
 
 interface UserCommentStatsCardProps {
-  stats: UserCommentingStats
-  onClick?: () => void
+  stats: UserCommentingStats;
+  onClick?: () => void;
 }
 
 export function UserCommentStatsCard({ stats, onClick }: UserCommentStatsCardProps) {
-    const { user, contributions } = stats
+  const { user, contributions } = stats;
 
-    return (
-      <Card className="w-full reading-shadow border-border/50">
-        <CardContent
-          className="flex items-start gap-4 px-3 md:px-4 py-4 cursor-pointer reading-hover reading-focus active:scale-[0.99] transition-all duration-200"
-          onClick={onClick}
-          role={onClick ? 'button' : undefined}
-          tabIndex={onClick ? 0 : undefined}
-        >
-          <div className="flex flex-1 items-start gap-4">
-            <Avatar className="size-12 shrink-0">
-              <AvatarImage src={user.profilePhotoURL || undefined} alt={user.nickname || "User"} />
-              <AvatarFallback>{user.nickname?.[0] || user.realname?.[0] || "U"}</AvatarFallback>
-            </Avatar>
-            <div className="flex min-w-0 flex-col gap-1.5">
-              <h3 className="truncate font-medium text-foreground">
-                {user.nickname || user.realname || "Anonymous"}
-              </h3>
-              {/* bio 등 추가 정보 필요시 여기에 */}
-            </div>
+  return (
+    <Card className='w-full reading-shadow border-border/50'>
+      <CardContent
+        className='flex items-start gap-4 px-3 md:px-4 py-4 cursor-pointer reading-hover reading-focus active:scale-[0.99] transition-all duration-200'
+        onClick={onClick}
+        role={onClick ? 'button' : undefined}
+        tabIndex={onClick ? 0 : undefined}
+      >
+        <div className='flex flex-1 items-start gap-4'>
+          <Avatar className='size-12 shrink-0'>
+            <AvatarImage src={user.profilePhotoURL || undefined} alt={user.nickname || 'User'} />
+            <AvatarFallback>{user.nickname?.[0] || user.realname?.[0] || 'U'}</AvatarFallback>
+          </Avatar>
+          <div className='flex min-w-0 flex-col gap-1.5'>
+            <h3 className='truncate font-medium text-foreground'>
+              {user.nickname || user.realname || 'Anonymous'}
+            </h3>
+            {/* bio 등 추가 정보 필요시 여기에 */}
           </div>
-          <div className="flex shrink-0 flex-col items-end gap-2">
-            <ContributionGraph 
-              type="commenting"
-              contributions={contributions} 
-              className="w-24"
-            />
-          </div>
-        </CardContent>
-      </Card>
-    )
-  } 
+        </div>
+        <div className='flex shrink-0 flex-col items-end gap-2'>
+          <ContributionGraph type='commenting' contributions={contributions} className='w-24' />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/stats/utils/contributionGridUtils.ts
+++ b/src/stats/utils/contributionGridUtils.ts
@@ -3,7 +3,7 @@ import { CommentingContribution } from '@/stats/utils/commentingContributionUtil
 
 // Constants for grid layout
 const WEEKS_TO_DISPLAY = 4
-const WEEKDAYS_COUNT = 5
+const WEEKDAYS_COUNT = 5  // Mon-Fri only
 const DAYS_PER_WEEK = 7
 const SUNDAY = 0
 const SATURDAY = 6
@@ -33,10 +33,25 @@ export function createEmptyMatrices(): { matrix: ContributionMatrix; weeklyContr
 }
 
 export function getTimeRange(): { weeksAgo: Date; today: Date } {
+  // Normalize today to start of day (00:00:00)
   const today = new Date()
-  const weeksAgo = new Date(today)
-  weeksAgo.setDate(today.getDate() - (WEEKS_TO_DISPLAY * DAYS_PER_WEEK - 1))
-  return { weeksAgo, today }
+  today.setHours(0, 0, 0, 0)
+  
+  // Calculate the Monday of the week that's WEEKS_TO_DISPLAY weeks ago
+  const daysAgo = WEEKS_TO_DISPLAY * DAYS_PER_WEEK - 1
+  const startDate = new Date(today)
+  startDate.setDate(today.getDate() - daysAgo)
+  
+  // Find the Monday of that week
+  const dayOfWeek = startDate.getDay()
+  const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1  // Sunday=0 needs 6 days back, others dayOfWeek-1
+  const mondayStart = new Date(startDate)
+  mondayStart.setDate(startDate.getDate() - daysToMonday)
+  
+  // Normalize to start of day (00:00:00)
+  mondayStart.setHours(0, 0, 0, 0)
+  
+  return { weeksAgo: mondayStart, today }
 }
 
 export function filterContributionsInTimeRange<T extends { createdAt: any }>(
@@ -51,14 +66,16 @@ export function filterContributionsInTimeRange<T extends { createdAt: any }>(
 }
 
 export function calculateGridPosition(date: Date, weeksAgo: Date): GridPosition | null {
-  const dayOfWeek = date.getDay()
+  const dayOfWeek = date.getDay() // 0=Sunday, 1=Monday, ..., 6=Saturday
   
   // Skip weekends
   if (dayOfWeek === SUNDAY || dayOfWeek === SATURDAY) {
     return null
   }
   
-  const weekdayColumn = dayOfWeek - 1 // Convert to Monday=0, Tuesday=1, ..., Friday=4
+  // Convert to Monday=0, Tuesday=1, Wednesday=2, Thursday=3, Friday=4
+  const weekdayColumn = dayOfWeek - 1
+  
   const daysDifference = Math.floor((date.getTime() - weeksAgo.getTime()) / MILLISECONDS_PER_DAY)
   const weekRow = Math.floor(daysDifference / DAYS_PER_WEEK)
   
@@ -77,12 +94,76 @@ export function placeContributionInGrid(
   weeksAgo: Date
 ): void {
   const date = new Date(contribution.createdAt)
+  // Normalize to start of day for consistent calculations
+  date.setHours(0, 0, 0, 0)
+  
   const position = calculateGridPosition(date, weeksAgo)
   
   if (position) {
     const { weekRow, weekdayColumn } = position
     matrices.matrix[weekRow][weekdayColumn] = getValue(contribution)
     matrices.weeklyContributions[weekRow][weekdayColumn] = contribution
+  }
+}
+
+// Type-specific contribution processing functions
+export function processPostingContributions(contributions: Contribution[]): GridResult {
+  const matrices = createEmptyMatrices()
+  const { weeksAgo, today } = getTimeRange()
+
+  const recentContributions = filterContributionsInTimeRange(contributions, weeksAgo, today)
+
+  recentContributions.forEach((contribution) => {
+    placeContributionInGrid(
+      contribution,
+      (c) => (c as Contribution).contentLength ?? 0,
+      matrices,
+      weeksAgo
+    )
+  })
+
+  // Calculate maxValue only from contributions that actually get placed (weekdays only)
+  const weekdayContributions = recentContributions.filter(c => {
+    const date = new Date(c.createdAt)
+    const dayOfWeek = date.getDay()
+    return dayOfWeek !== 0 && dayOfWeek !== 6 // Exclude weekends
+  })
+  const maxValue = Math.max(...weekdayContributions.map((c) => c.contentLength ?? 0), 0)
+
+  return {
+    matrix: matrices.matrix,
+    weeklyContributions: matrices.weeklyContributions,
+    maxValue
+  }
+}
+
+export function processCommentingContributions(contributions: CommentingContribution[]): GridResult {
+  const matrices = createEmptyMatrices()
+  const { weeksAgo, today } = getTimeRange()
+
+  const recentContributions = filterContributionsInTimeRange(contributions, weeksAgo, today)
+
+  recentContributions.forEach((contribution) => {
+    placeContributionInGrid(
+      contribution,
+      (c) => (c as CommentingContribution).countOfCommentAndReplies ?? 0,
+      matrices,
+      weeksAgo
+    )
+  })
+
+  // Calculate maxValue only from contributions that actually get placed (weekdays only)
+  const weekdayContributions = recentContributions.filter(c => {
+    const date = new Date(c.createdAt)
+    const dayOfWeek = date.getDay()
+    return dayOfWeek !== 0 && dayOfWeek !== 6 // Exclude weekends
+  })
+  const maxValue = Math.max(...weekdayContributions.map((c) => c.countOfCommentAndReplies ?? 0), 0)
+
+  return {
+    matrix: matrices.matrix,
+    weeklyContributions: matrices.weeklyContributions,
+    maxValue
   }
 }
 

--- a/src/stats/utils/contributionGridUtils.ts
+++ b/src/stats/utils/contributionGridUtils.ts
@@ -1,0 +1,90 @@
+import { Contribution } from "@/stats/model/WritingStats"
+import { CommentingContribution } from '@/stats/utils/commentingContributionUtils'
+
+// Constants for grid layout
+const WEEKS_TO_DISPLAY = 4
+const WEEKDAYS_COUNT = 5
+const DAYS_PER_WEEK = 7
+const SUNDAY = 0
+const SATURDAY = 6
+const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24
+
+export type ContributionData = Contribution | CommentingContribution
+export type ContributionMatrix = (number | null)[][]
+export type ContributionDataMatrix = (ContributionData | null)[][]
+
+export interface GridPosition {
+  weekRow: number
+  weekdayColumn: number
+}
+
+export interface GridResult {
+  matrix: ContributionMatrix
+  weeklyContributions: ContributionDataMatrix
+  maxValue: number
+}
+
+// Grid calculation utilities
+export function createEmptyMatrices(): { matrix: ContributionMatrix; weeklyContributions: ContributionDataMatrix } {
+  return {
+    matrix: Array.from({ length: WEEKS_TO_DISPLAY }, () => Array(WEEKDAYS_COUNT).fill(null)),
+    weeklyContributions: Array.from({ length: WEEKS_TO_DISPLAY }, () => Array(WEEKDAYS_COUNT).fill(null))
+  }
+}
+
+export function getTimeRange(): { weeksAgo: Date; today: Date } {
+  const today = new Date()
+  const weeksAgo = new Date(today)
+  weeksAgo.setDate(today.getDate() - (WEEKS_TO_DISPLAY * DAYS_PER_WEEK - 1))
+  return { weeksAgo, today }
+}
+
+export function filterContributionsInTimeRange<T extends { createdAt: any }>(
+  contributions: T[],
+  startDate: Date,
+  endDate: Date
+): T[] {
+  return contributions.filter(c => {
+    const contributionDate = new Date(c.createdAt)
+    return contributionDate >= startDate && contributionDate <= endDate
+  })
+}
+
+export function calculateGridPosition(date: Date, weeksAgo: Date): GridPosition | null {
+  const dayOfWeek = date.getDay()
+  
+  // Skip weekends
+  if (dayOfWeek === SUNDAY || dayOfWeek === SATURDAY) {
+    return null
+  }
+  
+  const weekdayColumn = dayOfWeek - 1 // Convert to Monday=0, Tuesday=1, ..., Friday=4
+  const daysDifference = Math.floor((date.getTime() - weeksAgo.getTime()) / MILLISECONDS_PER_DAY)
+  const weekRow = Math.floor(daysDifference / DAYS_PER_WEEK)
+  
+  // Ensure within bounds
+  if (weekRow >= 0 && weekRow < WEEKS_TO_DISPLAY && weekdayColumn >= 0 && weekdayColumn < WEEKDAYS_COUNT) {
+    return { weekRow, weekdayColumn }
+  }
+  
+  return null
+}
+
+export function placeContributionInGrid(
+  contribution: ContributionData,
+  getValue: (contribution: ContributionData) => number,
+  matrices: { matrix: ContributionMatrix; weeklyContributions: ContributionDataMatrix },
+  weeksAgo: Date
+): void {
+  const date = new Date(contribution.createdAt)
+  const position = calculateGridPosition(date, weeksAgo)
+  
+  if (position) {
+    const { weekRow, weekdayColumn } = position
+    matrices.matrix[weekRow][weekdayColumn] = getValue(contribution)
+    matrices.weeklyContributions[weekRow][weekdayColumn] = contribution
+  }
+}
+
+// Export constants for use in other files
+export { WEEKS_TO_DISPLAY }

--- a/src/stats/utils/test/contributionGridUtils.test.ts
+++ b/src/stats/utils/test/contributionGridUtils.test.ts
@@ -1,0 +1,244 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  createEmptyMatrices,
+  getTimeRange,
+  filterContributionsInTimeRange,
+  calculateGridPosition,
+  placeContributionInGrid,
+  processPostingContributions,
+  processCommentingContributions,
+  WEEKS_TO_DISPLAY,
+  type GridResult,
+  type ContributionData
+} from '../contributionGridUtils'
+import type { Contribution } from '@/stats/model/WritingStats'
+import type { CommentingContribution } from '@/stats/utils/commentingContributionUtils'
+
+// Mock current date to ensure consistent test results
+const MOCK_TODAY = new Date('2025-07-27T00:00:00.000Z') // Sunday
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(MOCK_TODAY)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('contributionGridUtils', () => {
+  describe('getTimeRange', () => {
+    it('should return today and Monday of 4 weeks ago', () => {
+      const { weeksAgo, today } = getTimeRange()
+      
+      expect(today.getDay()).toBe(0) // Sunday
+      expect(weeksAgo.getDay()).toBe(1) // Monday
+      expect(weeksAgo.toDateString()).toBe('Mon Jun 30 2025')
+      expect(today.toDateString()).toBe('Sun Jul 27 2025')
+    })
+
+    it('should normalize times to midnight', () => {
+      const { weeksAgo, today } = getTimeRange()
+      
+      expect(today.getHours()).toBe(0)
+      expect(today.getMinutes()).toBe(0)
+      expect(today.getSeconds()).toBe(0)
+      expect(today.getMilliseconds()).toBe(0)
+      
+      expect(weeksAgo.getHours()).toBe(0)
+      expect(weeksAgo.getMinutes()).toBe(0)
+      expect(weeksAgo.getSeconds()).toBe(0)
+      expect(weeksAgo.getMilliseconds()).toBe(0)
+    })
+  })
+
+  describe('createEmptyMatrices', () => {
+    it('should create matrices with correct dimensions', () => {
+      const { matrix, weeklyContributions } = createEmptyMatrices()
+      
+      expect(matrix).toHaveLength(WEEKS_TO_DISPLAY)
+      expect(matrix[0]).toHaveLength(5) // Mon-Fri
+      expect(weeklyContributions).toHaveLength(WEEKS_TO_DISPLAY)
+      expect(weeklyContributions[0]).toHaveLength(5)
+      
+      // All cells should be null initially
+      expect(matrix[0]).toEqual([null, null, null, null, null])
+      expect(weeklyContributions[0]).toEqual([null, null, null, null, null])
+    })
+  })
+
+  describe('filterContributionsInTimeRange', () => {
+    it('should filter contributions within date range', () => {
+      const contributions = [
+        { createdAt: new Date('2025-06-29') }, // Before range
+        { createdAt: new Date('2025-06-30') }, // Start of range
+        { createdAt: new Date('2025-07-15') }, // Within range
+        { createdAt: new Date('2025-07-28') }, // After range
+      ]
+      
+      const startDate = new Date('2025-06-30')
+      const endDate = new Date('2025-07-27')
+      
+      const filtered = filterContributionsInTimeRange(contributions, startDate, endDate)
+      
+      expect(filtered).toHaveLength(2)
+      expect(filtered[0].createdAt.toDateString()).toBe('Mon Jun 30 2025')
+      expect(filtered[1].createdAt.toDateString()).toBe('Tue Jul 15 2025')
+    })
+  })
+
+  describe('calculateGridPosition', () => {
+    const weeksAgo = new Date('2025-06-30T00:00:00.000Z') // Monday
+
+    it('should calculate correct position for weekdays', () => {
+      // Monday June 30th (Week 0, Col 0)
+      const mondayPos = calculateGridPosition(new Date('2025-06-30'), weeksAgo)
+      expect(mondayPos).toEqual({ weekRow: 0, weekdayColumn: 0 })
+
+      // Tuesday July 1st (Week 0, Col 1)
+      const tuesdayPos = calculateGridPosition(new Date('2025-07-01'), weeksAgo)
+      expect(tuesdayPos).toEqual({ weekRow: 0, weekdayColumn: 1 })
+
+      // Friday July 4th (Week 0, Col 4)
+      const fridayPos = calculateGridPosition(new Date('2025-07-04'), weeksAgo)
+      expect(fridayPos).toEqual({ weekRow: 0, weekdayColumn: 4 })
+
+      // Monday July 7th (Week 1, Col 0)
+      const nextMondayPos = calculateGridPosition(new Date('2025-07-07'), weeksAgo)
+      expect(nextMondayPos).toEqual({ weekRow: 1, weekdayColumn: 0 })
+    })
+
+    it('should return null for weekends', () => {
+      // Saturday
+      const saturdayPos = calculateGridPosition(new Date('2025-07-05'), weeksAgo)
+      expect(saturdayPos).toBeNull()
+
+      // Sunday
+      const sundayPos = calculateGridPosition(new Date('2025-07-06'), weeksAgo)
+      expect(sundayPos).toBeNull()
+    })
+
+    it('should return null for out-of-bounds dates', () => {
+      // Before range
+      const beforePos = calculateGridPosition(new Date('2025-06-29'), weeksAgo)
+      expect(beforePos).toBeNull()
+
+      // After range (more than 4 weeks)
+      const afterPos = calculateGridPosition(new Date('2025-08-01'), weeksAgo)
+      expect(afterPos).toBeNull()
+    })
+  })
+
+  describe('placeContributionInGrid', () => {
+    it('should place contribution in correct grid position', () => {
+      const matrices = createEmptyMatrices()
+      const weeksAgo = new Date('2025-06-30T00:00:00.000Z')
+      
+      const contribution: ContributionData = {
+        createdAt: new Date('2025-07-01T10:30:00.000Z').toISOString(), // Tuesday, should normalize to midnight
+        contentLength: 500
+      } as Contribution
+
+      placeContributionInGrid(
+        contribution,
+        (c) => (c as Contribution).contentLength ?? 0,
+        matrices,
+        weeksAgo
+      )
+
+      // Should be placed at Week 0, Column 1 (Tuesday)
+      expect(matrices.matrix[0][1]).toBe(500)
+      expect(matrices.weeklyContributions[0][1]).toBe(contribution)
+      
+      // Other positions should remain null
+      expect(matrices.matrix[0][0]).toBeNull()
+      expect(matrices.matrix[0][2]).toBeNull()
+    })
+
+    it('should not place weekend contributions', () => {
+      const matrices = createEmptyMatrices()
+      const weeksAgo = new Date('2025-06-30T00:00:00.000Z')
+      
+      const weekendContribution: ContributionData = {
+        createdAt: new Date('2025-07-05').toISOString(), // Saturday
+        contentLength: 300
+      } as Contribution
+
+      placeContributionInGrid(
+        weekendContribution,
+        (c) => (c as Contribution).contentLength ?? 0,
+        matrices,
+        weeksAgo
+      )
+
+      // No position should be filled
+      expect(matrices.matrix.flat().every(cell => cell === null)).toBe(true)
+      expect(matrices.weeklyContributions.flat().every(cell => cell === null)).toBe(true)
+    })
+  })
+
+  describe('Integration Test - Complete Grid Processing', () => {
+    it('should create correct grid for posting contributions', () => {
+      const contributions: Contribution[] = [
+        // Week 0
+        { createdAt: new Date('2025-06-30').toISOString(), contentLength: 100 }, // Mon
+        { createdAt: new Date('2025-07-01').toISOString(), contentLength: 200 }, // Tue
+        { createdAt: new Date('2025-07-03').toISOString(), contentLength: 300 }, // Thu
+        // Week 1  
+        { createdAt: new Date('2025-07-07').toISOString(), contentLength: 400 }, // Mon
+        { createdAt: new Date('2025-07-11').toISOString(), contentLength: 500 }, // Fri
+        // Weekends (should be ignored)
+        { createdAt: new Date('2025-07-05').toISOString(), contentLength: 999 }, // Sat
+        { createdAt: new Date('2025-07-06').toISOString(), contentLength: 999 }, // Sun
+      ] as Contribution[]
+
+      const result = processPostingContributions(contributions)
+
+      // Expected matrix: [Mon, Tue, Wed, Thu, Fri]
+      expect(result.matrix[0]).toEqual([100, 200, null, 300, null]) // Week 0
+      expect(result.matrix[1]).toEqual([400, null, null, null, 500]) // Week 1
+      expect(result.matrix[2]).toEqual([null, null, null, null, null]) // Week 2
+      expect(result.matrix[3]).toEqual([null, null, null, null, null]) // Week 3
+      
+      expect(result.maxValue).toBe(500)
+    })
+
+    it('should create correct grid for commenting contributions', () => {
+      const contributions: CommentingContribution[] = [
+        { createdAt: new Date('2025-07-01').toISOString(), countOfCommentAndReplies: 5 }, // Tue
+        { createdAt: new Date('2025-07-08').toISOString(), countOfCommentAndReplies: 10 }, // Tue next week
+      ] as CommentingContribution[]
+
+      const result = processCommentingContributions(contributions)
+
+      expect(result.matrix[0]).toEqual([null, 5, null, null, null]) // Week 0
+      expect(result.matrix[1]).toEqual([null, 10, null, null, null]) // Week 1
+      expect(result.maxValue).toBe(10)
+    })
+
+    it('should handle edge case: contributions exactly at range boundaries', () => {
+      const { weeksAgo, today } = getTimeRange()
+      
+      const contributions: Contribution[] = [
+        { createdAt: new Date(weeksAgo).toISOString(), contentLength: 100 }, // Exactly at start
+        { createdAt: new Date(today).toISOString(), contentLength: 200 }, // Exactly at end (Sunday, should be ignored)
+      ] as Contribution[]
+
+      const matrices = createEmptyMatrices()
+      const recentContributions = filterContributionsInTimeRange(contributions, weeksAgo, today)
+
+      recentContributions.forEach(contribution => {
+        placeContributionInGrid(
+          contribution,
+          (c) => (c as Contribution).contentLength ?? 0,
+          matrices,
+          weeksAgo
+        )
+      })
+
+      // Only Monday (start) should be placed, Sunday should be ignored
+      expect(matrices.matrix[0][0]).toBe(100) // Monday
+      expect(matrices.matrix.flat().filter(cell => cell !== null)).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
근본 원인: 시간 정밀도 문제

  버그:
  JavaScript Date 객체는 날짜뿐만 아니라 시간(시, 분, 초, 밀리초)도 포함합니다. 일수 차이를 계산할
   때 이것이 정수가 아닌 소수점 결과를 만들어냈습니다.

  예시:
  - 7월 1일 오전 10:30 - 6월 30일 오후 12:00 = 0.525일
  - Math.floor(0.525) = 0 → 잘못된 주/열 배치

  해결책:
  모든 날짜를 자정(00:00:00)으로 정규화하기 위해 setHours(0, 0, 0, 0)을 사용해서 시간 차이가 아닌
  순수한 날짜 차이를 기반으로 계산하도록 했습니다.

  결과:
  - 7월 1일 00:00 - 6월 30일 00:00 = 정확히 1.0일
  - Math.floor(1.0) = 1 → 올바른 배치

  이를 통해 그리드 배치가 [7970, 228, 825, 737, 748]에서 [null, 228, 825, 737, 748]로 수정되었고,
  null이 기여도가 없는 6월 30일 월요일을 올바르게 나타내게 되었습니다.
