### PR TITLE
security: service_role_key를 Supabase Vault로 이전

### DIFF
--- a/supabase/migrations/20260326000000_migrate_service_role_key_to_vault.sql
+++ b/supabase/migrations/20260326000000_migrate_service_role_key_to_vault.sql
@@ -7,8 +7,8 @@
 --   vault.secrets encrypts at rest and provides audit-friendly access.
 --
 -- If app_config already contains service_role_key, the migration moves it
--- to vault automatically. If not, the migration will fail — you must populate
--- app_config first or create the vault secret manually:
+-- to vault automatically. If not, it skips vault creation and prints a
+-- NOTICE — the operator must create the vault secret manually afterward:
 --   SELECT vault.create_secret('<your-service-role-key>', 'service_role_key');
 
 -- =============================================
@@ -39,10 +39,9 @@ BEGIN
     WHERE key = 'service_role_key';
 
     IF _existing_key IS NULL THEN
-      RAISE EXCEPTION
-        'service_role_key is not set in app_config and no existing vault secret was found. '
-        'Set app_config.key = ''service_role_key'' to a valid value, or manually create the '
-        'vault secret with vault.create_secret before re-running this migration.';
+      RAISE NOTICE
+        'service_role_key is not set in app_config — skipping vault secret creation. '
+        'Create it manually: SELECT vault.create_secret(''<your-key>'', ''service_role_key'');';
     ELSE
       -- vault.create_secret signature: (secret, name, description)
       PERFORM vault.create_secret(


### PR DESCRIPTION
## Summary
- `app_config` 테이블의 평문 `service_role_key`를 `vault.secrets`로 이전
- `get_app_config()` 함수가 `service_role_key` 요청 시 `vault.decrypted_secrets`에서 읽도록 변경
- 기존 알림 트리거(`notify_on_comment`, `notify_on_reply` 등)는 변경 없이 동작

### 동작 방식
- **운영 환경**: `app_config`에 `service_role_key`가 있으면 자동으로 vault로 이전
- **신규/로컬 환경**: 키가 없으면 NOTICE 출력 후 계속 진행. 운영자가 수동으로 vault secret 생성:
  ```sql
  SELECT vault.create_secret('<actual-key>', 'service_role_key');
  ```

### 보안 강화 사항
- `SECURITY DEFINER` 함수에 `SET search_path = public, vault` 적용
- `public.app_config`으로 schema-qualify하여 search_path injection 방지
- vault 쓰기 후 `decrypted_secrets` 검증 추가 (silent failure 방지)
- 이전 마이그레이션의 obsolete 안내 주석 추가

## Verification (local Supabase)

| Query | Result |
|-------|--------|
| `get_app_config('service_role_key')` | `test-key-for-vault-migration` (reads from vault) |
| `get_app_config('edge_function_url')` | `null` (falls back to `app_config`) |
| `COUNT(*) FROM app_config WHERE key = 'service_role_key'` | `0` (deleted) |
| `supabase db reset` | Passes with NOTICE (no key → skips vault creation) |

## Test plan
- [x] `supabase db reset` 성공 (NOTICE 출력 확인)
- [x] vault에서 키 조회 확인 (`get_app_config('service_role_key')`)
- [x] `app_config` fallback 동작 확인 (`get_app_config('edge_function_url')`)
- [x] `app_config`에서 `service_role_key` 행 삭제 확인
- [ ] 운영 환경 알림 트리거 정상 동작 확인 (배포 후)

Closes #527