### PR TITLE
Fix image upload responsiveness on mobile devices

### DIFF
--- a/src/post/hooks/useImageUpload.ts
+++ b/src/post/hooks/useImageUpload.ts
@@ -1,9 +1,9 @@
 import * as Sentry from '@sentry/react';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
-import heic2any from 'heic2any';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { storage } from '@/firebase';
+import { processImageForUpload } from '@/post/utils/ImageUtils';
 
 interface UseImageUploadProps {
     insertImage: (url: string) => void;
@@ -14,7 +14,6 @@ export function useImageUpload({ insertImage }: UseImageUploadProps) {
   const [uploadProgress, setUploadProgress] = useState(0);
 
   const imageHandler = async () => {
-
     const input = document.createElement('input');
     input.setAttribute('type', 'file');
     input.setAttribute('accept', 'image/*');
@@ -24,14 +23,12 @@ export function useImageUpload({ insertImage }: UseImageUploadProps) {
       const file = input.files?.[0];
       if (!file) return;
 
-      // Declare processedFile outside try block for catch block access
-      let processedFile = file;
-
       try {
+        // Set loading state immediately before any processing
         setIsUploading(true);
         setUploadProgress(0);
 
-        // 파일 크기 체크 (5MB)
+        // File size check (5MB)
         if (file.size > 5 * 1024 * 1024) {
           toast.error("파일 크기는 5MB를 초과할 수 없습니다.", {
             position: 'bottom-center',
@@ -40,36 +37,9 @@ export function useImageUpload({ insertImage }: UseImageUploadProps) {
           return;
         }
 
-        // HEIC 파일 변환 처리
-        if (file.type === 'image/heic' || file.type === 'image/heif' || file.name.toLowerCase().endsWith('.heic') || file.name.toLowerCase().endsWith('.heif')) {
-          try {
-            const convertedBlob = await heic2any({
-              blob: file,
-              toType: 'image/jpeg',
-              quality: 0.8
-            }) as Blob;
-            
-            // Convert blob to file with proper name
-            const convertedFileName = file.name.replace(/\.(heic|heif)$/i, '.jpg');
-            processedFile = new File([convertedBlob], convertedFileName, {
-              type: 'image/jpeg',
-              lastModified: Date.now()
-            });
-          } catch (conversionError) {
-            Sentry.captureException(conversionError, {
-              tags: { feature: 'image_upload', operation: 'heic_conversion' },
-              extra: { fileName: file.name, fileSize: file.size, fileType: file.type }
-            });
-            toast.error("HEIC 파일 변환에 실패했습니다.", {
-              position: 'bottom-center',
-            });
-            setIsUploading(false);
-            return;
-          }
-        }
-
-        // 파일 타입 체크 (변환된 파일 기준)
-        if (!processedFile.type.startsWith('image/')) {
+        // File type check (allow HEIC by extension)
+        const isHeicByExtension = /\.(heic|heif)$/i.test(file.name);
+        if (!file.type.startsWith('image/') && !isHeicByExtension) {
           toast.error("이미지 파일만 업로드할 수 있습니다.", {
             position: 'bottom-center',
           });
@@ -77,25 +47,27 @@ export function useImageUpload({ insertImage }: UseImageUploadProps) {
           return;
         }
 
-        // 업로드 시작 표시
-        setUploadProgress(20);
+        setUploadProgress(10);
 
-        // 날짜 기반 파일 경로 생성
+        // Process image (HEIC conversion + resize)
+        const processedFile = await processImageForUpload(file);
+        setUploadProgress(40);
+
+        // Generate storage path
         const now = new Date();
         const { dateFolder, timePrefix } = formatDate(now);
         const fileName = `${timePrefix}_${processedFile.name}`;
         const storageRef = ref(storage, `postImages/${dateFolder}/${fileName}`);
 
-        // 파일 업로드
-        setUploadProgress(40);
+        // Upload file
         const snapshot = await uploadBytes(storageRef, processedFile);
         setUploadProgress(70);
 
-        // URL 가져오기
+        // Get download URL
         const downloadURL = await getDownloadURL(snapshot.ref);
         setUploadProgress(90);
 
-        // 에디터에 이미지 삽입
+        // Insert image into editor
         insertImage(downloadURL);
 
         setUploadProgress(100);
@@ -104,16 +76,14 @@ export function useImageUpload({ insertImage }: UseImageUploadProps) {
         });
 
       } catch (error) {
-        setIsUploading(false);
         Sentry.captureException(error, {
           tags: { feature: 'image_upload', operation: 'upload_process' },
-          extra: { fileName: processedFile?.name, fileSize: processedFile?.size, fileType: processedFile?.type }
+          extra: { fileName: file?.name, fileSize: file?.size, fileType: file?.type }
         });
         toast.error("이미지 업로드에 실패했습니다.", {
           position: 'bottom-center',
         });
       } finally {
-        // 약간의 딜레이 후 로딩 상태 초기화
         setTimeout(() => {
           setIsUploading(false);
           setUploadProgress(0);


### PR DESCRIPTION
## Summary
- Centralize image processing logic in `ImageUtils.ts` with new `processImageForUpload()` function
- Add image resizing (max 1920px) before upload to reduce memory usage on mobile
- Use `requestAnimationFrame` to yield to browser during heavy operations, keeping UI responsive

## Problem
Users reported the web app becoming unresponsive when attaching images from their phone's album (both iPhone and Android).

## Root Causes
1. No image resizing - large mobile photos (12MP+) consumed too much memory
2. HEIC conversion blocked the main thread
3. No browser yielding during CPU-intensive operations

## Changes
| File | Change |
|------|--------|
| `src/post/utils/ImageUtils.ts` | Added `processImageForUpload()` with HEIC conversion + resize |
| `src/post/hooks/useTiptapImageUpload.ts` | Use centralized `processImageForUpload()` |
| `src/post/hooks/useImageUpload.ts` | Use centralized `processImageForUpload()` |

## Test plan
- [ ] Upload large image (>3000px) from mobile device - should resize and upload smoothly
- [ ] Upload HEIC image from iPhone - should convert and upload without freezing UI
- [ ] Upload regular JPEG - should work as before
- [ ] Verify loading spinner appears immediately when selecting image
