### PR TITLE
좋아요 알림 메시지를 '공감했어요'로 변경

### DIFF
--- a/supabase/functions/_shared/notificationMessages.ts
+++ b/supabase/functions/_shared/notificationMessages.ts
@@ -26,7 +26,7 @@ export function buildNotificationMessage(
     case 'comment_on_post':
       return `${actorName}님이 '${preview}' 글에 댓글을 달았어요.`;
     case 'like_on_post':
-      return `${actorName}님이 '${preview}' 글에 좋아요를 눌렀어요.`;
+      return `${actorName}님이 '${preview}' 글에 공감했어요.`;
     case 'reply_on_post':
       return `${actorName}님이 '${preview}' 글에 답글을 달았어요.`;
     case 'reply_on_comment':

--- a/supabase/functions/tests/notification-messages-test.ts
+++ b/supabase/functions/tests/notification-messages-test.ts
@@ -13,7 +13,7 @@ Deno.test('buildNotificationMessage', async (t) => {
 
   await t.step('like_on_post: 글에 좋아요 메시지 생성', () => {
     const result = buildNotificationMessage('like_on_post', '김철수', '멋진 하루');
-    assertEquals(result, "김철수님이 '멋진 하루' 글에 좋아요를 눌렀어요.");
+    assertEquals(result, "김철수님이 '멋진 하루' 글에 공감했어요.");
   });
 
   await t.step('reply_on_post: 글에 답글 메시지 생성', () => {
@@ -50,7 +50,7 @@ Deno.test('buildNotificationMessage', async (t) => {
 
   await t.step('빈 콘텐츠 처리', () => {
     const result = buildNotificationMessage('like_on_post', '유저', '');
-    assertEquals(result, "유저님이 '' 글에 좋아요를 눌렀어요.");
+    assertEquals(result, "유저님이 '' 글에 공감했어요.");
   });
 
   await t.step('빈 actorName 처리', () => {


### PR DESCRIPTION
## Summary
- 좋아요 알림 메시지를 `글에 좋아요를 눌렀어요` → `글에 공감했어요`로 변경
- 앱의 톤앤매너에 더 적합한 표현으로 개선

## Test plan
- [x] Deno 테스트 통과 확인 (14 steps all pass)
- [x] Edge function 배포 완료 (`create-notification`)