### PR TITLE
feat(draft): 임시저장 실패 시 재시도 및 토스트 알림 추가

### DIFF
--- a/src/draft/hooks/useDraftSaveMutation.ts
+++ b/src/draft/hooks/useDraftSaveMutation.ts
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { MutableRefObject } from 'react';
+import { toast } from 'sonner';
 import { Draft } from '@/draft/model/Draft';
 import { saveDraft } from '@/draft/utils/draftUtils';
 
@@ -44,6 +45,20 @@ export function useDraftSaveMutation({
       );
       onSaved?.(savedDraft);
       return savedDraft;
+    },
+    retry: 3,
+    retryDelay: (attemptIndex) => Math.min(1000 * Math.pow(2, attemptIndex), 8000),
+    onError: (error: Error) => {
+      const isTimeout = error.message?.includes('timed out');
+      toast.warning(
+        isTimeout
+          ? '네트워크 연결이 불안정해서 임시 저장하지 못했어요'
+          : '임시 저장에 문제가 생겼어요',
+        {
+          position: 'bottom-center',
+          duration: 5000,
+        }
+      );
     },
   });
 } 


### PR DESCRIPTION
## Summary
- Add retry logic with exponential backoff (3 retries, max 8s delay) to draft save mutation
- Show toast notification when save fails after all retries exhausted
- Different messages for timeout vs other errors

## Test Plan
- [ ] Verify type-check passes
- [ ] Verify lint passes
- [ ] Verify tests pass
- [ ] Manual test: Block Firebase in DevTools, type content, wait ~47s for toast

🤖 Generated with [Claude Code](https://claude.ai/code)