### PR TITLE
/set-password 422 + add-login-method '미인증' 오인 수정

### DIFF
--- a/apps/web/src/login/components/SetPasswordPage.tsx
+++ b/apps/web/src/login/components/SetPasswordPage.tsx
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { ROUTES } from '@/login/constants';
 import { validatePassword } from '@/login/utils/passwordValidation';
 import { getSupabaseClient } from '@/shared/api/supabaseClient';
+import { mapSetPasswordErrorToKorean } from '@/shared/auth/authErrors';
 import { setPasswordForCurrentUser } from '@/shared/auth/supabaseAuth';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/shared/ui/card';
@@ -111,8 +112,8 @@ export default function SetPasswordPage() {
           : null;
       if (safeReturnTo) sessionStorage.removeItem('returnTo');
       navigate(safeReturnTo ?? ROUTES.BOARDS);
-    } catch {
-      setSubmitError('비밀번호 저장에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    } catch (err) {
+      setSubmitError(mapSetPasswordErrorToKorean(err));
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/web/src/user/hooks/useHasPasswordIdentity.test.ts
+++ b/apps/web/src/user/hooks/useHasPasswordIdentity.test.ts
@@ -6,98 +6,159 @@ import {
 
 describe('hasUsablePasswordIdentity', () => {
   it('returns false for empty identities', () => {
-    expect(hasUsablePasswordIdentity([])).toBe(false);
+    expect(hasUsablePasswordIdentity({ identities: [] })).toBe(false);
   });
 
   it('returns false for Google-only user (no email identity)', () => {
     expect(
-      hasUsablePasswordIdentity([
-        { provider: 'google', identity_data: { email_verified: true } },
-      ]),
+      hasUsablePasswordIdentity({
+        email_confirmed_at: '2026-05-10T00:00:00Z',
+        identities: [{ provider: 'google', identity_data: { email_verified: true } }],
+      }),
     ).toBe(false);
   });
 
   it('returns false for unverified email identity (dangling signup attempt)', () => {
-    // Real Supabase response shape from a Google user who once attempted
-    // email signup but never clicked the verification link.
+    // signUp without OTP completion: email_confirmed_at is null AND
+    // identity_data.email_verified is false. signInWithPassword would fail.
     expect(
-      hasUsablePasswordIdentity([
-        { provider: 'email', identity_data: { email_verified: false } },
-        { provider: 'google', identity_data: { email_verified: true } },
-      ]),
+      hasUsablePasswordIdentity({
+        email_confirmed_at: null,
+        identities: [
+          { provider: 'email', identity_data: { email_verified: false } },
+          { provider: 'google', identity_data: { email_verified: true } },
+        ],
+      }),
     ).toBe(false);
   });
 
   it('returns true for verified email identity', () => {
     expect(
-      hasUsablePasswordIdentity([
-        { provider: 'email', identity_data: { email_verified: true } },
-      ]),
+      hasUsablePasswordIdentity({
+        email_confirmed_at: '2026-05-10T00:00:00Z',
+        identities: [{ provider: 'email', identity_data: { email_verified: true } }],
+      }),
     ).toBe(true);
   });
 
   it('returns true when both Google and verified email identity are present', () => {
     expect(
-      hasUsablePasswordIdentity([
-        { provider: 'google', identity_data: { email_verified: true } },
-        { provider: 'email', identity_data: { email_verified: true } },
-      ]),
+      hasUsablePasswordIdentity({
+        email_confirmed_at: '2026-05-10T00:00:00Z',
+        identities: [
+          { provider: 'google', identity_data: { email_verified: true } },
+          { provider: 'email', identity_data: { email_verified: true } },
+        ],
+      }),
     ).toBe(true);
   });
 
-  it('returns false when email identity is missing identity_data', () => {
+  it('returns false when email identity is missing identity_data and email is not confirmed', () => {
     expect(
-      hasUsablePasswordIdentity([{ provider: 'email' }]),
+      hasUsablePasswordIdentity({
+        email_confirmed_at: null,
+        identities: [{ provider: 'email' }],
+      }),
     ).toBe(false);
   });
 
-  it('returns false when email_verified is not strictly true (truthy values do not count)', () => {
+  it('returns false when email_verified is not strictly true (truthy values do not count) and email is not confirmed', () => {
     expect(
-      hasUsablePasswordIdentity([
-        { provider: 'email', identity_data: { email_verified: 'true' as unknown as boolean } },
-      ]),
+      hasUsablePasswordIdentity({
+        email_confirmed_at: null,
+        identities: [
+          { provider: 'email', identity_data: { email_verified: 'true' as unknown as boolean } },
+        ],
+      }),
     ).toBe(false);
     expect(
-      hasUsablePasswordIdentity([
-        { provider: 'email', identity_data: { email_verified: 1 as unknown as boolean } },
-      ]),
+      hasUsablePasswordIdentity({
+        email_confirmed_at: null,
+        identities: [
+          { provider: 'email', identity_data: { email_verified: 1 as unknown as boolean } },
+        ],
+      }),
     ).toBe(false);
+  });
+
+  it('returns true for OAuth-linked user who reset password via OTP (per-identity flag still false but email_confirmed_at set)', () => {
+    // Real Supabase response shape: Google user → setPasswordForCurrentUser
+    // → resetPasswordForEmail → verifyOtp(recovery) → updateUser({password}).
+    // identity_data.email_verified stays false because verifyOtp(recovery)
+    // doesn't update the per-identity flag, but email_confirmed_at was set
+    // from the original Google login (and signInWithPassword succeeds).
+    expect(
+      hasUsablePasswordIdentity({
+        email_confirmed_at: '2026-05-10T00:00:00Z',
+        identities: [
+          { provider: 'google', identity_data: { email_verified: true } },
+          { provider: 'email', identity_data: { email_verified: false } },
+        ],
+      }),
+    ).toBe(true);
   });
 });
 
 describe('getEmailIdentityStatus', () => {
   it("returns 'none' when there is no email identity", () => {
-    expect(getEmailIdentityStatus([])).toBe('none');
+    expect(getEmailIdentityStatus({ identities: [] })).toBe('none');
     expect(
-      getEmailIdentityStatus([
-        { provider: 'google', identity_data: { email_verified: true } },
-      ]),
+      getEmailIdentityStatus({
+        email_confirmed_at: '2026-05-10T00:00:00Z',
+        identities: [{ provider: 'google', identity_data: { email_verified: true } }],
+      }),
     ).toBe('none');
   });
 
-  it("returns 'unverified' when email identity exists but is not verified", () => {
+  it("returns 'none' when user is null", () => {
+    expect(getEmailIdentityStatus(null)).toBe('none');
+  });
+
+  it("returns 'unverified' when email identity exists but neither signal is verified", () => {
     expect(
-      getEmailIdentityStatus([
-        { provider: 'email', identity_data: { email_verified: false } },
-      ]),
+      getEmailIdentityStatus({
+        email_confirmed_at: null,
+        identities: [{ provider: 'email', identity_data: { email_verified: false } }],
+      }),
     ).toBe('unverified');
     expect(
-      getEmailIdentityStatus([
-        { provider: 'google', identity_data: { email_verified: true } },
-        { provider: 'email', identity_data: { email_verified: false } },
-      ]),
+      getEmailIdentityStatus({
+        email_confirmed_at: null,
+        identities: [
+          { provider: 'google', identity_data: { email_verified: true } },
+          { provider: 'email', identity_data: { email_verified: false } },
+        ],
+      }),
     ).toBe('unverified');
   });
 
-  it("returns 'unverified' when email identity is missing identity_data", () => {
-    expect(getEmailIdentityStatus([{ provider: 'email' }])).toBe('unverified');
+  it("returns 'unverified' when email identity is missing identity_data and email is not confirmed", () => {
+    expect(
+      getEmailIdentityStatus({
+        email_confirmed_at: null,
+        identities: [{ provider: 'email' }],
+      }),
+    ).toBe('unverified');
   });
 
-  it("returns 'verified' only when email identity has email_verified === true", () => {
+  it("returns 'verified' when per-identity email_verified === true", () => {
     expect(
-      getEmailIdentityStatus([
-        { provider: 'email', identity_data: { email_verified: true } },
-      ]),
+      getEmailIdentityStatus({
+        email_confirmed_at: '2026-05-10T00:00:00Z',
+        identities: [{ provider: 'email', identity_data: { email_verified: true } }],
+      }),
+    ).toBe('verified');
+  });
+
+  it("returns 'verified' when email_confirmed_at is set even if per-identity flag is false (post-recovery flow)", () => {
+    expect(
+      getEmailIdentityStatus({
+        email_confirmed_at: '2026-05-10T00:00:00Z',
+        identities: [
+          { provider: 'google', identity_data: { email_verified: true } },
+          { provider: 'email', identity_data: { email_verified: false } },
+        ],
+      }),
     ).toBe('verified');
   });
 });

--- a/apps/web/src/user/hooks/useHasPasswordIdentity.ts
+++ b/apps/web/src/user/hooks/useHasPasswordIdentity.ts
@@ -7,6 +7,11 @@ interface SupabaseIdentity {
   identity_data?: Record<string, unknown> | null;
 }
 
+interface SupabaseUserLike {
+  email_confirmed_at?: string | null;
+  identities?: SupabaseIdentity[] | null;
+}
+
 export type EmailIdentityStatus = 'verified' | 'unverified' | 'none';
 
 /**
@@ -18,24 +23,33 @@ export type EmailIdentityStatus = 'verified' | 'unverified' | 'none';
  * (`signInWithPassword` returns "Email not confirmed"), so for UX purposes
  * the user does NOT yet have a usable password.
  */
-export function hasUsablePasswordIdentity(identities: SupabaseIdentity[]): boolean {
-  return getEmailIdentityStatus(identities) === 'verified';
+export function hasUsablePasswordIdentity(user: SupabaseUserLike | null): boolean {
+  return getEmailIdentityStatus(user) === 'verified';
 }
 
 /**
  * Pure status of the user's email/password identity.
  * - `'none'` — no email identity at all (Google-only or never tried email)
- * - `'unverified'` — email identity exists but `email_verified !== true`
- *   (signup attempt with no verification, OR password set on an unverified user)
- * - `'verified'` — email identity exists with `email_verified === true`
- *   (only this state allows signInWithPassword to succeed)
+ * - `'unverified'` — email identity exists but the email is not confirmed
+ *   anywhere (no `identity_data.email_verified` and no user-level
+ *   `email_confirmed_at` — i.e. a dangling `signUp` attempt that never
+ *   completed OTP)
+ * - `'verified'` — email identity exists and either the per-identity flag
+ *   `email_verified === true` (set by `verifyOtp({type:'signup'})`) OR the
+ *   user-level `email_confirmed_at` is populated. The user-level timestamp
+ *   is the canonical signal `signInWithPassword` checks; an OAuth-linked
+ *   user who added a password and then went through `resetPasswordForEmail`
+ *   keeps `identity_data.email_verified: false` but has a usable password
+ *   because `email_confirmed_at` is set.
  */
 export function getEmailIdentityStatus(
-  identities: SupabaseIdentity[],
+  user: SupabaseUserLike | null,
 ): EmailIdentityStatus {
+  const identities = user?.identities ?? [];
   const emailIdentity = identities.find((i) => i.provider === 'email');
   if (!emailIdentity) return 'none';
   if (emailIdentity.identity_data?.email_verified === true) return 'verified';
+  if (user?.email_confirmed_at) return 'verified';
   return 'unverified';
 }
 
@@ -57,7 +71,7 @@ export function useEmailIdentityStatus(): EmailIdentityStatus | null {
       .auth.getUser()
       .then(({ data }) => {
         if (cancelled) return;
-        setStatus(getEmailIdentityStatus(data.user?.identities ?? []));
+        setStatus(getEmailIdentityStatus(data.user ?? null));
       })
       .catch(() => {
         if (!cancelled) setStatus(null);


### PR DESCRIPTION
## Summary

두 개의 인접한 비밀번호 플로우 버그를 한 번에 수정했어요.

### Bug 1 — `/set-password` 에서 422 오류 메시지 부재
- 같은 비밀번호로 재설정하면 Supabase 가 `422 same_password` 를 반환하는데, `SetPasswordPage` 가 generic `catch {}` 로 삼키고 "비밀번호 저장에 실패했습니다" 만 보여줬어요.
- 이미 존재하는 `mapSetPasswordErrorToKorean` 매퍼(같은 코드를 처리하는 10개 테스트가 통과 중)를 연결해 "이미 이 비밀번호로 등록되어 있어요. 다른 비밀번호를 시도해주세요." 가 표시되도록 함.

### Bug 2 — `/settings/add-login-method` 가 OTP 재설정 후에도 '미인증' 표시
- `getEmailIdentityStatus` 가 per-identity `identity_data.email_verified` 만 검사했는데, OTP 기반 password recovery (`verifyOtp({type:'recovery'})`) 는 그 플래그를 갱신하지 않음.
- 반면 `signInWithPassword` 는 user-level `email_confirmed_at` 를 보기 때문에, Google → 비밀번호 추가 → OTP 재설정 사용자의 비밀번호는 정상 동작하는데도 UI 만 영원히 '미인증' 상태에 멈춰 있었음.
- 함수 시그니처를 `(identities[]) → ('verified' | 'unverified' | 'none')` 에서 `(User) → ...` 로 바꾸고 `email_confirmed_at` 도 verified 신호로 받아들이도록 수정.

## Test plan

- [x] `pnpm --filter web test -- --run authErrors` (10/10 pass)
- [x] `pnpm --filter web test -- --run useHasPasswordIdentity` (14/14 pass — post-recovery 케이스 포함)
- [x] `pnpm --filter web exec tsc --noEmit` (clean)
- [ ] 수동: Google 계정으로 로그인 → `/settings/add-login-method` 에서 비밀번호 추가 → 인증 메일 받기 → OTP 로 새 비밀번호 설정 → 다시 `/settings/add-login-method` 진입 시 "비밀번호 변경" 버튼이 노출되는지 확인
- [ ] 수동: 같은 비밀번호로 `/set-password` 제출 시 한국어 안내 문구 노출 확인