### PR TITLE
글을 수정하면 바로 상세 페이지에서 최신화되도록

### DIFF
--- a/src/post/components/PostEditPage.tsx
+++ b/src/post/components/PostEditPage.tsx
@@ -82,9 +82,9 @@ function PostEditForm({ boardId, postId }: { boardId: string; postId: string }) 
 
     try {
       await updatePost(boardId, postId, editState.title, editState.content, editState.contentJson);
-      // Invalidate the post cache to ensure PostDetailPage shows fresh data
-      await queryClient.invalidateQueries(['post', boardId, postId]);
       navigate(`/board/${boardId}/post/${postId}`);
+      // Invalidate after navigation to avoid unnecessary refetching on edit page
+      queryClient.invalidateQueries(['post', boardId, postId]);
     } catch (error) {
       console.error('Error updating post:', error);
       toast({


### PR DESCRIPTION
- 수정에 성공하면 리액트 쿼리 캐시를 무효화한다