### PR TITLE
Phase 6: Supabase 읽기 전환 시작

### DIFF
--- a/docs/plan_and_review/migration_progress.md
+++ b/docs/plan_and_review/migration_progress.md
@@ -282,7 +282,7 @@ Shadow reads allow comparing Firestore and Supabase query results during migrati
 
 **Implemented**: 2026-02-10
 
-Shadow reads detected **60 unresolved Sentry issues** — data in Firestore fan-out collections missing from Supabase tables.
+Shadow reads detected **60+ unresolved Sentry issues** (62 at final count) — data in Firestore fan-out collections missing from Supabase tables.
 
 **Root causes identified:**
 1. **Primary**: `VITE_DUAL_WRITE_ENABLED` was missing from CI until Feb 8 (commit `93437eb5`). Dual write never ran in production for ~3 weeks (Jan 16 → Feb 8).


### PR DESCRIPTION
## Summary
- Shadow read 불일치 62건 분석: 모두 false positive (삭제된 댓글/답글의 orphaned fan-out 엔트리)
- `VITE_READ_SOURCE` GitHub secret을 `supabase`로 변경 완료
- 마이그레이션 문서 Phase 6 진행 상황 반영

## Context
Shadow read에서 Firestore fan-out (`commentings`, `replyings`, `postings`)과 Supabase SQL 쿼리를 비교한 결과, 불일치의 원인은 삭제된 댓글/답글의 fan-out 잔존 엔트리였음. Supabase 쿼리가 더 정확한 결과를 반환.

## Test plan
- [ ] Merge 후 CI 배포 확인
- [ ] 배포 후 주요 페이지 정상 동작 확인 (게시글 목록, 댓글, 답글, 통계)
- [ ] 문제 발생 시 `VITE_READ_SOURCE=firestore`로 롤백