### PR TITLE
fix: 모바일 키보드가 Tiptap 툴바 가리는 문제

### DIFF
--- a/apps/web/src/post/components/EditorToolbar.tsx
+++ b/apps/web/src/post/components/EditorToolbar.tsx
@@ -15,6 +15,7 @@ import {
   X,
 } from 'lucide-react';
 import { useState } from 'react';
+import { useKeyboardInset } from '@/post/hooks/useKeyboardInset';
 import { useScrollIndicators } from '@/post/hooks/useScrollIndicators';
 import { isValidHttpUrl } from '@/post/utils/sanitizeHtml';
 import { Button } from '@/shared/ui/button';
@@ -34,6 +35,7 @@ export function EditorToolbar({ editor, onImageUpload, variant = 'sticky' }: Edi
   const [linkUrl, setLinkUrl] = useState('');
   const [isLinkPopoverOpen, setIsLinkPopoverOpen] = useState(false);
   const { scrollContainerRef, canScrollLeft, canScrollRight } = useScrollIndicators();
+  const keyboardInset = useKeyboardInset();
 
   // Use TipTap's useEditorState for optimized re-renders
   const editorState = useEditorState({
@@ -86,8 +88,15 @@ export function EditorToolbar({ editor, onImageUpload, variant = 'sticky' }: Edi
         'px-4 py-2 my-4',
       );
 
+  // Use `bottom` (not `transform`) to avoid creating a new containing block
+  // that could affect backdrop-filter rendering on some Safari versions.
+  const stickyStyle =
+    variant === 'sticky' && keyboardInset > 0
+      ? { bottom: `${keyboardInset}px` }
+      : undefined;
+
   return (
-    <div className={containerClass}>
+    <div className={containerClass} style={stickyStyle}>
       <div className='relative mx-auto max-w-4xl'>
         {/* Left gradient indicator */}
         {canScrollLeft && (

--- a/apps/web/src/post/hooks/useKeyboardInset.ts
+++ b/apps/web/src/post/hooks/useKeyboardInset.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns how many pixels the on-screen keyboard occupies at the bottom
+ * of the layout viewport.
+ *
+ * Why: position:fixed anchors to the layout viewport, but mobile keyboards
+ * shrink the visual viewport without resizing the layout. Use this offset
+ * to translate fixed-bottom UI above the keyboard.
+ */
+export function useKeyboardInset(): number {
+  const [inset, setInset] = useState(0);
+
+  useEffect(() => {
+    const visualViewport = window.visualViewport;
+    if (!visualViewport) return;
+
+    const update = () => {
+      // Pinch-zoom also shrinks the visual viewport. Only treat shrinkage as keyboard inset.
+      if (visualViewport.scale > 1) {
+        setInset(0);
+        return;
+      }
+      const bottomInset =
+        window.innerHeight - visualViewport.height - visualViewport.offsetTop;
+      setInset(Math.max(0, bottomInset));
+    };
+
+    update();
+    visualViewport.addEventListener('resize', update);
+    visualViewport.addEventListener('scroll', update);
+    return () => {
+      visualViewport.removeEventListener('resize', update);
+      visualViewport.removeEventListener('scroll', update);
+    };
+  }, []);
+
+  return inset;
+}


### PR DESCRIPTION
## 무엇을 / 왜

리모트 컨피그로 새 Tiptap 에디터가 활성화된 뒤, 모바일에서 키보드가 올라오면 sticky 툴바가 키보드에 완전히 가려집니다. 사용자는 글을 입력하는 동안 서식 버튼/이미지 업로드를 사용할 수 없습니다.

**원인:** `EditorToolbar`의 sticky 변형은 `position: fixed; bottom: 0`인데, 이는 *layout viewport* 기준입니다. 모바일 키보드는 *visual viewport*만 줄이고 layout viewport는 그대로 둡니다. 그 결과 툴바는 layout viewport 바닥 = 키보드 뒤에 위치하게 됩니다.

## 어떻게 고쳤나

작은 커스텀 훅 `useKeyboardInset`이 `window.visualViewport`의 `resize`/`scroll`을 듣고 키보드가 차지하는 픽셀 수를 반환합니다. 그 값만큼 sticky 툴바의 `bottom`을 올립니다.

- `transform` 대신 `bottom` 사용: `transform`은 새 containing block을 만들어 일부 iOS Safari에서 `backdrop-filter` 렌더링이 깨질 수 있음
- 핀치 줌 가드: `visualViewport.scale > 1`이면 `inset = 0` (줌 시 false positive 방지)
- 데스크탑 inline 변형은 영향 없음 (`variant === 'sticky'` 분기)
- `visualViewport`가 없는 환경(매우 오래된 Android < Chrome 61, IE)에서는 graceful하게 0을 반환 → 기존(가려지는) 동작 그대로 = 회귀 없음

## 호환성

- iOS Safari 13+ (2019-09)
- Chrome for Android 61+ (Chrome 108부터 visualViewport가 키보드 신호의 정식 소스)
- Samsung Internet 8.2+
- Firefox for Android, Android WebView, KaiOS 3+
- 글로벌 ~95.7% (caniuse)

## 영향 범위

격리된 변경입니다. `EditorToolbar` 컴포넌트만 수정. 다른 fixed-bottom UI(BottomTabsNavigator, IntroCTA, drawer, toast)는 건드리지 않았습니다.

## 알려진 한계

- iOS Safari 15.0–15.3에서는 키보드 등장 시 `resize` 이벤트가 가끔 누락되는 케이스가 있습니다. 그 경우 사용자가 한 번 스크롤하면 복구됩니다. iOS 15.4+에서 수정됐으며 2026-04 시점 해당 버전 사용자는 미미합니다.

## Test plan

- [ ] iOS Safari (실기기) — 글 작성 페이지에서 본문 클릭 → 키보드 올라옴 → 툴바가 키보드 위에 정확히 붙는지 확인
- [ ] Android Chrome (실기기) — 동일 시나리오
- [ ] 데스크탑 — inline 툴바가 그대로인지, 동작 변화 없는지 확인
- [ ] iOS에서 핀치 줌 시 툴바가 임의로 떠오르지 않는지 확인
- [ ] 링크 popover가 키보드가 올라온 상태에서도 정상 위치에 뜨는지 확인 (Radix Portal 사용 → 영향 없어야 함)