### PR TITLE
Fix race condition between auto-save drafts and post submission

### DIFF
--- a/src/draft/hooks/__tests__/useAutoSaveDraftsHelpers.test.ts
+++ b/src/draft/hooks/__tests__/useAutoSaveDraftsHelpers.test.ts
@@ -1,0 +1,243 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useRef, MutableRefObject } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * Hook to track the latest value in a ref for use in callbacks.
+ * This avoids stale closure issues in intervals and event handlers.
+ */
+function useLatestValueRef<T>(value: T): MutableRefObject<T> {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+}
+
+/**
+ * Hook to prevent concurrent execution of async operations.
+ * If an operation is already in-flight, subsequent calls will wait for it to complete.
+ */
+function useConcurrentOperationGuard() {
+  const currentOperationPromiseRef = useRef<Promise<unknown> | null>(null);
+
+  const executeWithGuard = async <T>(operation: () => Promise<T>): Promise<T | undefined> => {
+    if (currentOperationPromiseRef.current !== null) {
+      await currentOperationPromiseRef.current;
+      return undefined;
+    }
+
+    const operationPromise = operation();
+    currentOperationPromiseRef.current = operationPromise;
+
+    try {
+      return await operationPromise;
+    } finally {
+      currentOperationPromiseRef.current = null;
+    }
+  };
+
+  const isOperationInFlight = () => currentOperationPromiseRef.current !== null;
+
+  return { executeWithGuard, isOperationInFlight };
+}
+
+describe('useLatestValueRef', () => {
+  describe('when value changes', () => {
+    it('updates ref.current to the latest value', () => {
+      const { result, rerender } = renderHook(({ value }) => useLatestValueRef(value), {
+        initialProps: { value: 'initial' },
+      });
+
+      expect(result.current.current).toBe('initial');
+
+      rerender({ value: 'updated' });
+
+      expect(result.current.current).toBe('updated');
+    });
+  });
+
+  describe('when used with objects', () => {
+    it('tracks the latest object reference', () => {
+      const initialObject = { count: 1 };
+      const updatedObject = { count: 2 };
+
+      const { result, rerender } = renderHook(({ value }) => useLatestValueRef(value), {
+        initialProps: { value: initialObject },
+      });
+
+      expect(result.current.current).toBe(initialObject);
+
+      rerender({ value: updatedObject });
+
+      expect(result.current.current).toBe(updatedObject);
+    });
+  });
+
+  describe('when ref is used in callback', () => {
+    it('provides access to latest value without stale closure', () => {
+      const { result, rerender } = renderHook(({ value }) => useLatestValueRef(value), {
+        initialProps: { value: 0 },
+      });
+
+      const capturedRef = result.current;
+
+      rerender({ value: 5 });
+      rerender({ value: 10 });
+
+      expect(capturedRef.current).toBe(10);
+    });
+  });
+});
+
+describe('useConcurrentOperationGuard', () => {
+  describe('when no operation is in-flight', () => {
+    it('executes the operation and returns its result', async () => {
+      const { result } = renderHook(() => useConcurrentOperationGuard());
+
+      const mockOperation = vi.fn().mockResolvedValue('success');
+
+      let operationResult: string | undefined;
+      await act(async () => {
+        operationResult = await result.current.executeWithGuard(mockOperation);
+      });
+
+      expect(mockOperation).toHaveBeenCalledTimes(1);
+      expect(operationResult).toBe('success');
+    });
+
+    it('reports isOperationInFlight as false before and after', async () => {
+      const { result } = renderHook(() => useConcurrentOperationGuard());
+
+      expect(result.current.isOperationInFlight()).toBe(false);
+
+      const mockOperation = vi.fn().mockResolvedValue('done');
+
+      await act(async () => {
+        await result.current.executeWithGuard(mockOperation);
+      });
+
+      expect(result.current.isOperationInFlight()).toBe(false);
+    });
+  });
+
+  describe('when operation is in-flight', () => {
+    it('waits for the current operation to complete before returning', async () => {
+      const { result } = renderHook(() => useConcurrentOperationGuard());
+
+      let resolveFirst: (value: string) => void;
+      const firstOperationPromise = new Promise<string>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const firstOperation = vi.fn().mockReturnValue(firstOperationPromise);
+      const secondOperation = vi.fn().mockResolvedValue('second');
+
+      let firstResult: string | undefined;
+      let secondResult: string | undefined;
+
+      act(() => {
+        result.current.executeWithGuard(firstOperation).then((r) => {
+          firstResult = r;
+        });
+      });
+
+      expect(result.current.isOperationInFlight()).toBe(true);
+
+      act(() => {
+        result.current.executeWithGuard(secondOperation).then((r) => {
+          secondResult = r;
+        });
+      });
+
+      expect(secondOperation).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveFirst!('first');
+      });
+
+      await waitFor(() => {
+        expect(firstResult).toBe('first');
+        expect(secondResult).toBe(undefined);
+      });
+
+      expect(secondOperation).not.toHaveBeenCalled();
+    });
+
+    it('reports isOperationInFlight as true during execution', async () => {
+      const { result } = renderHook(() => useConcurrentOperationGuard());
+
+      let resolveOperation: () => void;
+      const operationPromise = new Promise<void>((resolve) => {
+        resolveOperation = resolve;
+      });
+
+      act(() => {
+        result.current.executeWithGuard(() => operationPromise);
+      });
+
+      expect(result.current.isOperationInFlight()).toBe(true);
+
+      await act(async () => {
+        resolveOperation!();
+      });
+
+      expect(result.current.isOperationInFlight()).toBe(false);
+    });
+  });
+
+  describe('when operation throws an error', () => {
+    it('resets guard state after error', async () => {
+      const { result } = renderHook(() => useConcurrentOperationGuard());
+
+      const error = new Error('Operation failed');
+      const failingOperation = vi.fn().mockRejectedValue(error);
+
+      await act(async () => {
+        try {
+          await result.current.executeWithGuard(failingOperation);
+        } catch (e) {
+          expect(e).toBe(error);
+        }
+      });
+
+      expect(result.current.isOperationInFlight()).toBe(false);
+
+      const successOperation = vi.fn().mockResolvedValue('recovered');
+      let recoveredResult: string | undefined;
+
+      await act(async () => {
+        recoveredResult = await result.current.executeWithGuard(successOperation);
+      });
+
+      expect(successOperation).toHaveBeenCalledTimes(1);
+      expect(recoveredResult).toBe('recovered');
+    });
+  });
+
+  describe('when multiple concurrent calls are made', () => {
+    it('only executes the first operation', async () => {
+      const { result } = renderHook(() => useConcurrentOperationGuard());
+
+      let resolveFirst: () => void;
+      const firstPromise = new Promise<string>((resolve) => {
+        resolveFirst = () => resolve('first');
+      });
+
+      const firstOp = vi.fn().mockReturnValue(firstPromise);
+      const secondOp = vi.fn().mockResolvedValue('second');
+      const thirdOp = vi.fn().mockResolvedValue('third');
+
+      act(() => {
+        result.current.executeWithGuard(firstOp);
+        result.current.executeWithGuard(secondOp);
+        result.current.executeWithGuard(thirdOp);
+      });
+
+      expect(firstOp).toHaveBeenCalledTimes(1);
+      expect(secondOp).not.toHaveBeenCalled();
+      expect(thirdOp).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveFirst!();
+      });
+    });
+  });
+});

--- a/src/draft/hooks/useAutoSaveDrafts.ts
+++ b/src/draft/hooks/useAutoSaveDrafts.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, MutableRefObject } from 'react';
 import { useInterval } from 'react-simplikit';
 import { useDraftSaveMutation } from './useDraftSaveMutation';
 
@@ -8,8 +8,8 @@ interface UseAutoSaveDraftsProps {
   title: string;
   content: string;
   initialDraftId?: string;
-  intervalMs?: number; // 주기적 저장 (기본 10000)
-  enabled?: boolean; // 자동 저장 활성화 여부 (기본 true)
+  intervalMs?: number;
+  enabled?: boolean;
 }
 
 interface UseAutoSaveDraftsResult {
@@ -20,45 +20,58 @@ interface UseAutoSaveDraftsResult {
   manualSave: () => Promise<void>;
 }
 
+interface DraftContent {
+  title: string;
+  content: string;
+}
+
 /**
- * 임시 저장 초안(Draft)을 10초마다 자동으로 저장하는 커스텀 훅입니다.
- * 
- * - useInterval 훅을 사용해 10초마다 title/content가 마지막 저장값과 다를 때만 저장합니다.
- * - 수동 저장(manualSave) 함수도 제공합니다.
- * - react-query의 useMutation을 활용하여 저장 상태, 에러, 로딩을 관리합니다.
- * 
- * @param {Object} params - 훅에 전달할 파라미터 객체
- * @param {string} params.boardId - 게시판 ID (필수)
- * @param {string|undefined} params.userId - 사용자 ID (필수)
- * @param {string} params.title - 현재 입력 중인 제목
- * @param {string} params.content - 현재 입력 중인 본문
- * @param {string} [params.initialDraftId] - 최초 draftId (있으면 해당 draft를 이어서 저장)
- * @param {number} [params.intervalMs=10000] - 주기적 저장 간격(ms)
- * @param {boolean} [params.enabled=true] - 자동 저장 활성화 여부 (form 제출 중 비활성화용)
- * 
- * @returns {Object} 반환값 객체
- * @returns {string|null} return.draftId - 현재 임시저장 draft의 ID
- * @returns {Date|null} return.lastSavedAt - 마지막 저장 시각
- * @returns {boolean} return.isSaving - 저장 중 여부(로딩 상태)
- * @returns {Error|null} return.savingError - 저장 중 발생한 에러
- * @returns {() => Promise<void>} return.manualSave - 수동 저장 함수
- * 
- * @example
- * const {
- *   draftId,
- *   lastSavedAt,
- *   isSaving,
- *   savingError,
- *   manualSave
- * } = useAutoSaveDrafts({
- *   boardId: 'board123',
- *   userId: currentUser?.uid,
- *   title,
- *   content,
- *   initialDraftId: loadedDraftId,
- *   intervalMs: 10000,
- * });
+ * Hook to track the latest value in a ref for use in callbacks.
+ * This avoids stale closure issues in intervals and event handlers.
  */
+function useLatestValueRef<T>(value: T): MutableRefObject<T> {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+}
+
+/**
+ * Hook to prevent concurrent execution of async operations.
+ * If an operation is already in-flight, subsequent calls will wait for it to complete.
+ */
+function useConcurrentOperationGuard() {
+  const currentOperationPromiseRef = useRef<Promise<unknown> | null>(null);
+
+  const executeWithGuard = useCallback(async <T>(operation: () => Promise<T>): Promise<T | undefined> => {
+    if (currentOperationPromiseRef.current !== null) {
+      await currentOperationPromiseRef.current;
+      return undefined;
+    }
+
+    const operationPromise = operation();
+    currentOperationPromiseRef.current = operationPromise;
+
+    try {
+      return await operationPromise;
+    } finally {
+      currentOperationPromiseRef.current = null;
+    }
+  }, []);
+
+  const isOperationInFlight = useCallback(() => currentOperationPromiseRef.current !== null, []);
+
+  return { executeWithGuard, isOperationInFlight };
+}
+
+function hasContentChanged(
+  currentContent: DraftContent,
+  lastSavedContent: DraftContent
+): boolean {
+  const titleHasChanged = currentContent.title !== lastSavedContent.title;
+  const contentHasChanged = currentContent.content !== lastSavedContent.content;
+  return titleHasChanged || contentHasChanged;
+}
+
 export function useAutoSaveDrafts({
   boardId,
   userId,
@@ -73,40 +86,50 @@ export function useAutoSaveDrafts({
   const [lastSavedTitle, setLastSavedTitle] = useState<string>(title);
   const [lastSavedContent, setLastSavedContent] = useState<string>(content);
 
-  // 최신 title/content를 ref로 추적
-  const titleRef = useRef(title);
-  const contentRef = useRef(content);
-  // ref를 최신값으로 동기화
-  titleRef.current = title;
-  contentRef.current = content;
+  const draftIdRef = useLatestValueRef(draftId);
+  const currentTitleRef = useLatestValueRef(title);
+  const currentContentRef = useLatestValueRef(content);
+  const isAutoSaveEnabledRef = useLatestValueRef(enabled);
 
-  // 저장 mutation
+  const { executeWithGuard, isOperationInFlight } = useConcurrentOperationGuard();
+
   const { mutateAsync: saveDraftMutate, isLoading, error } = useDraftSaveMutation({
-    draftId,
+    draftIdRef,
     boardId,
     userId,
-    title: titleRef.current,
-    content: contentRef.current,
+    titleRef: currentTitleRef,
+    contentRef: currentContentRef,
     onSaved: (savedDraft) => {
       setDraftId(savedDraft.id);
       setLastSavedAt(savedDraft.savedAt.toDate());
-      setLastSavedTitle(titleRef.current);
-      setLastSavedContent(contentRef.current);
+      setLastSavedTitle(currentTitleRef.current);
+      setLastSavedContent(currentContentRef.current);
     },
   });
 
-  // 수동 저장
   const manualSave = useCallback(async () => {
-    await saveDraftMutate();
-  }, [saveDraftMutate]);
+    await executeWithGuard(() => saveDraftMutate());
+  }, [executeWithGuard, saveDraftMutate]);
 
-  // useInterval로 10초마다 자동 저장 (enabled가 false면 비활성화)
   useInterval(() => {
-    if (!enabled) return;
+    const isAutoSaveDisabled = !isAutoSaveEnabledRef.current;
+    if (isAutoSaveDisabled) return;
 
-    const shouldSave = titleRef.current !== lastSavedTitle || contentRef.current !== lastSavedContent;
-    if (shouldSave) {
-      saveDraftMutate();
+    const isSaveAlreadyInProgress = isOperationInFlight();
+    if (isSaveAlreadyInProgress) return;
+
+    const currentContent: DraftContent = {
+      title: currentTitleRef.current,
+      content: currentContentRef.current,
+    };
+    const lastSaved: DraftContent = {
+      title: lastSavedTitle,
+      content: lastSavedContent,
+    };
+
+    const shouldSaveDraft = hasContentChanged(currentContent, lastSaved);
+    if (shouldSaveDraft) {
+      executeWithGuard(() => saveDraftMutate());
     }
   }, intervalMs);
 

--- a/src/draft/hooks/useDraftSaveMutation.ts
+++ b/src/draft/hooks/useDraftSaveMutation.ts
@@ -1,33 +1,40 @@
+import { MutableRefObject } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { saveDraft } from '@/draft/utils/draftUtils';
+import { Draft } from '@/draft/model/Draft';
 
 interface UseDraftSaveMutationProps {
-  draftId: string | null;
+  draftIdRef: MutableRefObject<string | null>;
   boardId: string;
   userId: string | undefined;
-  title: string;
-  content: string;
-  onSaved?: (savedDraft: any) => void;
+  titleRef: MutableRefObject<string>;
+  contentRef: MutableRefObject<string>;
+  onSaved?: (savedDraft: Draft) => void;
 }
 
 export function useDraftSaveMutation({
-  draftId,
+  draftIdRef,
   boardId,
   userId,
-  title,
-  content,
+  titleRef,
+  contentRef,
   onSaved,
 }: UseDraftSaveMutationProps) {
   return useMutation({
     mutationFn: async () => {
       if (!userId || !boardId) throw new Error('로그인 또는 게시판 정보가 없습니다.');
-      if (!title.trim() && !content.trim()) return null;
+
+      const currentTitle = titleRef.current;
+      const currentContent = contentRef.current;
+
+      if (!currentTitle.trim() && !currentContent.trim()) return null;
+
       const savedDraft = await saveDraft(
         {
-          id: draftId || undefined,
+          id: draftIdRef.current || undefined,
           boardId,
-          title,
-          content,
+          title: currentTitle,
+          content: currentContent,
         },
         userId
       );

--- a/src/post/components/PostCreationPage.tsx
+++ b/src/post/components/PostCreationPage.tsx
@@ -81,7 +81,7 @@ export default function PostCreationPage() {
     }
   }, [actionData?.error]);
 
-  useAutoSaveDrafts({
+  const { draftId: autoSavedDraftId } = useAutoSaveDrafts({
     boardId: boardId || '',
     userId: currentUser?.uid,
     title,
@@ -90,6 +90,9 @@ export default function PostCreationPage() {
     intervalMs: 10000,
     enabled: !isSubmitting,
   });
+
+  // Use the auto-saved draft ID, or fall back to the loaded draft ID
+  const currentDraftId = autoSavedDraftId || loadedDraftId || '';
   return (
     <div>
       <PostEditorHeader
@@ -124,6 +127,7 @@ export default function PostCreationPage() {
           <input type='hidden' name='title' value={title} />
           <input type='hidden' name='content' value={content} />
           <input type='hidden' name='contentJson' value={safeStringifyJson(contentJson)} />
+          <input type='hidden' name='draftId' value={currentDraftId} />
 
           <PostTitleEditor value={title} onChange={(e) => setTitle(e.target.value)} />
           <PostEditor


### PR DESCRIPTION
## Summary
- Fix Firestore sync queue corruption when auto-save and post submission happen concurrently
- Add `useConcurrentOperationGuard` hook to prevent overlapping save operations
- Add `useLatestValueRef` hook to avoid stale closure issues in interval callbacks
- Pass draftId to form for proper draft cleanup after successful post creation

## Problem
When user stays on post creation page for a while and clicks submit, the auto-save interval could fire simultaneously with post submission, causing concurrent Firestore writes that corrupt the sync queue with error: "FIRESTORE INTERNAL ASSERTION FAILED: Unexpected state"

## Test plan
- [ ] Stay on post creation page for 10+ seconds while typing
- [ ] Click submit button and verify no Firestore errors occur
- [ ] Verify draft is deleted after successful post creation