### PR TITLE
CI 빌드에 Supabase 환경변수 추가

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -23,6 +23,8 @@ jobs:
           VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
           VITE_READ_SOURCE: ${{ secrets.VITE_READ_SOURCE }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
## Summary
- 프로덕션 배포 시 `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`가 빌드에 포함되지 않아 Supabase 클라이언트 초기화 실패
- `VITE_READ_SOURCE`가 `supabase` 또는 `shadow`일 때 `getSupabaseClient()`가 호출되는데, 연결 정보가 없어 에러 발생
- Sentry Issue [#7249325605]: `usePostingStreak` 등 다수 쿼리에서 "Missing Supabase configuration" 에러

## Changes
- `firebase-hosting-merge.yml` 빌드 스텝에 `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY` 시크릿 전달 추가

## Prerequisites
- GitHub repository secrets에 `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY` 추가 완료