### PR TITLE
Dual-write 활성화 및 Supabase 백필 갭 복구

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -25,6 +25,7 @@ jobs:
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_DUAL_WRITE_ENABLED: ${{ secrets.VITE_DUAL_WRITE_ENABLED }}
           VITE_READ_SOURCE: ${{ secrets.VITE_READ_SOURCE }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
## Summary
- CI 빌드에 `VITE_DUAL_WRITE_ENABLED` 환경변수가 누락되어 프로덕션에서 Supabase dual-write가 한 번도 활성화되지 않았음
- 결과: Supabase 데이터가 백필 완료 시점(Jan 16) 이후 23일간 동기화되지 않음
- `backfill-gap.ts` 타임스탬프를 마지막 동기화 시점으로 업데이트하여 갭 데이터 복구 준비

## Changes
- `firebase-hosting-merge.yml`: `VITE_DUAL_WRITE_ENABLED` secret 전달 추가
- `backfill-gap.ts`: `EXPORT_COMPLETED_AT`를 `2026-01-16T15:06:37Z`로 변경

## After merge
1. 배포 완료 후 dual-write 자동 활성화 (신규 데이터 동기화 시작)
2. 별도 터미널에서 백필 실행: `npx tsx scripts/migration/backfill-gap.ts --dry-run`
3. dry-run 확인 후: `npx tsx scripts/migration/backfill-gap.ts`
4. shadow 모드에서 24-48시간 모니터링 후 `VITE_READ_SOURCE=supabase` 전환

## Test plan
- [ ] dry-run으로 누락 건수 확인
- [ ] 백필 실행 후 Supabase 최신 post 날짜 확인
- [ ] shadow 모드에서 Sentry mismatch 없음 확인