### PR TITLE
Sentry 성능 모니터링 체계 구축

### DIFF
--- a/apps/web/src/board/components/test/BoardListPage.test.tsx
+++ b/apps/web/src/board/components/test/BoardListPage.test.tsx
@@ -20,6 +20,9 @@ vi.mock('@sentry/react', () => ({
   captureException: vi.fn(),
   withScope: vi.fn((cb: (scope: Record<string, unknown>) => void) => cb({ setContext: vi.fn(), setFingerprint: vi.fn() })),
   addBreadcrumb: vi.fn(),
+  startSpan: vi.fn((_ctx: unknown, cb: () => unknown) => cb()),
+  wrapCreateBrowserRouterV6: vi.fn((createRouter: unknown) => createRouter),
+  reactRouterV6BrowserTracingIntegration: vi.fn(),
 }));
 
 // react-router-dom: Link만 mock, 나머지는 실제 모듈 사용

--- a/apps/web/src/board/hooks/useBoardLoader.ts
+++ b/apps/web/src/board/hooks/useBoardLoader.ts
@@ -26,7 +26,7 @@ export async function boardLoader({ params }: LoaderFunctionArgs) {
     }
 
     // Check board permissions before allowing access
-    const userData = await Sentry.startSpan({ name: 'fetchUser', op: 'db.query', attributes: { userId: user.uid } }, () => fetchUser(user.uid));
+    const userData = await Sentry.startSpan({ name: 'fetchUser', op: 'db.query' }, () => fetchUser(user.uid));
     if (!userData) {
       // Track permission error for missing user data
       const permissionError = new FirebaseError('permission-denied', 'User data not found');

--- a/apps/web/src/board/hooks/useBoardLoader.ts
+++ b/apps/web/src/board/hooks/useBoardLoader.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import { FirebaseError } from 'firebase/app';
 import type { LoaderFunctionArgs } from 'react-router-dom';
 import { SupabaseNetworkError } from '@/shared/api/supabaseClient';
@@ -15,8 +16,9 @@ export async function boardLoader({ params }: LoaderFunctionArgs) {
   }
 
   try {
+    return await Sentry.startSpan({ name: 'boardLoader', op: 'route.loader', attributes: { boardId } }, async () => {
     // Get current user
-    const user = await getCurrentUser();
+    const user = await Sentry.startSpan({ name: 'getCurrentUser', op: 'auth' }, () => getCurrentUser());
 
     if (!user) {
       // Route guard (PrivateRoutes) will redirect to /login
@@ -24,7 +26,7 @@ export async function boardLoader({ params }: LoaderFunctionArgs) {
     }
 
     // Check board permissions before allowing access
-    const userData = await fetchUser(user.uid);
+    const userData = await Sentry.startSpan({ name: 'fetchUser', op: 'db.query', attributes: { userId: user.uid } }, () => fetchUser(user.uid));
     if (!userData) {
       // Track permission error for missing user data
       const permissionError = new FirebaseError('permission-denied', 'User data not found');
@@ -73,6 +75,7 @@ export async function boardLoader({ params }: LoaderFunctionArgs) {
     }
 
     return { boardId };
+    });
   } catch (error) {
     console.error('Failed to validate board access:', error);
 

--- a/apps/web/src/board/hooks/useBoardLoader.ts
+++ b/apps/web/src/board/hooks/useBoardLoader.ts
@@ -17,64 +17,64 @@ export async function boardLoader({ params }: LoaderFunctionArgs) {
 
   try {
     return await Sentry.startSpan({ name: 'boardLoader', op: 'route.loader', attributes: { boardId } }, async () => {
-    // Get current user
-    const user = await Sentry.startSpan({ name: 'getCurrentUser', op: 'auth' }, () => getCurrentUser());
+      // Get current user
+      const user = await Sentry.startSpan({ name: 'getCurrentUser', op: 'auth' }, () => getCurrentUser());
 
-    if (!user) {
-      // Route guard (PrivateRoutes) will redirect to /login
-      return { boardId };
-    }
-
-    // Check board permissions before allowing access
-    const userData = await Sentry.startSpan({ name: 'fetchUser', op: 'db.query' }, () => fetchUser(user.uid));
-    if (!userData) {
-      // Track permission error for missing user data
-      const permissionError = new FirebaseError('permission-denied', 'User data not found');
-      trackFirebasePermissionError(permissionError, {
-        operation: 'read',
-        path: `users/${user.uid}`,
-        userId: user.uid,
-        additionalInfo: {
-          reason: 'User document not found in Supabase',
-          boardId,
-        },
-      });
-
-      throw new Response('User data not found', { status: 403 });
-    }
-
-    const userPermission = userData.boardPermissions?.[boardId];
-    if (userPermission !== 'read' && userPermission !== 'write') {
-      // Track permission error for insufficient board permissions
-      const permissionError = new FirebaseError('permission-denied', 'Insufficient board permissions');
-      trackFirebasePermissionError(permissionError, {
-        operation: 'read',
-        path: `boards/${boardId}`,
-        userId: user.uid,
-        additionalInfo: {
-          reason: 'User lacks read/write permission for board',
-          userPermission: userPermission || 'none',
-          requiredPermission: 'read or write',
-          boardId,
-          availablePermissions: Object.keys(userData.boardPermissions || {}),
-        },
-      });
-
-      // Log hints for debugging
-      const hints = getPermissionErrorHints('boards', 'read');
-      if (hints) {
-        console.error('Board Permission Error - Debug Info:', {
-          boardId,
-          userId: user.uid,
-          currentPermission: userPermission || 'none',
-          ...hints,
-        });
+      if (!user) {
+        // Route guard (PrivateRoutes) will redirect to /login
+        return { boardId };
       }
 
-      throw new Response('Access denied - insufficient board permissions', { status: 403 });
-    }
+      // Check board permissions before allowing access
+      const userData = await Sentry.startSpan({ name: 'fetchUser', op: 'db.query' }, () => fetchUser(user.uid));
+      if (!userData) {
+        // Track permission error for missing user data
+        const permissionError = new FirebaseError('permission-denied', 'User data not found');
+        trackFirebasePermissionError(permissionError, {
+          operation: 'read',
+          path: `users/${user.uid}`,
+          userId: user.uid,
+          additionalInfo: {
+            reason: 'User document not found in Supabase',
+            boardId,
+          },
+        });
 
-    return { boardId };
+        throw new Response('User data not found', { status: 403 });
+      }
+
+      const userPermission = userData.boardPermissions?.[boardId];
+      if (userPermission !== 'read' && userPermission !== 'write') {
+        // Track permission error for insufficient board permissions
+        const permissionError = new FirebaseError('permission-denied', 'Insufficient board permissions');
+        trackFirebasePermissionError(permissionError, {
+          operation: 'read',
+          path: `boards/${boardId}`,
+          userId: user.uid,
+          additionalInfo: {
+            reason: 'User lacks read/write permission for board',
+            userPermission: userPermission || 'none',
+            requiredPermission: 'read or write',
+            boardId,
+            availablePermissions: Object.keys(userData.boardPermissions || {}),
+          },
+        });
+
+        // Log hints for debugging
+        const hints = getPermissionErrorHints('boards', 'read');
+        if (hints) {
+          console.error('Board Permission Error - Debug Info:', {
+            boardId,
+            userId: user.uid,
+            currentPermission: userPermission || 'none',
+            ...hints,
+          });
+        }
+
+        throw new Response('Access denied - insufficient board permissions', { status: 403 });
+      }
+
+      return { boardId };
     });
   } catch (error) {
     console.error('Failed to validate board access:', error);

--- a/apps/web/src/board/hooks/useBoardPostsLoader.ts
+++ b/apps/web/src/board/hooks/useBoardPostsLoader.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import type { LoaderFunctionArgs } from 'react-router-dom';
 import { fetchRecentPosts } from '@/post/api/post';
 import { getCurrentUser } from '@/shared/utils/authUtils';
@@ -11,9 +10,8 @@ export async function boardPostsLoader({ params }: LoaderFunctionArgs) {
     throw new Response('Missing boardId parameter', { status: 400 });
   }
 
-  return await Sentry.startSpan({ name: 'boardPostsLoader', op: 'route.loader', attributes: { boardId } }, async () => {
   // PrivateRoutes ensures user is authenticated before this runs
-  const currentUser = await Sentry.startSpan({ name: 'getCurrentUser', op: 'auth' }, () => getCurrentUser());
+  const currentUser = await getCurrentUser();
 
   if (!currentUser) {
     throw new Response('로그인 후 이용해주세요.', { status: 401 });
@@ -21,10 +19,10 @@ export async function boardPostsLoader({ params }: LoaderFunctionArgs) {
 
   try {
     // Get blocked users first
-    const blockedByUsers = await Sentry.startSpan({ name: 'getBlockedByUsers', op: 'db.query' }, () => getBlockedByUsers(currentUser.uid));
+    const blockedByUsers = await getBlockedByUsers(currentUser.uid);
 
     // Fetch initial posts (first page with 7 items)
-    const initialPosts = await Sentry.startSpan({ name: 'fetchRecentPosts', op: 'db.query', attributes: { boardId, limit: 7 } }, () => fetchRecentPosts(boardId, 7, blockedByUsers));
+    const initialPosts = await fetchRecentPosts(boardId, 7, blockedByUsers);
 
     return {
       boardId,
@@ -35,5 +33,4 @@ export async function boardPostsLoader({ params }: LoaderFunctionArgs) {
     console.error('Failed to fetch board posts:', error);
     throw new Response('Failed to load posts', { status: 500 });
   }
-  });
 }

--- a/apps/web/src/board/hooks/useBoardPostsLoader.ts
+++ b/apps/web/src/board/hooks/useBoardPostsLoader.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import type { LoaderFunctionArgs } from 'react-router-dom';
 import { fetchRecentPosts } from '@/post/api/post';
 import { getCurrentUser } from '@/shared/utils/authUtils';
@@ -5,13 +6,14 @@ import { getBlockedByUsers } from '@/user/api/user';
 
 export async function boardPostsLoader({ params }: LoaderFunctionArgs) {
   const { boardId } = params;
-  
+
   if (!boardId) {
     throw new Response('Missing boardId parameter', { status: 400 });
   }
 
+  return await Sentry.startSpan({ name: 'boardPostsLoader', op: 'route.loader', attributes: { boardId } }, async () => {
   // PrivateRoutes ensures user is authenticated before this runs
-  const currentUser = await getCurrentUser();
+  const currentUser = await Sentry.startSpan({ name: 'getCurrentUser', op: 'auth' }, () => getCurrentUser());
 
   if (!currentUser) {
     throw new Response('로그인 후 이용해주세요.', { status: 401 });
@@ -19,18 +21,19 @@ export async function boardPostsLoader({ params }: LoaderFunctionArgs) {
 
   try {
     // Get blocked users first
-    const blockedByUsers = await getBlockedByUsers(currentUser.uid);
-    
+    const blockedByUsers = await Sentry.startSpan({ name: 'getBlockedByUsers', op: 'db.query' }, () => getBlockedByUsers(currentUser.uid));
+
     // Fetch initial posts (first page with 7 items)
-    const initialPosts = await fetchRecentPosts(boardId, 7, blockedByUsers);
-    
-    return { 
-      boardId, 
+    const initialPosts = await Sentry.startSpan({ name: 'fetchRecentPosts', op: 'db.query', attributes: { boardId, limit: 7 } }, () => fetchRecentPosts(boardId, 7, blockedByUsers));
+
+    return {
+      boardId,
       initialPosts,
-      blockedByUsers 
+      blockedByUsers
     };
   } catch (error) {
     console.error('Failed to fetch board posts:', error);
     throw new Response('Failed to load posts', { status: 500 });
   }
+  });
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,4 +1,5 @@
-import { createBrowserRouter, redirect, ScrollRestoration } from 'react-router-dom';
+import { redirect, ScrollRestoration } from 'react-router-dom';
+import { sentryCreateBrowserRouter } from './sentry';
 import './index.css';
 import { Toaster } from '@/shared/ui/sonner';
 
@@ -148,7 +149,7 @@ const privateRoutesWithoutNav = {
 
 // --- Router 생성 ---
 
-export const router = createBrowserRouter([
+export const router = sentryCreateBrowserRouter([
   {
     path: '/',
     element: <RootLayout />,

--- a/apps/web/src/sentry.ts
+++ b/apps/web/src/sentry.ts
@@ -6,7 +6,7 @@ import { isIndexedDbConnectionError } from '@/shared/lib/queryErrorTracking';
 // Configuration constants
 const SENTRY_CONFIG = {
   DSN: 'https://8909fb2b0ca421e67d747c29dc427694@o4508460976635904.ingest.us.sentry.io/4508460981747712',
-  TRACE_SAMPLE_RATE: 1.0,
+  TRACE_SAMPLE_RATE: Number(import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE) || 1.0,
   REPLAY_SAMPLE_RATE: 0.1,
   REPLAY_ON_ERROR_RATE: 1.0,
 } as const;
@@ -113,7 +113,7 @@ export const initSentry = (): void => {
     tracePropagationTargets: [
       'localhost',
       /^https:\/\/daily-writing-friends\.com\/api/,
-      /^https:\/\/.*\.supabase\.co/,
+      import.meta.env.VITE_SUPABASE_URL,
     ],
     replaysSessionSampleRate: isDevelopment ? 0 : SENTRY_CONFIG.REPLAY_SAMPLE_RATE,
     replaysOnErrorSampleRate: SENTRY_CONFIG.REPLAY_ON_ERROR_RATE,

--- a/apps/web/src/sentry.ts
+++ b/apps/web/src/sentry.ts
@@ -1,10 +1,12 @@
 import * as Sentry from '@sentry/react';
+import { useEffect } from 'react';
+import { useLocation, useNavigationType, createRoutesFromChildren, matchRoutes, createBrowserRouter } from 'react-router-dom';
 import { isIndexedDbConnectionError } from '@/shared/lib/queryErrorTracking';
 
 // Configuration constants
 const SENTRY_CONFIG = {
   DSN: 'https://8909fb2b0ca421e67d747c29dc427694@o4508460976635904.ingest.us.sentry.io/4508460981747712',
-  TRACE_SAMPLE_RATE: 0.1,
+  TRACE_SAMPLE_RATE: 1.0,
   REPLAY_SAMPLE_RATE: 0.1,
   REPLAY_ON_ERROR_RATE: 1.0,
 } as const;
@@ -98,13 +100,20 @@ export const initSentry = (): void => {
     environment,
     sendDefaultPii: true,
     integrations: [
-      Sentry.browserTracingIntegration(),
+      Sentry.reactRouterV6BrowserTracingIntegration({
+        useEffect,
+        useLocation,
+        useNavigationType,
+        createRoutesFromChildren,
+        matchRoutes,
+      }),
       Sentry.replayIntegration(),
     ],
     tracesSampleRate: SENTRY_CONFIG.TRACE_SAMPLE_RATE,
     tracePropagationTargets: [
       'localhost',
       /^https:\/\/daily-writing-friends\.com\/api/,
+      /^https:\/\/.*\.supabase\.co/,
     ],
     replaysSessionSampleRate: isDevelopment ? 0 : SENTRY_CONFIG.REPLAY_SAMPLE_RATE,
     replaysOnErrorSampleRate: SENTRY_CONFIG.REPLAY_ON_ERROR_RATE,
@@ -176,3 +185,5 @@ export const setSentryContext = (key: string, context: Record<string, unknown>) 
 export const setSentryTags = (tags: Record<string, string>) => {
   Sentry.setTags(tags);
 };
+
+export const sentryCreateBrowserRouter = Sentry.wrapCreateBrowserRouterV6(createBrowserRouter);

--- a/apps/web/src/setupTest.ts
+++ b/apps/web/src/setupTest.ts
@@ -9,6 +9,9 @@ vi.mock('@sentry/react', () => ({
   captureException: vi.fn(),
   withScope: vi.fn((cb: (scope: Record<string, unknown>) => void) => cb({ setContext: vi.fn(), setFingerprint: vi.fn() })),
   addBreadcrumb: vi.fn(),
+  startSpan: vi.fn((_ctx: unknown, cb: () => unknown) => cb()),
+  wrapCreateBrowserRouterV6: vi.fn((createRouter: unknown) => createRouter),
+  reactRouterV6BrowserTracingIntegration: vi.fn(),
 }));
 
 // React Testing Library의 DOM 매처 확장

--- a/docs/plans/2026-04-21-sentry-performance-monitoring.md
+++ b/docs/plans/2026-04-21-sentry-performance-monitoring.md
@@ -1,0 +1,299 @@
+# Sentry Performance Monitoring Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the board detail page's performance visible in Sentry — know WHERE time is spent (query vs render vs network) and WHEN it gets worse.
+
+**Architecture:** Replace the generic `browserTracingIntegration()` with `reactRouterV6BrowserTracingIntegration()` for parameterized route names, raise sample rate to 1.0, and add custom `Sentry.startSpan()` calls to the board detail loaders so each Supabase call appears as a distinct span in the Sentry Performance waterfall.
+
+**Tech Stack:** @sentry/react v8, react-router-dom v6, Supabase, React Query v4
+
+---
+
+### Task 1: Raise tracesSampleRate to 1.0
+
+**Files:**
+- Modify: `apps/web/src/sentry.ts:7`
+
+**Step 1: Change sample rate**
+
+In `sentry.ts`, change the `TRACE_SAMPLE_RATE` constant:
+
+```typescript
+// Before
+TRACE_SAMPLE_RATE: 0.1,
+
+// After
+TRACE_SAMPLE_RATE: 1.0,
+```
+
+**Step 2: Verify build**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add apps/web/src/sentry.ts
+git commit -m "perf: raise Sentry tracesSampleRate to 1.0 for full visibility"
+```
+
+---
+
+### Task 2: Add React Router v6 Sentry integration
+
+This replaces `browserTracingIntegration()` with `reactRouterV6BrowserTracingIntegration()` and wraps `createBrowserRouter` with `Sentry.wrapCreateBrowserRouterV6()`. This gives parameterized route names like `/board/:boardId` instead of `/board/abc123` in the Sentry Performance dashboard.
+
+**Files:**
+- Modify: `apps/web/src/sentry.ts`
+- Modify: `apps/web/src/router.tsx`
+
+**Step 1: Update sentry.ts to use reactRouterV6BrowserTracingIntegration**
+
+Replace `browserTracingIntegration()` in the integrations array:
+
+```typescript
+// sentry.ts — add these imports at the top
+import * as Sentry from '@sentry/react';
+import { useEffect } from 'react';
+import {
+  useLocation,
+  useNavigationType,
+  createRoutesFromChildren,
+  matchRoutes,
+} from 'react-router-dom';
+
+// In the integrations array inside Sentry.init(), replace:
+//   Sentry.browserTracingIntegration(),
+// with:
+Sentry.reactRouterV6BrowserTracingIntegration({
+  useEffect,
+  useLocation,
+  useNavigationType,
+  createRoutesFromChildren,
+  matchRoutes,
+}),
+```
+
+**Step 2: Export wrapCreateBrowserRouter from sentry.ts**
+
+Add at the bottom of `sentry.ts`:
+
+```typescript
+/**
+ * Wrapped createBrowserRouter for Sentry route-parameterized transaction names.
+ * Use this instead of createBrowserRouter from react-router-dom.
+ */
+export const sentryCreateBrowserRouter = Sentry.wrapCreateBrowserRouterV6(
+  // Lazy import to avoid circular dependency — router.tsx imports from sentry.ts
+  // so we accept createBrowserRouter as a parameter instead
+);
+```
+
+Actually, to avoid circular imports (router.tsx already imports from sentry.ts indirectly), export the wrapper function directly:
+
+```typescript
+import { createBrowserRouter } from 'react-router-dom';
+
+export const sentryCreateBrowserRouter = Sentry.wrapCreateBrowserRouterV6(createBrowserRouter);
+```
+
+**Step 3: Update router.tsx to use the wrapped router**
+
+In `router.tsx`, replace:
+
+```typescript
+// Before
+import { createBrowserRouter, redirect, ScrollRestoration } from 'react-router-dom';
+// ...
+export const router = createBrowserRouter([
+
+// After
+import { redirect, ScrollRestoration } from 'react-router-dom';
+import { sentryCreateBrowserRouter } from './sentry';
+// ...
+export const router = sentryCreateBrowserRouter([
+```
+
+**Step 4: Verify build**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 5: Verify dev server starts**
+
+Run: `cd apps/web && npx vite --port 5199 &` then check `http://localhost:5199` loads.
+Kill the dev server after verifying.
+
+**Step 6: Commit**
+
+```bash
+git add apps/web/src/sentry.ts apps/web/src/router.tsx
+git commit -m "perf: integrate Sentry with React Router v6 for parameterized route names"
+```
+
+---
+
+### Task 3: Add custom spans to board loaders
+
+Wrap each async operation in `boardLoader` and `boardPostsLoader` with `Sentry.startSpan()` so the Sentry Performance waterfall shows exactly how long each Supabase call takes.
+
+**Files:**
+- Modify: `apps/web/src/board/hooks/useBoardLoader.ts`
+- Modify: `apps/web/src/board/hooks/useBoardPostsLoader.ts`
+
+**Step 1: Instrument boardLoader**
+
+In `useBoardLoader.ts`, wrap the key operations:
+
+```typescript
+import * as Sentry from '@sentry/react';
+
+export async function boardLoader({ params }: LoaderFunctionArgs) {
+  const { boardId } = params;
+
+  if (!boardId) {
+    throw new Response('Missing board ID', { status: 400 });
+  }
+
+  return Sentry.startSpan(
+    { name: 'boardLoader', op: 'route.loader', attributes: { boardId } },
+    async () => {
+      try {
+        const user = await Sentry.startSpan(
+          { name: 'getCurrentUser', op: 'auth' },
+          () => getCurrentUser(),
+        );
+
+        if (!user) {
+          return { boardId };
+        }
+
+        const userData = await Sentry.startSpan(
+          { name: 'fetchUser', op: 'db.query', attributes: { userId: user.uid } },
+          () => fetchUser(user.uid),
+        );
+
+        // ... rest of permission checks remain unchanged ...
+```
+
+Keep the existing error handling and permission logic. Only wrap the two async calls: `getCurrentUser()` and `fetchUser(user.uid)`.
+
+**Step 2: Instrument boardPostsLoader**
+
+In `useBoardPostsLoader.ts`, wrap the key operations:
+
+```typescript
+import * as Sentry from '@sentry/react';
+
+export async function boardPostsLoader({ params }: LoaderFunctionArgs) {
+  const { boardId } = params;
+
+  if (!boardId) {
+    throw new Response('Missing boardId parameter', { status: 400 });
+  }
+
+  return Sentry.startSpan(
+    { name: 'boardPostsLoader', op: 'route.loader', attributes: { boardId } },
+    async () => {
+      const currentUser = await Sentry.startSpan(
+        { name: 'getCurrentUser', op: 'auth' },
+        () => getCurrentUser(),
+      );
+
+      if (!currentUser) {
+        throw new Response('로그인 후 이용해주세요.', { status: 401 });
+      }
+
+      try {
+        const blockedByUsers = await Sentry.startSpan(
+          { name: 'getBlockedByUsers', op: 'db.query' },
+          () => getBlockedByUsers(currentUser.uid),
+        );
+
+        const initialPosts = await Sentry.startSpan(
+          { name: 'fetchRecentPosts', op: 'db.query', attributes: { boardId, limit: 7 } },
+          () => fetchRecentPosts(boardId, 7, blockedByUsers),
+        );
+
+        return { boardId, initialPosts, blockedByUsers };
+      } catch (error) {
+        console.error('Failed to fetch board posts:', error);
+        throw new Response('Failed to load posts', { status: 500 });
+      }
+    },
+  );
+}
+```
+
+**Step 3: Verify build**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Run existing tests**
+
+Run: `cd apps/web && npx vitest run --reporter=verbose 2>&1 | tail -20`
+Expected: All tests pass (these loaders may not have unit tests, but we verify no regressions)
+
+**Step 5: Commit**
+
+```bash
+git add apps/web/src/board/hooks/useBoardLoader.ts apps/web/src/board/hooks/useBoardPostsLoader.ts
+git commit -m "perf: add Sentry spans to board loaders for query-level visibility"
+```
+
+---
+
+### Task 4: Add Supabase domain to tracePropagationTargets
+
+Currently only `localhost` and `daily-writing-friends.com/api` are in `tracePropagationTargets`. Supabase API calls don't get the `sentry-trace` header, so distributed tracing doesn't work.
+
+**Files:**
+- Modify: `apps/web/src/sentry.ts:105-108`
+
+**Step 1: Add Supabase domain pattern**
+
+```typescript
+// Before
+tracePropagationTargets: [
+  'localhost',
+  /^https:\/\/daily-writing-friends\.com\/api/,
+],
+
+// After
+tracePropagationTargets: [
+  'localhost',
+  /^https:\/\/daily-writing-friends\.com\/api/,
+  /^https:\/\/.*\.supabase\.co/,
+],
+```
+
+**Step 2: Verify build**
+
+Run: `cd apps/web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add apps/web/src/sentry.ts
+git commit -m "perf: add Supabase domain to Sentry tracePropagationTargets"
+```
+
+---
+
+## Out of Scope (for follow-up issues)
+
+These were identified during analysis but are NOT part of this monitoring setup:
+
+1. **Duplicate `getBlockedByUsers` call** — `boardPostsLoader` fetches blocked users, but `useRecentPosts` hook re-fetches them via a `useEffect`. This causes `fetchRecentPosts` to fire twice on cold load. This is a **performance bug**, not a monitoring gap. File a separate issue.
+
+2. **Sequential queries in `fetchUser`** — `fetchUserFromSupabase` makes 2-3 sequential Supabase calls (user → permissions → optional buddy). These could be parallelized with `Promise.all`. Separate optimization issue.
+
+3. **Supabase server-side monitoring** — `pg_stat_statements` and Supabase dashboard slow query monitoring. DBA-level work, not app code.
+
+4. **Alerting** — Set thresholds after 1-2 weeks of baseline data at 100% sample rate. Sentry's built-in Web Vitals alerts (LCP > 2.5s) are one-click once data exists.
+
+5. **Stats page / post list monitoring** — Start with board detail (actual pain point), expand custom spans to other pages once the pattern is validated.


### PR DESCRIPTION
## Summary

- Sentry Performance 모니터링을 React Router v6와 통합하여 라우트별 성능 집계 가능하도록 설정
- 보드 상세 페이지 로더에 커스텀 span을 추가하여 각 Supabase 쿼리 소요시간 개별 추적 가능
- tracesSampleRate를 1.0으로 올리고 Supabase 도메인을 tracePropagationTargets에 추가

## Changes

- `sentry.ts`: `browserTracingIntegration` → `reactRouterV6BrowserTracingIntegration`, sample rate 0.1 → 1.0, Supabase domain 추가
- `router.tsx`: `createBrowserRouter` → `sentryCreateBrowserRouter` (parameterized route names)
- `useBoardLoader.ts` / `useBoardPostsLoader.ts`: `Sentry.startSpan()` wrappers on all async calls
- Test mocks updated for new Sentry exports

## Test plan

- [ ] `pnpm --filter web type-check` passes
- [ ] `pnpm --filter web test:run` — 603/603 tests pass
- [ ] Deploy to staging, visit board detail page, verify spans appear in Sentry Performance dashboard
- [ ] Check Sentry Performance → `/board/:boardId` shows parameterized route name (not literal IDs)
- [ ] Verify waterfall shows child spans: `getCurrentUser`, `fetchUser`, `getBlockedByUsers`, `fetchRecentPosts`

Closes #534