### PR TITLE
perf: batch Supabase queries to eliminate N+1 round-trips on stats page

### DIFF
--- a/src/shared/api/supabaseReads.ts
+++ b/src/shared/api/supabaseReads.ts
@@ -994,6 +994,61 @@ export async function fetchNotificationsFromSupabase(
   }));
 }
 
+// --- Batch Comment/Reply Counts (for stats aggregation) ---
+
+export interface CommentCountRow {
+  user_id: string;
+  created_at: string;
+}
+
+/**
+ * Batch-fetch comment rows for multiple users within a date range.
+ * Returns only user_id + created_at — no JOINs needed since stats only count per day.
+ * Uses index: idx_comments_user_created
+ */
+export async function fetchBatchCommentCountsByDateRange(
+  userIds: string[],
+  start: Date,
+  end: Date
+): Promise<CommentCountRow[]> {
+  if (userIds.length === 0) return [];
+  const supabase = getSupabaseClient();
+
+  const { data, error } = await supabase
+    .from('comments')
+    .select('user_id, created_at')
+    .in('user_id', userIds)
+    .gte('created_at', start.toISOString())
+    .lt('created_at', end.toISOString());
+
+  if (error) throw error;
+  return (data || []) as CommentCountRow[];
+}
+
+/**
+ * Batch-fetch reply rows for multiple users within a date range.
+ * Returns only user_id + created_at — no JOINs needed since stats only count per day.
+ * Uses index: idx_replies_user_created
+ */
+export async function fetchBatchReplyCountsByDateRange(
+  userIds: string[],
+  start: Date,
+  end: Date
+): Promise<CommentCountRow[]> {
+  if (userIds.length === 0) return [];
+  const supabase = getSupabaseClient();
+
+  const { data, error } = await supabase
+    .from('replies')
+    .select('user_id, created_at')
+    .in('user_id', userIds)
+    .gte('created_at', start.toISOString())
+    .lt('created_at', end.toISOString());
+
+  if (error) throw error;
+  return (data || []) as CommentCountRow[];
+}
+
 // --- Activity Counts ---
 
 export interface ActivityCounts {


### PR DESCRIPTION
## Summary

- Replace per-user commenting stats queries (2N round-trips with `posts!inner` JOINs) with **2 batch queries** using PostgREST `.in()` filter and **no JOINs**
- Add `fetchBatchCommentCountsByDateRange` / `fetchBatchReplyCountsByDateRange` that select only `user_id` + `created_at` (stats only need these fields to count per day)
- Refactor `useCommentingStats` and `useCurrentUserCommentingStats` to use batch functions with client-side grouping

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Queries (30 users) | 60 (with JOINs) | 2 (no JOINs) |
| Data transferred | Full rows + post data | `user_id` + `created_at` only |
| SQL migration | — | None needed |

## What's preserved

- `fetchCommentingsByDateRangeFromSupabase` / `fetchReplyingsByDateRangeFromSupabase` — still used by `usePostProfileBadges` → `fetchCommentingData`
- `createUserCommentingStats` / `aggregateCommentingContributions` — still used by the same path
- `fetchActivityCountsFromSupabase` — unchanged (lower priority, deferred)

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run test:run` — all 445 tests pass
- [ ] Load Stats page with 10+ users → DevTools Network: expect 2 requests (comments + replies) with `user_id=in.(...)` filter instead of 2N individual requests
- [ ] Spot-check 2-3 user stats match previous values


🤖 Generated with [Claude Code](https://claude.com/claude-code)