### PR TITLE
알림에서 삭제된 댓글/답글 참조해서 에러나는 문제 해결

### DIFF
--- a/src/comment/hooks/useCommentContent.ts
+++ b/src/comment/hooks/useCommentContent.ts
@@ -1,7 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchCommentById } from '@/comment/api/comment';
 
-export function useCommentContent(boardId: string, postId: string, commentId: string) {
+export function useCommentContent(
+  boardId: string,
+  postId: string,
+  commentId: string,
+  options?: { enabled?: boolean }
+) {
   const {
     data: comment,
     isLoading,
@@ -9,7 +14,8 @@ export function useCommentContent(boardId: string, postId: string, commentId: st
   } = useQuery({
     queryKey: ['comment', boardId, postId, commentId],
     queryFn: () => fetchCommentById(boardId, postId, commentId),
-    enabled: !!boardId && !!postId && !!commentId,
+    enabled: options?.enabled !== undefined ? options.enabled : (!!boardId && !!postId && !!commentId),
+    retry: false, // Don't retry for potentially deleted comments
   });
   const content = comment?.content ?? null;
   return { content, isLoading, error };

--- a/src/comment/hooks/useReplyContent.ts
+++ b/src/comment/hooks/useReplyContent.ts
@@ -6,6 +6,7 @@ export function useReplyContent(
   postId: string,
   commentId: string,
   replyId: string,
+  options?: { enabled?: boolean }
 ) {
   const {
     data: reply,
@@ -14,7 +15,8 @@ export function useReplyContent(
   } = useQuery({
     queryKey: ['reply', boardId, postId, commentId, replyId],
     queryFn: () => fetchReplyById(boardId, postId, commentId, replyId),
-    enabled: !!boardId && !!postId && !!commentId && !!replyId,
+    enabled: options?.enabled !== undefined ? options.enabled : (!!boardId && !!postId && !!commentId && !!replyId),
+    retry: false, // Don't retry for potentially deleted replies
   });
   const content = reply?.content ?? null;
   return { content, isLoading, error };


### PR DESCRIPTION
**Hook signature mismatch in useNotificationMessage.ts:24-35**
- The hooks were being called with an { enabled } options parameter that didn't exist in their signatures, causing them to always execute even when they shouldn't. When referencing deleted comments/replies, Firebase throws the misleading "client is offline" error.