### PR TITLE
포스트 작성 후 postingStreak 캐시 무효화

### DIFF
--- a/src/post/hooks/useCreatePostAction.ts
+++ b/src/post/hooks/useCreatePostAction.ts
@@ -76,6 +76,11 @@ export async function createPostAction({ request, params }: ActionFunctionArgs) 
       queryKey: ['userPostings', authorId],
     });
 
+    // Invalidate posting streak cache to show updated streak on PostCard
+    queryClient.invalidateQueries({
+      queryKey: ['postingStreak', authorId],
+    });
+
     return redirect(`/create/${boardId}/completion?contentLength=${content.length}`);
   } catch (error) {
     console.error('게시물 작성 중 오류가 발생했습니다:', error);


### PR DESCRIPTION
## Summary
- 포스트 작성 후 `postingStreak` 캐시를 무효화하여 보드 페이지로 돌아갔을 때 업데이트된 스트릭이 표시되도록 함

## Test plan
- [ ] 새 포스트 작성 후 보드 페이지로 돌아가면 PostCard에 업데이트된 스트릭 배지가 표시되는지 확인