### PR TITLE
perf: 게시판 페이지 N+1 쿼리를 배치 쿼리로 전환

### DIFF
--- a/src/board/components/RecentPostCardList.tsx
+++ b/src/board/components/RecentPostCardList.tsx
@@ -120,6 +120,7 @@ const RecentPostCardList: React.FC<RecentPostCardListProps> = ({ boardId, onPost
           onClick={() => handlePostClick(post.id)}
           onClickProfile={onClickProfile}
           prefetchedData={batchData?.get(post.authorId)}
+          isBatchMode={!!batchData}
         />
       ))}
       <div ref={inViewRef} />

--- a/src/post/components/PostCard.tsx
+++ b/src/post/components/PostCard.tsx
@@ -15,6 +15,7 @@ interface PostCardProps {
   onClick: (postId: string) => void;
   onClickProfile?: (userId: string) => void;
   prefetchedData?: PostCardPrefetchedData;
+  isBatchMode?: boolean;
 }
 
 function handleKeyDown(e: React.KeyboardEvent, onClick: (e: React.KeyboardEvent | React.MouseEvent) => void) {
@@ -24,7 +25,7 @@ function handleKeyDown(e: React.KeyboardEvent, onClick: (e: React.KeyboardEvent 
   }
 }
 
-const PostCard: React.FC<PostCardProps> = ({ post, onClick, onClickProfile, prefetchedData }) => {
+const PostCard: React.FC<PostCardProps> = ({ post, onClick, onClickProfile, prefetchedData, isBatchMode }) => {
   const {
     authorData,
     isAuthorLoading,
@@ -33,7 +34,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick, onClickProfile, pref
     isStreakLoading,
     isPrivate,
     contentPreview,
-  } = usePostCard(post, prefetchedData);
+  } = usePostCard(post, prefetchedData, isBatchMode);
 
   const handleCardClick = () => {
     onClick(post.id);


### PR DESCRIPTION
## Summary
- PostCard마다 개별 유저/뱃지/스트릭 Supabase 쿼리가 발생하던 N+1 문제 해결
- 리스트 레벨에서 `.in()` 배치 쿼리로 일괄 조회 후 하위 컴포넌트에 전달
- 7개 게시글 기준 ~28 requests → 4 requests로 감소

## Changes
- `supabaseReads.ts`: 배치 조회 함수 4종 추가 (users, comments, replies, posts)
- `useBatchPostCardData.ts`: 리스트 레벨 배치 훅 신규 생성
- `RecentPostCardList.tsx`: 배치 훅 호출 및 데이터 전달
- `PostCard.tsx` / `usePostCard.ts`: prefetchedData 수용, 개별 훅 비활성화

## Test plan
- [x] `tsc --noEmit` 통과
- [ ] 게시판 페이지 진입 후 Network 탭에서 개별 유저/뱃지/스트릭 쿼리 사라짐 확인
- [ ] PostCard에 작성자 이름, 프로필 사진, 뱃지, 스트릭 정상 표시 확인

## Related
- Sentry Issue #7279529937: N+1 User Fetching on Board Load