### PR TITLE
notify 트리거 SECURITY DEFINER 전환 — 댓글/좋아요 403 해결

### DIFF
--- a/supabase/migrations/20260505000001_fix_notify_triggers_security_definer.sql
+++ b/supabase/migrations/20260505000001_fix_notify_triggers_security_definer.sql
@@ -1,0 +1,170 @@
+-- Fix notification triggers blocked by EXECUTE privilege on get_app_config
+--
+-- Root cause: notify_on_* trigger functions run as SECURITY INVOKER (default).
+-- When an authenticated user inserts a comment/reply/like/reaction, the
+-- trigger function calls get_app_config(), which has had EXECUTE revoked
+-- from anon/authenticated since 20260326 (vault migration re-applied the
+-- REVOKE that was retroactively added to the 20260222 migration but never
+-- actually executed in production until now). The call fails with
+-- "permission denied for function get_app_config (42501)" and the entire
+-- INSERT aborts, surfacing as a 403 to the client.
+--
+-- Fix: SECURITY DEFINER makes each notify function run as the function
+-- owner, which still has EXECUTE on get_app_config. This is safe because:
+--   1. The functions only PERFORM net.http_post — no row writes
+--   2. They only fire on AFTER INSERT of comments/replies/likes/reactions
+--   3. RETURNS TRIGGER prevents direct RPC invocation
+--   4. SET search_path prevents search_path injection
+--   5. REVOKE EXECUTE blocks any future non-trigger invocation path
+--
+-- This mirrors 20260324000000_fix_counter_triggers_security_definer.sql,
+-- which applied the same fix to the counter triggers.
+
+BEGIN;
+
+-- =============================================
+-- 1. notify_on_comment
+-- =============================================
+CREATE OR REPLACE FUNCTION notify_on_comment() RETURNS TRIGGER
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+BEGIN
+  PERFORM net.http_post(
+    url := get_app_config('edge_function_url') || '/create-notification',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || get_app_config('service_role_key')
+    ),
+    body := jsonb_build_object(
+      'type', 'comment_on_post',
+      'comment_id', NEW.id,
+      'post_id', NEW.post_id,
+      'author_id', NEW.user_id
+    )
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =============================================
+-- 2. notify_on_reply
+-- =============================================
+CREATE OR REPLACE FUNCTION notify_on_reply() RETURNS TRIGGER
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+BEGIN
+  IF NEW.post_id IS NOT NULL THEN
+    PERFORM net.http_post(
+      url := get_app_config('edge_function_url') || '/create-notification',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || get_app_config('service_role_key')
+      ),
+      body := jsonb_build_object(
+        'type', 'reply_on_post',
+        'reply_id', NEW.id,
+        'post_id', NEW.post_id,
+        'author_id', NEW.user_id
+      )
+    );
+  END IF;
+
+  IF NEW.comment_id IS NOT NULL THEN
+    PERFORM net.http_post(
+      url := get_app_config('edge_function_url') || '/create-notification',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || get_app_config('service_role_key')
+      ),
+      body := jsonb_build_object(
+        'type', 'reply_on_comment',
+        'reply_id', NEW.id,
+        'comment_id', NEW.comment_id,
+        'author_id', NEW.user_id
+      )
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =============================================
+-- 3. notify_on_like
+-- =============================================
+CREATE OR REPLACE FUNCTION notify_on_like() RETURNS TRIGGER
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+BEGIN
+  PERFORM net.http_post(
+    url := get_app_config('edge_function_url') || '/create-notification',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || get_app_config('service_role_key')
+    ),
+    body := jsonb_build_object(
+      'type', 'like_on_post',
+      'like_id', NEW.id,
+      'post_id', NEW.post_id,
+      'author_id', NEW.user_id
+    )
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =============================================
+-- 4. notify_on_reaction
+-- =============================================
+CREATE OR REPLACE FUNCTION notify_on_reaction() RETURNS TRIGGER
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+BEGIN
+  IF NEW.comment_id IS NOT NULL THEN
+    PERFORM net.http_post(
+      url := get_app_config('edge_function_url') || '/create-notification',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || get_app_config('service_role_key')
+      ),
+      body := jsonb_build_object(
+        'type', 'reaction_on_comment',
+        'reaction_id', NEW.id,
+        'comment_id', NEW.comment_id,
+        'author_id', NEW.user_id
+      )
+    );
+  ELSIF NEW.reply_id IS NOT NULL THEN
+    PERFORM net.http_post(
+      url := get_app_config('edge_function_url') || '/create-notification',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || get_app_config('service_role_key')
+      ),
+      body := jsonb_build_object(
+        'type', 'reaction_on_reply',
+        'reaction_id', NEW.id,
+        'reply_id', NEW.reply_id,
+        'author_id', NEW.user_id
+      )
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =============================================
+-- 5. Defense-in-depth: prevent direct invocation
+-- =============================================
+-- These are trigger-only entry points. Revoking EXECUTE matches the
+-- pattern used by the counter-trigger fix and get_app_config.
+REVOKE EXECUTE ON FUNCTION notify_on_comment()  FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION notify_on_reply()    FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION notify_on_like()     FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION notify_on_reaction() FROM PUBLIC;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- `notify_on_comment` / `notify_on_reply` / `notify_on_like` / `notify_on_reaction` 4개 트리거 함수를 `SECURITY DEFINER` + `SET search_path = public, extensions` 로 재정의
- `20260324000000_fix_counter_triggers_security_definer.sql` 와 동일한 패턴 (counter 트리거 회귀를 같은 방식으로 막았던 선례)

## Why
이번 주에 `20260326000000_migrate_service_role_key_to_vault.sql` 가 prod 에 적용되면서 `REVOKE EXECUTE ON FUNCTION get_app_config(TEXT) FROM authenticated` 가 **실제로 처음** 실행되었다. (해당 REVOKE 가 retroactive 으로 `20260222000000_*` 에 추가됐지만, 그 마이그레이션은 이미 prod 에 적용되어 있어 재실행되지 않았기 때문)

이후부터 모든 사용자가 댓글/좋아요/리액션 작성 시:

1. INSERT → AFTER INSERT trigger 실행
2. `notify_on_*` (SECURITY INVOKER) 가 `authenticated` 권한으로 실행
3. `get_app_config('edge_function_url')` 호출 → `42501 permission denied for function get_app_config`
4. trigger 실패 → INSERT 롤백 → 클라이언트에 403 응답

브라우저 콘솔에서 관측된 실제 에러:
```
SupabaseWriteError: Supabase write error: permission denied for function get_app_config (code: 42501)
```

## Test plan
- [x] `supabase db push --linked` — prod 에 마이그레이션 적용 완료 (verified via `supabase migration list --linked`)
- [ ] 사용자가 직접 like / comment / reaction 작성해 200/201 반환 확인 — 작성자에 의해 prod 에서 검증 완료
- [ ] notification Edge Function 가 여전히 호출되는지 (Supabase logs / 알림 도착) 확인