### PR TITLE
join 폼 제출 시 에러 메시지를 구체적으로 분리

### DIFF
--- a/src/login/components/JoinFormPageForActiveUser.tsx
+++ b/src/login/components/JoinFormPageForActiveUser.tsx
@@ -30,7 +30,7 @@ export default function JoinFormPageForActiveUser() {
      */
     const handleSubmit = async (data: JoinFormDataForActiveUser) => {
       if (!currentUser?.uid) {
-        showErrorToast(toast, new Error("로그인 상태가 만료되었습니다. 다시 로그인해주세요."));
+        toast.error("로그인 상태가 만료되었습니다. 다시 로그인해주세요.");
         return;
       }
       if (!upcomingBoard?.id) {

--- a/src/login/components/JoinFormPageForNewUser.tsx
+++ b/src/login/components/JoinFormPageForNewUser.tsx
@@ -31,7 +31,7 @@ export default function JoinFormPageForNewUser() {
      */
     const handleSubmit = async (data: JoinFormDataForNewUser) => {
         if (!currentUser?.uid) {
-            showErrorToast(toast, new Error("로그인 상태가 만료되었습니다. 다시 로그인해주세요."));
+            toast.error("로그인 상태가 만료되었습니다. 다시 로그인해주세요.");
             return;
         }
         if (!upcomingBoard?.id) {


### PR DESCRIPTION
## Summary
- 모바일 Safari에서 Firebase Auth 상태가 유실된 채로 join 폼 제출 시, "필수 정보가 누락되었습니다"라는 모호한 에러가 표시되던 문제 수정
- 인증 만료와 보드 정보 누락을 분리하여 각각 원인에 맞는 안내 메시지 제공
- `JoinFormPageForActiveUser`, `JoinFormPageForNewUser` 양쪽에 동일하게 적용

## Test plan
- [ ] /join/form/active-user 에서 정상 제출 동작 확인
- [ ] /join/form/new-user 에서 정상 제출 동작 확인
- [ ] Auth 상태 유실 시 "로그인 상태가 만료되었습니다" 메시지 확인