### PR TITLE
사용자 승인/거부를 Supabase 단독 쓰기로 전환

### DIFF
--- a/apps/admin/src/app/admin/user-approval/page.tsx
+++ b/apps/admin/src/app/admin/user-approval/page.tsx
@@ -167,13 +167,13 @@ export default function UserApprovalPage() {
     onSuccess: (userId) => {
       // 캐시 데이터 업데이트
       queryClient.invalidateQueries({ queryKey: ['board', selectedBoardId] })
-      
+
       // 대기 중인 사용자 목록에서 해당 사용자 제거
-      queryClient.setQueryData(['waitingUsers', selectedBoardId], (oldData: WaitingUser[] | undefined) => {
+      queryClient.setQueryData(['waitingUsers', selectedBoardId, selectedBoard?.cohort], (oldData: WaitingUser[] | undefined) => {
         if (!oldData) return []
         return oldData.filter(user => user.id !== userId)
       })
-      
+
       toast.success("사용자에게 게시판 접근 권한이 부여되었습니다.")
     },
     onError: (error) => {
@@ -201,13 +201,13 @@ export default function UserApprovalPage() {
     onSuccess: (userId) => {
       // 캐시 데이터 업데이트
       queryClient.invalidateQueries({ queryKey: ['board', selectedBoardId] })
-      
+
       // 대기 중인 사용자 목록에서 해당 사용자 제거
-      queryClient.setQueryData(['waitingUsers', selectedBoardId], (oldData: WaitingUser[] | undefined) => {
+      queryClient.setQueryData(['waitingUsers', selectedBoardId, selectedBoard?.cohort], (oldData: WaitingUser[] | undefined) => {
         if (!oldData) return []
         return oldData.filter(user => user.id !== userId)
       })
-      
+
       toast.success("사용자의 게시판 가입 요청이 거부되었습니다.")
     },
     onError: (error) => {


### PR DESCRIPTION
## Summary
- 관리자 페이지의 사용자 승인/거부 기능이 Firestore에 쓰기를 시도하여 에러 발생 (마이그레이션 후 board 문서 부재)
- Firestore dual-write를 제거하고 Supabase를 단독 쓰기 대상으로 전환
- 읽기는 이미 Supabase로 전환되어 있었으므로 쓰기도 통일

## Test plan
- [ ] 관리자 페이지에서 사용자 승인 버튼 클릭 시 에러 없이 동작 확인
- [ ] 승인 후 `user_board_permissions` 테이블에 write 권한 추가 확인
- [ ] 승인 후 `board_waiting_users` 테이블에서 해당 사용자 제거 확인
- [ ] 사용자 거부 버튼 클릭 시 에러 없이 동작 확인