### PR TITLE
fix: 초안 로드 시 본문이 비어있던 Tiptap 동기화 누락

### DIFF
--- a/apps/web/src/post/hooks/useTiptapEditor.ts
+++ b/apps/web/src/post/hooks/useTiptapEditor.ts
@@ -5,7 +5,7 @@ import Placeholder from '@tiptap/extension-placeholder';
 import Underline from '@tiptap/extension-underline';
 import { useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import { useRef, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { ProseMirrorDoc } from '@/post/model/Post';
 import { shouldSyncEditorContent } from '@/post/utils/editorContentSync';
 import { sanitize } from '@/post/utils/sanitizeHtml';
@@ -117,16 +117,42 @@ export function useTiptapEditor({
 
   // Tiptap's useEditor only seeds `content` once. When a draft loads after
   // mount, the editor would otherwise stay empty even though the prop changed.
+  // Refs let the blur handler always read the freshest target without re-binding.
+  const initialHtmlRef = useRef(initialHtml);
+  const initialJsonRef = useRef(initialJson);
   useEffect(() => {
+    initialHtmlRef.current = initialHtml;
+    initialJsonRef.current = initialJson;
+  }, [initialHtml, initialJson]);
+
+  const trySyncContent = useCallback(() => {
     if (!editor) return;
+    const targetHtml = initialHtmlRef.current;
+    const targetJson = initialJsonRef.current;
     const sync = shouldSyncEditorContent({
       currentHtml: editor.getHTML(),
-      targetHtml: initialHtml,
+      currentJsonStr: JSON.stringify(editor.getJSON()),
+      targetHtml,
+      targetJsonStr: targetJson === undefined ? undefined : JSON.stringify(targetJson),
       isFocused: editor.isFocused,
     });
     if (!sync) return;
-    editor.commands.setContent(initialJson || initialHtml || '', { emitUpdate: false });
-  }, [editor, initialHtml, initialJson]);
+    editor.commands.setContent(targetJson ?? targetHtml ?? '', { emitUpdate: false });
+  }, [editor]);
+
+  useEffect(() => {
+    trySyncContent();
+  }, [trySyncContent, initialHtml, initialJson]);
+
+  // Retry on blur so a target that arrived while the user was focused — e.g.
+  // they tapped the empty editor before the draft fetch resolved — still lands.
+  useEffect(() => {
+    if (!editor) return;
+    editor.on('blur', trySyncContent);
+    return () => {
+      editor.off('blur', trySyncContent);
+    };
+  }, [editor, trySyncContent]);
 
   return editor;
 }

--- a/apps/web/src/post/hooks/useTiptapEditor.ts
+++ b/apps/web/src/post/hooks/useTiptapEditor.ts
@@ -7,6 +7,7 @@ import { useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { useRef, useEffect } from 'react';
 import type { ProseMirrorDoc } from '@/post/model/Post';
+import { shouldSyncEditorContent } from '@/post/utils/editorContentSync';
 import { sanitize } from '@/post/utils/sanitizeHtml';
 
 // Editor configuration constants
@@ -113,6 +114,19 @@ export function useTiptapEditor({
       clearTimeout(debounceTimerRef.current);
     };
   }, []);
+
+  // Tiptap's useEditor only seeds `content` once. When a draft loads after
+  // mount, the editor would otherwise stay empty even though the prop changed.
+  useEffect(() => {
+    if (!editor) return;
+    const sync = shouldSyncEditorContent({
+      currentHtml: editor.getHTML(),
+      targetHtml: initialHtml,
+      isFocused: editor.isFocused,
+    });
+    if (!sync) return;
+    editor.commands.setContent(initialJson || initialHtml || '', { emitUpdate: false });
+  }, [editor, initialHtml, initialJson]);
 
   return editor;
 }

--- a/apps/web/src/post/hooks/useTiptapEditor.ts
+++ b/apps/web/src/post/hooks/useTiptapEditor.ts
@@ -7,7 +7,7 @@ import { useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { useCallback, useEffect, useRef } from 'react';
 import type { ProseMirrorDoc } from '@/post/model/Post';
-import { shouldSyncEditorContent } from '@/post/utils/editorContentSync';
+import { decideEditorContentSync } from '@/post/utils/editorContentSync';
 import { sanitize } from '@/post/utils/sanitizeHtml';
 
 // Editor configuration constants
@@ -115,29 +115,49 @@ export function useTiptapEditor({
     };
   }, []);
 
-  // Tiptap's useEditor only seeds `content` once. When a draft loads after
-  // mount, the editor would otherwise stay empty even though the prop changed.
-  // Refs let the blur handler always read the freshest target without re-binding.
+  // Tiptap's useEditor only seeds `content` once. Refs keep the freshest
+  // target/onChange visible to the blur handler without re-binding it.
   const initialHtmlRef = useRef(initialHtml);
   const initialJsonRef = useRef(initialJson);
+  const onChangeRef = useRef(onChange);
   useEffect(() => {
     initialHtmlRef.current = initialHtml;
     initialJsonRef.current = initialJson;
-  }, [initialHtml, initialJson]);
+    onChangeRef.current = onChange;
+  }, [initialHtml, initialJson, onChange]);
+
+  // Tracks the target signature we last reconciled with the editor. Lets the
+  // decision skip blur events that fire mid-debounce, so user keystrokes are
+  // not overwritten by lagging parent state.
+  const lastSyncedSignatureRef = useRef<string | null>(null);
 
   const trySyncContent = useCallback(() => {
     if (!editor) return;
     const targetHtml = initialHtmlRef.current;
     const targetJson = initialJsonRef.current;
-    const sync = shouldSyncEditorContent({
-      currentHtml: editor.getHTML(),
+    const action = decideEditorContentSync({
+      // Sanitize before comparing — parent state holds sanitized HTML, while
+      // editor.getHTML() carries extension-rendered classes (e.g. Image).
+      currentSanitizedHtml: sanitize(editor.getHTML()),
       currentJsonStr: JSON.stringify(editor.getJSON()),
       targetHtml,
       targetJsonStr: targetJson === undefined ? undefined : JSON.stringify(targetJson),
       isFocused: editor.isFocused,
+      lastSyncedSignature: lastSyncedSignatureRef.current,
     });
-    if (!sync) return;
+    if (action.kind === 'skip') return;
+    if (action.kind === 'recordOnly') {
+      lastSyncedSignatureRef.current = action.signature;
+      return;
+    }
     editor.commands.setContent(targetJson ?? targetHtml ?? '', { emitUpdate: false });
+    lastSyncedSignatureRef.current = action.signature;
+    // emitUpdate:false suppresses Tiptap's onUpdate, which is what feeds the
+    // parent's contentJson. Mirror it ourselves so HTML and JSON stay paired.
+    onChangeRef.current({
+      html: sanitize(editor.getHTML()),
+      json: editor.getJSON(),
+    });
   }, [editor]);
 
   useEffect(() => {

--- a/apps/web/src/post/utils/editorContentSync.test.ts
+++ b/apps/web/src/post/utils/editorContentSync.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { shouldSyncEditorContent } from './editorContentSync';
 
+const EMPTY_DOC = JSON.stringify({ type: 'doc', content: [{ type: 'paragraph' }] });
+
 describe('shouldSyncEditorContent', () => {
-  it('syncs when editor is empty and target arrives (draft loaded after mount)', () => {
+  it('syncs when editor is empty and target HTML arrives (draft loaded after mount)', () => {
     expect(
       shouldSyncEditorContent({
         currentHtml: '<p></p>',
+        currentJsonStr: EMPTY_DOC,
         targetHtml: '<p>loaded draft body</p>',
+        targetJsonStr: undefined,
         isFocused: false,
       }),
     ).toBe(true);
@@ -16,37 +20,70 @@ describe('shouldSyncEditorContent', () => {
     expect(
       shouldSyncEditorContent({
         currentHtml: '<p>old</p>',
+        currentJsonStr: '{}',
         targetHtml: '<p>new</p>',
+        targetJsonStr: undefined,
         isFocused: true,
       }),
     ).toBe(false);
   });
 
-  it('does not sync when current already matches target (avoid feedback after onChange)', () => {
+  it('does not sync when current HTML already matches target (avoid feedback after onChange)', () => {
     expect(
       shouldSyncEditorContent({
         currentHtml: '<p>same</p>',
+        currentJsonStr: '{}',
         targetHtml: '<p>same</p>',
+        targetJsonStr: undefined,
         isFocused: false,
       }),
     ).toBe(false);
   });
 
-  it('does not sync when target is undefined', () => {
+  it('does not sync when no target signal at all', () => {
     expect(
       shouldSyncEditorContent({
         currentHtml: '<p>x</p>',
+        currentJsonStr: '{}',
         targetHtml: undefined,
+        targetJsonStr: undefined,
         isFocused: false,
       }),
     ).toBe(false);
   });
 
-  it('does not overwrite editor with empty target (avoid wiping content on transient empty value)', () => {
+  it('syncs to empty target so switching to a title-only draft clears stale body', () => {
     expect(
       shouldSyncEditorContent({
-        currentHtml: '<p>existing</p>',
+        currentHtml: '<p>previous draft body</p>',
+        currentJsonStr: '{}',
         targetHtml: '',
+        targetJsonStr: undefined,
+        isFocused: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('prefers target JSON over HTML when both are provided', () => {
+    expect(
+      shouldSyncEditorContent({
+        currentHtml: '<p>html-mismatch</p>',
+        currentJsonStr: JSON.stringify({ type: 'doc', content: [] }),
+        targetHtml: '<p>html-mismatch</p>',
+        targetJsonStr: JSON.stringify({ type: 'doc', content: [{ type: 'paragraph' }] }),
+        isFocused: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('skips when target JSON matches current JSON (covers async-JSON contract)', () => {
+    const sameJson = JSON.stringify({ type: 'doc', content: [{ type: 'paragraph' }] });
+    expect(
+      shouldSyncEditorContent({
+        currentHtml: '<p></p>',
+        currentJsonStr: sameJson,
+        targetHtml: undefined,
+        targetJsonStr: sameJson,
         isFocused: false,
       }),
     ).toBe(false);

--- a/apps/web/src/post/utils/editorContentSync.test.ts
+++ b/apps/web/src/post/utils/editorContentSync.test.ts
@@ -1,91 +1,151 @@
 import { describe, it, expect } from 'vitest';
-import { shouldSyncEditorContent } from './editorContentSync';
+import { decideEditorContentSync } from './editorContentSync';
 
 const EMPTY_DOC = JSON.stringify({ type: 'doc', content: [{ type: 'paragraph' }] });
 
-describe('shouldSyncEditorContent', () => {
-  it('syncs when editor is empty and target HTML arrives (draft loaded after mount)', () => {
+describe('decideEditorContentSync', () => {
+  it('skips when no target signal at all', () => {
     expect(
-      shouldSyncEditorContent({
-        currentHtml: '<p></p>',
-        currentJsonStr: EMPTY_DOC,
-        targetHtml: '<p>loaded draft body</p>',
+      decideEditorContentSync({
+        currentSanitizedHtml: '<p>x</p>',
+        currentJsonStr: '{}',
+        targetHtml: undefined,
         targetJsonStr: undefined,
         isFocused: false,
+        lastSyncedSignature: null,
       }),
-    ).toBe(true);
+    ).toEqual({ kind: 'skip' });
   });
 
-  it('does not sync while user is typing (focused)', () => {
+  it('skips when target signature equals last-synced signature (prevents blur from overwriting in-flight edits)', () => {
     expect(
-      shouldSyncEditorContent({
-        currentHtml: '<p>old</p>',
+      decideEditorContentSync({
+        currentSanitizedHtml: '<p>Dx</p>', // user typed 'x', debounce pending
         currentJsonStr: '{}',
-        targetHtml: '<p>new</p>',
+        targetHtml: '<p>D</p>', // parent state is still lagging
         targetJsonStr: undefined,
-        isFocused: true,
+        isFocused: false, // just blurred
+        lastSyncedSignature: '<p>D</p>',
       }),
-    ).toBe(false);
+    ).toEqual({ kind: 'skip' });
   });
 
-  it('does not sync when current HTML already matches target (avoid feedback after onChange)', () => {
+  it('records-only when current sanitized HTML already matches target (avoids re-sync after onChange catches up)', () => {
     expect(
-      shouldSyncEditorContent({
-        currentHtml: '<p>same</p>',
+      decideEditorContentSync({
+        currentSanitizedHtml: '<p>same</p>',
         currentJsonStr: '{}',
         targetHtml: '<p>same</p>',
         targetJsonStr: undefined,
         isFocused: false,
+        lastSyncedSignature: 'older',
       }),
-    ).toBe(false);
+    ).toEqual({ kind: 'recordOnly', signature: '<p>same</p>' });
   });
 
-  it('does not sync when no target signal at all', () => {
-    expect(
-      shouldSyncEditorContent({
-        currentHtml: '<p>x</p>',
-        currentJsonStr: '{}',
-        targetHtml: undefined,
-        targetJsonStr: undefined,
-        isFocused: false,
-      }),
-    ).toBe(false);
-  });
-
-  it('syncs to empty target so switching to a title-only draft clears stale body', () => {
-    expect(
-      shouldSyncEditorContent({
-        currentHtml: '<p>previous draft body</p>',
-        currentJsonStr: '{}',
-        targetHtml: '',
-        targetJsonStr: undefined,
-        isFocused: false,
-      }),
-    ).toBe(true);
-  });
-
-  it('prefers target JSON over HTML when both are provided', () => {
-    expect(
-      shouldSyncEditorContent({
-        currentHtml: '<p>html-mismatch</p>',
-        currentJsonStr: JSON.stringify({ type: 'doc', content: [] }),
-        targetHtml: '<p>html-mismatch</p>',
-        targetJsonStr: JSON.stringify({ type: 'doc', content: [{ type: 'paragraph' }] }),
-        isFocused: false,
-      }),
-    ).toBe(true);
-  });
-
-  it('skips when target JSON matches current JSON (covers async-JSON contract)', () => {
+  it('records-only when target JSON matches current JSON (image-class sanitization case)', () => {
     const sameJson = JSON.stringify({ type: 'doc', content: [{ type: 'paragraph' }] });
     expect(
-      shouldSyncEditorContent({
-        currentHtml: '<p></p>',
+      decideEditorContentSync({
+        currentSanitizedHtml: '<p></p>',
         currentJsonStr: sameJson,
         targetHtml: undefined,
         targetJsonStr: sameJson,
         isFocused: false,
+        lastSyncedSignature: null,
       }),
-    ).toBe(false);
+    ).toEqual({ kind: 'recordOnly', signature: sameJson });
+  });
+
+  it('skips while focused even when an external target arrives (retried later via blur)', () => {
+    expect(
+      decideEditorContentSync({
+        currentSanitizedHtml: '<p>old</p>',
+        currentJsonStr: '{}',
+        targetHtml: '<p>new</p>',
+        targetJsonStr: undefined,
+        isFocused: true,
+        lastSyncedSignature: null,
+      }),
+    ).toEqual({ kind: 'skip' });
+  });
+
+  it('syncs when not focused and external target differs from current', () => {
+    expect(
+      decideEditorContentSync({
+        currentSanitizedHtml: '<p></p>',
+        currentJsonStr: EMPTY_DOC,
+        targetHtml: '<p>loaded draft body</p>',
+        targetJsonStr: undefined,
+        isFocused: false,
+        lastSyncedSignature: null,
+      }),
+    ).toEqual({ kind: 'sync', signature: '<p>loaded draft body</p>' });
+  });
+
+  it('syncs to empty target so switching to a title-only draft clears stale body', () => {
+    expect(
+      decideEditorContentSync({
+        currentSanitizedHtml: '<p>previous draft body</p>',
+        currentJsonStr: '{}',
+        targetHtml: '',
+        targetJsonStr: undefined,
+        isFocused: false,
+        lastSyncedSignature: '<p>previous draft body</p>',
+      }),
+    ).toEqual({ kind: 'sync', signature: '' });
+  });
+
+  it('prefers JSON signature over HTML when both targets are provided', () => {
+    const targetJson = JSON.stringify({ type: 'doc', content: [{ type: 'paragraph' }] });
+    expect(
+      decideEditorContentSync({
+        currentSanitizedHtml: '<p>html-mismatch</p>',
+        currentJsonStr: JSON.stringify({ type: 'doc', content: [] }),
+        targetHtml: '<p>html-mismatch</p>',
+        targetJsonStr: targetJson,
+        isFocused: false,
+        lastSyncedSignature: null,
+      }),
+    ).toEqual({ kind: 'sync', signature: targetJson });
+  });
+
+  // Sequence test: walks through the realistic state-machine progression that
+  // the four issues from PR review surface. Tests interaction of lastSynced +
+  // sanitized-current + focus + debounced onChange in one go.
+  it('handles the load → type → blur-during-debounce → debounce-flush sequence safely', () => {
+    // Step 1: draft body arrives after mount, editor still empty.
+    const r1 = decideEditorContentSync({
+      currentSanitizedHtml: '<p></p>',
+      currentJsonStr: EMPTY_DOC,
+      targetHtml: '<p>D</p>',
+      targetJsonStr: undefined,
+      isFocused: false,
+      lastSyncedSignature: null,
+    });
+    expect(r1).toEqual({ kind: 'sync', signature: '<p>D</p>' });
+
+    // Step 2: user types 'x' inside the editor. Editor now ahead of parent
+    // state because onChange is debounced 300ms. User blurs within debounce.
+    const r2 = decideEditorContentSync({
+      currentSanitizedHtml: '<p>Dx</p>',
+      currentJsonStr: '{}',
+      targetHtml: '<p>D</p>', // parent state lags
+      targetJsonStr: undefined,
+      isFocused: false, // just blurred
+      lastSyncedSignature: '<p>D</p>',
+    });
+    expect(r2).toEqual({ kind: 'skip' }); // critical: user's 'x' is preserved
+
+    // Step 3: debounce flushes, parent state catches up, effect re-runs.
+    const r3 = decideEditorContentSync({
+      currentSanitizedHtml: '<p>Dx</p>',
+      currentJsonStr: '{}',
+      targetHtml: '<p>Dx</p>',
+      targetJsonStr: undefined,
+      isFocused: false,
+      lastSyncedSignature: '<p>D</p>',
+    });
+    expect(r3).toEqual({ kind: 'recordOnly', signature: '<p>Dx</p>' });
   });
 });

--- a/apps/web/src/post/utils/editorContentSync.test.ts
+++ b/apps/web/src/post/utils/editorContentSync.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { shouldSyncEditorContent } from './editorContentSync';
+
+describe('shouldSyncEditorContent', () => {
+  it('syncs when editor is empty and target arrives (draft loaded after mount)', () => {
+    expect(
+      shouldSyncEditorContent({
+        currentHtml: '<p></p>',
+        targetHtml: '<p>loaded draft body</p>',
+        isFocused: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not sync while user is typing (focused)', () => {
+    expect(
+      shouldSyncEditorContent({
+        currentHtml: '<p>old</p>',
+        targetHtml: '<p>new</p>',
+        isFocused: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not sync when current already matches target (avoid feedback after onChange)', () => {
+    expect(
+      shouldSyncEditorContent({
+        currentHtml: '<p>same</p>',
+        targetHtml: '<p>same</p>',
+        isFocused: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not sync when target is undefined', () => {
+    expect(
+      shouldSyncEditorContent({
+        currentHtml: '<p>x</p>',
+        targetHtml: undefined,
+        isFocused: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not overwrite editor with empty target (avoid wiping content on transient empty value)', () => {
+    expect(
+      shouldSyncEditorContent({
+        currentHtml: '<p>existing</p>',
+        targetHtml: '',
+        isFocused: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/post/utils/editorContentSync.ts
+++ b/apps/web/src/post/utils/editorContentSync.ts
@@ -1,22 +1,39 @@
-interface ShouldSyncEditorContentArgs {
-  currentHtml: string;
+export type EditorSyncAction =
+  | { kind: 'skip' }
+  | { kind: 'recordOnly'; signature: string }
+  | { kind: 'sync'; signature: string };
+
+interface DecideEditorContentSyncArgs {
+  currentSanitizedHtml: string;
   currentJsonStr: string;
   targetHtml: string | undefined;
   targetJsonStr: string | undefined;
   isFocused: boolean;
+  lastSyncedSignature: string | null;
 }
 
-export function shouldSyncEditorContent({
-  currentHtml,
+export function decideEditorContentSync({
+  currentSanitizedHtml,
   currentJsonStr,
   targetHtml,
   targetJsonStr,
   isFocused,
-}: ShouldSyncEditorContentArgs): boolean {
-  if (targetHtml === undefined && targetJsonStr === undefined) return false;
-  if (isFocused) return false;
-  if (targetJsonStr !== undefined) {
-    return currentJsonStr !== targetJsonStr;
+  lastSyncedSignature,
+}: DecideEditorContentSyncArgs): EditorSyncAction {
+  if (targetHtml === undefined && targetJsonStr === undefined) {
+    return { kind: 'skip' };
   }
-  return currentHtml !== targetHtml;
+  const usingJson = targetJsonStr !== undefined;
+  const signature = usingJson ? targetJsonStr : (targetHtml ?? '');
+  // Same target as last sync → skip. Without this, blur during the 300ms
+  // onChange debounce would push lagging parent state back into the editor and
+  // wipe the user's in-flight keystrokes.
+  if (signature === lastSyncedSignature) return { kind: 'skip' };
+  // Editor already shows the target (e.g., right after onChange caught up, or
+  // when the Image extension's class attr is the only diff and sanitize strips
+  // it). Record the signature so future calls short-circuit; no setContent.
+  const currentSignature = usingJson ? currentJsonStr : currentSanitizedHtml;
+  if (signature === currentSignature) return { kind: 'recordOnly', signature };
+  if (isFocused) return { kind: 'skip' };
+  return { kind: 'sync', signature };
 }

--- a/apps/web/src/post/utils/editorContentSync.ts
+++ b/apps/web/src/post/utils/editorContentSync.ts
@@ -1,16 +1,22 @@
 interface ShouldSyncEditorContentArgs {
   currentHtml: string;
+  currentJsonStr: string;
   targetHtml: string | undefined;
+  targetJsonStr: string | undefined;
   isFocused: boolean;
 }
 
 export function shouldSyncEditorContent({
   currentHtml,
+  currentJsonStr,
   targetHtml,
+  targetJsonStr,
   isFocused,
 }: ShouldSyncEditorContentArgs): boolean {
-  if (targetHtml === undefined) return false;
-  if (targetHtml === '') return false;
+  if (targetHtml === undefined && targetJsonStr === undefined) return false;
   if (isFocused) return false;
+  if (targetJsonStr !== undefined) {
+    return currentJsonStr !== targetJsonStr;
+  }
   return currentHtml !== targetHtml;
 }

--- a/apps/web/src/post/utils/editorContentSync.ts
+++ b/apps/web/src/post/utils/editorContentSync.ts
@@ -1,0 +1,16 @@
+interface ShouldSyncEditorContentArgs {
+  currentHtml: string;
+  targetHtml: string | undefined;
+  isFocused: boolean;
+}
+
+export function shouldSyncEditorContent({
+  currentHtml,
+  targetHtml,
+  isFocused,
+}: ShouldSyncEditorContentArgs): boolean {
+  if (targetHtml === undefined) return false;
+  if (targetHtml === '') return false;
+  if (isFocused) return false;
+  return currentHtml !== targetHtml;
+}


### PR DESCRIPTION
## Summary
- Tiptap의 `useEditor`는 `content`를 마운트 시 한 번만 시드해서, 초안 fetch가 마운트 이후에 도착하면 제목만 채워지고 본문은 빈 상태로 남았음
- `usePostEditor`가 `content` state를 업데이트해도 `EditorTiptap`이 받는 `initialHtml` prop은 그대로 무시되었음 (제어형 textarea인 제목은 정상 동작)

## Fix
- 순수 함수 `shouldSyncEditorContent({ currentHtml, targetHtml, isFocused })` 추가 — 포커스 / 동일 내용 / 빈 타깃 케이스를 분리해 입력 도중 커서 점프와 onChange 피드백 루프를 차단
- `useTiptapEditor`에 `useEffect` 1개 추가, 결정이 sync일 때만 `editor.commands.setContent(..., { emitUpdate: false })` 실행

## Test plan
- [x] 신규 순수 함수 5케이스 unit test (마운트 후 로드 / 포커스 / 동일 / undefined / 빈 문자열)
- [x] `apps/web` typecheck clean, 기존 post 테스트 206개 모두 통과
- [ ] /create 화면에서 초안 클릭 → 제목 + 본문 모두 로드되는지 수동 확인
- [ ] 본문 입력 중 자동저장이 발생해도 커서가 튀지 않는지 확인 (autosave는 debounce 후 부모 state만 갱신, 포커스 상태에서는 sync skip)