### PR TITLE
fetchUser 네트워크 에러와 permission-denied 분리

### DIFF
--- a/apps/web/src/board/hooks/useBoardLoader.ts
+++ b/apps/web/src/board/hooks/useBoardLoader.ts
@@ -1,5 +1,6 @@
 import { FirebaseError } from 'firebase/app';
 import type { LoaderFunctionArgs } from 'react-router-dom';
+import { SupabaseNetworkError } from '@/shared/api/supabaseClient';
 import { getCurrentUser } from '@/shared/utils/authUtils';
 import { trackFirebasePermissionError, getPermissionErrorHints } from '@/shared/utils/firebaseErrorTracking';
 import { getCurrentUserIdFromStorage } from '@/shared/utils/getCurrentUserId';
@@ -32,7 +33,7 @@ export async function boardLoader({ params }: LoaderFunctionArgs) {
         path: `users/${user.uid}`,
         userId: user.uid,
         additionalInfo: {
-          reason: 'User document not found in Firestore',
+          reason: 'User document not found in Supabase',
           boardId,
         },
       });
@@ -90,6 +91,9 @@ export async function boardLoader({ params }: LoaderFunctionArgs) {
 
     if (error instanceof Response) {
       throw error; // Re-throw Response errors (permission/auth errors)
+    }
+    if (error instanceof SupabaseNetworkError) {
+      throw new Response('네트워크 연결을 확인하고 다시 시도해주세요.', { status: 503 });
     }
     throw new Response('Board access validation failed', { status: 500 });
   }

--- a/apps/web/src/post/hooks/usePostDetailLoader.ts
+++ b/apps/web/src/post/hooks/usePostDetailLoader.ts
@@ -1,5 +1,6 @@
 import type { LoaderFunctionArgs } from 'react-router-dom';
 import { fetchPost } from '@/post/utils/postUtils';
+import { SupabaseNetworkError } from '@/shared/api/supabaseClient';
 import { getCurrentUser } from '@/shared/utils/authUtils';
 import { fetchUser } from '@/user/api/user';
 
@@ -39,6 +40,9 @@ export async function postDetailLoader({ params }: LoaderFunctionArgs) {
     console.error('Failed to fetch post:', error);
     if (error instanceof Response) {
       throw error; // Re-throw Response errors (permission/auth errors)
+    }
+    if (error instanceof SupabaseNetworkError) {
+      throw new Response('네트워크 연결을 확인하고 다시 시도해주세요.', { status: 503 });
     }
     throw new Response('Post not found', { status: 404 });
   }

--- a/apps/web/src/shared/api/supabaseClient.test.ts
+++ b/apps/web/src/shared/api/supabaseClient.test.ts
@@ -1,5 +1,6 @@
+import type { PostgrestError } from '@supabase/supabase-js';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { throwOnError, executeTrackedWrite, SupabaseWriteError } from './supabaseClient';
+import { throwOnError, executeTrackedWrite, SupabaseWriteError, SupabaseNetworkError, isNetworkError } from './supabaseClient';
 
 const mockSetContext = vi.fn();
 const mockSetFingerprint = vi.fn();
@@ -145,6 +146,58 @@ describe('throwOnError', () => {
 
     expect(mockSetFingerprint).not.toHaveBeenCalled();
   });
+
+  it('throws SupabaseNetworkError for "Load failed" with empty code', () => {
+    const networkError = {
+      message: 'TypeError: Load failed',
+      code: '',
+      details: '@https://example.com/assets/index.js:1270:7060',
+      hint: '',
+    };
+
+    expect(() => throwOnError({ error: networkError }, 'createComment')).toThrow(SupabaseNetworkError);
+  });
+
+  it('does not captureException for network errors', () => {
+    const networkError = {
+      message: 'TypeError: Load failed',
+      code: '',
+      details: '',
+      hint: '',
+    };
+
+    expect(() => throwOnError({ error: networkError })).toThrow(SupabaseNetworkError);
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(addSentryBreadcrumb).toHaveBeenCalledWith(
+      'Supabase network error',
+      'supabase.write',
+      expect.objectContaining({ message: 'TypeError: Load failed' }),
+      'warning',
+    );
+  });
+
+  it('throws SupabaseNetworkError for "Failed to fetch" with empty code', () => {
+    const networkError = {
+      message: 'TypeError: Failed to fetch',
+      code: '',
+      details: '',
+      hint: '',
+    };
+
+    expect(() => throwOnError({ error: networkError })).toThrow(SupabaseNetworkError);
+  });
+
+  it('throws SupabaseWriteError (not network error) when code is present', () => {
+    const dbError = {
+      message: 'Load failed',
+      code: '23505',
+      details: '',
+      hint: '',
+    };
+
+    expect(() => throwOnError({ error: dbError })).toThrow(SupabaseWriteError);
+  });
 });
 
 describe('executeTrackedWrite', () => {
@@ -201,4 +254,39 @@ describe('executeTrackedWrite', () => {
 
     consoleSpy.mockRestore();
   }, 5000);
+});
+
+describe('isNetworkError', () => {
+  it('returns true for "Load failed" with empty code', () => {
+    expect(isNetworkError({ message: 'TypeError: Load failed', code: '', details: '', hint: '' } as PostgrestError)).toBe(true);
+  });
+
+  it('returns true for "Failed to fetch" with empty code', () => {
+    expect(isNetworkError({ message: 'TypeError: Failed to fetch', code: '', details: '', hint: '' } as PostgrestError)).toBe(true);
+  });
+
+  it('returns true for "NetworkError" with empty code', () => {
+    expect(isNetworkError({ message: 'NetworkError when attempting to fetch resource', code: '', details: '', hint: '' } as PostgrestError)).toBe(true);
+  });
+
+  it('returns false when error has a code', () => {
+    expect(isNetworkError({ message: 'Load failed', code: '23505', details: '', hint: '' } as PostgrestError)).toBe(false);
+  });
+
+  it('returns false for non-network error messages', () => {
+    expect(isNetworkError({ message: 'duplicate key violation', code: '', details: '', hint: '' } as PostgrestError)).toBe(false);
+  });
+});
+
+describe('SupabaseNetworkError', () => {
+  it('message does not contain "write"', () => {
+    const error = new SupabaseNetworkError({ message: 'Load failed', code: '', details: '', hint: '' } as PostgrestError);
+    expect(error.message).not.toContain('write');
+  });
+
+  it('message contains the original error message', () => {
+    const error = new SupabaseNetworkError({ message: 'Load failed', code: '', details: '', hint: '' } as PostgrestError);
+    expect(error.message).toContain('Load failed');
+    expect(error.message).toContain('Supabase network error');
+  });
 });

--- a/apps/web/src/shared/api/supabaseClient.ts
+++ b/apps/web/src/shared/api/supabaseClient.ts
@@ -58,12 +58,42 @@ export class SupabaseWriteError extends Error {
   }
 }
 
+export class SupabaseNetworkError extends Error {
+  constructor(public readonly postgrestError: PostgrestError) {
+    super(`Supabase network error: ${postgrestError.message}`);
+    this.name = 'SupabaseNetworkError';
+  }
+}
+
+const NETWORK_ERROR_PATTERNS = [
+  'Load failed',
+  'Failed to fetch',
+  'NetworkError',
+  'network error',
+  'cancelled',
+  'AbortError',
+];
+
+export function isNetworkError(error: PostgrestError): boolean {
+  return !error.code && NETWORK_ERROR_PATTERNS.some((p) => error.message.includes(p));
+}
+
 /** Execute a Supabase operation and throw on error, reporting to Sentry if an error occurs */
 export function throwOnError(
   result: { error: PostgrestError | null },
   operation?: string,
 ): void {
   if (result.error) {
+    if (isNetworkError(result.error)) {
+      addSentryBreadcrumb(
+        operation ? `Supabase network error: ${operation}` : 'Supabase network error',
+        'supabase.write',
+        { message: result.error.message, operation },
+        'warning',
+      );
+      throw new SupabaseNetworkError(result.error);
+    }
+
     const writeError = new SupabaseWriteError(result.error);
 
     addSentryBreadcrumb(

--- a/apps/web/src/shared/api/supabaseReads.ts
+++ b/apps/web/src/shared/api/supabaseReads.ts
@@ -7,7 +7,7 @@
  *   idx_replies_comment_created, idx_permissions_user
  */
 
-import { getSupabaseClient } from './supabaseClient';
+import { getSupabaseClient, isNetworkError, SupabaseNetworkError } from './supabaseClient';
 import type { Board } from '@/board/model/Board';
 import type { Post } from '@/post/model/Post';
 import { PostVisibility } from '@/post/model/Post';
@@ -691,33 +691,51 @@ export async function fetchUserFromSupabase(uid: string): Promise<User | null> {
     .eq('id', uid)
     .single();
 
-  if (error || !data) {
-    if (error?.code !== 'PGRST116') {
-      console.error('Supabase fetchUser error:', error);
+  if (error) {
+    if (isNetworkError(error)) {
+      throw new SupabaseNetworkError(error);
     }
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    console.error('Supabase fetchUser error:', error);
+    throw error;
+  }
+
+  if (!data) {
     return null;
   }
 
   // Fetch board permissions
-  const { data: permData } = await supabase
+  const { data: permData, error: permError } = await supabase
     .from('user_board_permissions')
     .select('board_id, permission')
     .eq('user_id', uid);
+
+  if (permError) {
+    if (isNetworkError(permError)) {
+      throw new SupabaseNetworkError(permError);
+    }
+    console.error('Supabase fetchUser board permissions error:', permError);
+    throw permError;
+  }
 
   const boardPermissions: Record<string, 'read' | 'write'> = {};
   for (const p of permData || []) {
     boardPermissions[p.board_id] = p.permission as 'read' | 'write';
   }
 
-  // Fetch known buddy info if exists
+  // Fetch known buddy info if exists (optional — log and continue on failure)
   let knownBuddy: User['knownBuddy'] = undefined;
   if (data.known_buddy_uid) {
-    const { data: buddyData } = await supabase
+    const { data: buddyData, error: buddyError } = await supabase
       .from('users')
       .select('id, nickname, profile_photo_url')
       .eq('id', data.known_buddy_uid)
       .single();
-    if (buddyData) {
+    if (buddyError) {
+      console.error('Supabase fetchUser knownBuddy error:', buddyError);
+    } else if (buddyData) {
       knownBuddy = {
         uid: buddyData.id,
         nickname: buddyData.nickname,

--- a/apps/web/src/shared/components/PermissionErrorBoundary.tsx
+++ b/apps/web/src/shared/components/PermissionErrorBoundary.tsx
@@ -8,12 +8,39 @@ import {
   AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogAction,
+  AlertDialogCancel,
 } from '@/shared/ui/alert-dialog';
 
 export function PermissionErrorBoundary() {
   const error = useRouteError();
   const navigate = useNavigate();
   const [open, setOpen] = React.useState(true);
+
+  // Check if it's a 503 network error
+  if (isRouteErrorResponse(error) && error.status === 503) {
+    return (
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>네트워크 오류</AlertDialogTitle>
+            <AlertDialogDescription>
+              {typeof error.data === 'string' ? error.data : '네트워크 연결에 문제가 있어요.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => {
+              setOpen(false);
+              navigate('/boards', { replace: true });
+            }}>홈으로</AlertDialogCancel>
+            <AlertDialogAction onClick={() => {
+              setOpen(false);
+              window.location.reload();
+            }}>다시 시도</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
 
   // Check if it's a 403 permission error
   if (isRouteErrorResponse(error) && error.status === 403) {

--- a/apps/web/src/user/components/BlockedUsersPage.tsx
+++ b/apps/web/src/user/components/BlockedUsersPage.tsx
@@ -119,10 +119,22 @@ export default function BlockedUsersPage() {
         return;
       }
       // 차단 유저 정보 fetch
-      const users = await Promise.all(
+      const results = await Promise.allSettled(
         blockedUids.map(uid => fetchUser(uid))
       );
-      setBlockedUsers(users.filter(Boolean));
+      const rejectedCount = results.filter(r => r.status === 'rejected').length;
+      const users = results
+        .filter((r): r is PromiseFulfilledResult<User | null> => r.status === 'fulfilled')
+        .map(r => r.value)
+        .filter((u): u is User => u !== null);
+      if (rejectedCount > 0 && users.length > 0) {
+        toast.warning(`차단된 사용자 ${rejectedCount}명의 정보를 불러오지 못했습니다.`);
+      }
+      if (users.length === 0 && rejectedCount === results.length) {
+        toast.error('차단된 사용자 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.');
+        return;
+      }
+      setBlockedUsers(users);
     })();
   }, [currentUser]);
 


### PR DESCRIPTION
## Summary
- `fetchUserFromSupabase`가 네트워크 에러 시 `null` 대신 `SupabaseNetworkError`를 throw하도록 변경 (primary + permissions + buddy 서브쿼리)
- `boardLoader`/`postDetailLoader`에서 `SupabaseNetworkError` catch → 503 Response로 변환
- `PermissionErrorBoundary`에 503 전용 UI 추가 ("다시 시도" + "홈으로" 버튼)
- `BlockedUsersPage`에서 `Promise.all` → `Promise.allSettled`로 개별 실패 격리
- `isNetworkError` export + `SupabaseNetworkError` 메시지에서 "write" 제거 (읽기/쓰기 공통 사용)

## Why
- iOS Safari "Load failed" 네트워크 에러가 `permission-denied`로 잘못 분류되어 Sentry 노이즈 발생 (#6943148177, #6881999577)
- permissions 서브쿼리 실패 시 `boardPermissions = {}` → loader가 권한 없음으로 오판하는 버그 존재

## Test plan
- [x] `npx vitest run supabaseClient.test.ts` — 24/24 pass
- [x] `npx tsc --noEmit` — clean
- [ ] iOS Safari에서 네트워크 끊고 보드 접근 → "네트워크 오류" dialog 확인
- [ ] 정상 네트워크에서 권한 없는 보드 접근 → 기존 "읽기 권한 없음" dialog 유지 확인