### PR TITLE
클라이언트 N+1 방지: donator_status 픽스 + Batch-First Hook 컨벤션

### DIFF
--- a/.claude/skills/api-layer/SKILL.md
+++ b/.claude/skills/api-layer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-layer
-description: Use when creating or modifying API functions in */api/ directories. Enforces Firestore patterns and data fetching conventions.
+description: Use when creating or modifying API functions in */api/ directories or data-fetching hooks. Enforces Firestore patterns, data fetching conventions, and N+1 prevention.
 ---
 
 # API Layer Patterns

--- a/.claude/skills/api-layer/SKILL.md
+++ b/.claude/skills/api-layer/SKILL.md
@@ -78,6 +78,41 @@ const mutation = useMutation({
 });
 ```
 
+## N+1 Prevention: Batch-First Hook Convention
+
+### Rule
+
+Expose list-context data fetchers as one batch hook taking `ids: string[]` and returning `Set<id>` or `Map<id, T>`. Do not create a singular wrapper that delegates to the batch hook with a single-element array.
+
+### Anti-pattern
+
+```ts
+// N+1 vector — unique queryKey per id, React Query cannot dedupe
+export function useDonatorStatus(userId: string) {
+  const { activeUserIds } = useDonatorStatusBatch([userId]);
+  return activeUserIds.has(userId);
+}
+```
+
+A row component calling this passes review. Mount 100 rows and you get 100 HTTP calls.
+
+### Correct shape
+
+```ts
+// Only the batch hook is exposed.
+// The list parent fetches once; rows read from props.
+const { activeUserIds } = useDonatorStatusBatch(authors.map(a => a.id));
+// Pass isDonator={activeUserIds.has(author.id)} to each row.
+```
+
+### Single-id contexts (profile page, etc.)
+
+Call the raw fetcher (`fetchActiveDonatorIds([id])`) inline within a page-local hook. Do not export a shared singular hook — a future list will reuse it and reopen the trap.
+
+### Why
+
+A singular wrapper passes code review because each row uses one hook in isolation. N+1 emerges only when many rows mount together. Removing the wrapper removes the trap at the source.
+
 ## Quick Reference
 
 | Pattern | When |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,23 @@ All commands run from repository root.
 | `tailwind.config.js` | Tailwind CSS configuration |
 | `supabase/config.toml` | Supabase local dev config |
 
+## Skills
+
+`.claude/skills/` contains project-specific coding conventions. Each skill auto-loads via its frontmatter trigger.
+
+| Skill | Domain |
+|-------|--------|
+| `api-layer` | Data fetchers, API functions, list-fetching hooks (N+1 prevention) |
+| `react-component` | `.tsx` component structure |
+| `react-hook` | Custom hook patterns, exhaustive-deps |
+| `firebase-functions` | Cloud Functions in `/functions` |
+| `daily-writing-friends-design` | UI / Tailwind conventions |
+| `testing` | TDD, output-based test patterns |
+| `refactoring` | Functional Core / Imperative Shell extraction |
+| `type-system` | Type safety reviews |
+| `verify-runtime` | Verifying data-flow changes via dev logs |
+| `code-style` | Naming and clarity rules |
+
 ## Related Docs
 
 - [Authentication & Routing](./docs/AUTHENTICATION_ROUTING.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ All commands run from repository root.
 
 ## Skills
 
-`.claude/skills/` contains project-specific coding conventions. Each skill auto-loads via its frontmatter trigger.
+`.claude/skills/` contains project-specific coding conventions.
 
 | Skill | Domain |
 |-------|--------|

--- a/apps/web/src/donator/hooks/useDonatorStatus.ts
+++ b/apps/web/src/donator/hooks/useDonatorStatus.ts
@@ -5,10 +5,6 @@ import { buildDonatorQueryIds } from '../utils/donatorQueryKeys';
 
 const FIVE_MINUTES_MS = 5 * 60 * 1000;
 
-// TODO(perf): Each PostUserProfile renders calls useDonatorStatus independently. React
-// Query dedupes identical queryKeys, but a feed of N unique authors still fires N parallel
-// donator_status lookups on first load. Once we touch useBatchPostCardData again, hoist
-// this lookup there and pass isDonator down via PostCardPrefetchedData.
 export function useDonatorStatusBatch(userIds: string[]) {
   const stableIds = useMemo(() => buildDonatorQueryIds(userIds), [userIds]);
 
@@ -21,13 +17,4 @@ export function useDonatorStatusBatch(userIds: string[]) {
 
   const activeUserIds = useMemo(() => new Set(query.data ?? []), [query.data]);
   return { activeUserIds, isLoading: query.isLoading };
-}
-
-export function useDonatorStatus(userId: string | undefined) {
-  const ids = useMemo(() => (userId ? [userId] : []), [userId]);
-  const { activeUserIds, isLoading } = useDonatorStatusBatch(ids);
-  return {
-    isDonator: userId ? activeUserIds.has(userId) : false,
-    isLoading,
-  };
 }

--- a/apps/web/src/post/components/PostCard.tsx
+++ b/apps/web/src/post/components/PostCard.tsx
@@ -33,6 +33,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick, onClickProfile, pref
     streak,
     isStreakLoading,
     isPrivate,
+    isDonator,
     contentPreview,
   } = usePostCard(post, prefetchedData, isBatchMode);
 
@@ -63,6 +64,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick, onClickProfile, pref
           isPrivate={isPrivate}
           authorData={authorData}
           isAuthorLoading={isAuthorLoading}
+          isDonator={isDonator}
           badges={badges}
           streak={streak}
           isStreakLoading={isStreakLoading}
@@ -87,6 +89,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, onClick, onClickProfile, pref
               isPrivate={isPrivate}
               authorData={authorData}
               isAuthorLoading={isAuthorLoading}
+              isDonator={isDonator}
               badges={badges}
               streak={streak}
               isStreakLoading={isStreakLoading}

--- a/apps/web/src/post/components/PostCardHeader.tsx
+++ b/apps/web/src/post/components/PostCardHeader.tsx
@@ -12,6 +12,7 @@ interface PostCardHeaderProps {
   isPrivate: boolean;
   authorData: PostAuthorData;
   isAuthorLoading: boolean;
+  isDonator: boolean;
   badges?: WritingBadge[];
   streak?: boolean[];
   isStreakLoading?: boolean;
@@ -24,6 +25,7 @@ export const PostCardHeader: React.FC<PostCardHeaderProps> = ({
   isPrivate,
   authorData,
   isAuthorLoading,
+  isDonator,
   badges,
   streak,
   isStreakLoading,
@@ -36,6 +38,7 @@ export const PostCardHeader: React.FC<PostCardHeaderProps> = ({
         <PostUserProfile
           authorData={authorData}
           isLoading={isAuthorLoading}
+          isDonator={isDonator}
           onClickProfile={onClickProfile || noopClickHandler}
           badges={badges}
           streak={streak}

--- a/apps/web/src/post/components/PostUserProfile.tsx
+++ b/apps/web/src/post/components/PostUserProfile.tsx
@@ -1,5 +1,4 @@
 import { DonatorBadge } from '@/donator/components/DonatorBadge';
-import { useDonatorStatus } from '@/donator/hooks/useDonatorStatus';
 import ComposedAvatar from '@/shared/ui/ComposedAvatar';
 import { Skeleton } from '@/shared/ui/skeleton';
 import { PostingStreakBadge } from '@/stats/components/PostingStreakBadge';
@@ -18,6 +17,7 @@ export interface PostAuthorData {
 interface PostUserProfileProps {
   authorData: PostAuthorData | null;
   isLoading: boolean;
+  isDonator: boolean;
   onClickProfile: (e: React.MouseEvent) => void;
   badges?: WritingBadge[];
   streak?: boolean[];
@@ -27,12 +27,12 @@ interface PostUserProfileProps {
 export const PostUserProfile: React.FC<PostUserProfileProps> = ({
   authorData,
   isLoading,
+  isDonator,
   onClickProfile,
   badges,
   streak,
   isStreakLoading,
 }) => {
-  const { isDonator } = useDonatorStatus(authorData?.id);
   return (
   <div className='flex items-center'>
     {isLoading ? (

--- a/apps/web/src/post/hooks/__tests__/useBatchPostCardData.test.ts
+++ b/apps/web/src/post/hooks/__tests__/useBatchPostCardData.test.ts
@@ -62,6 +62,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows: [],
         streakWorkingDays: workingDays,
+        donatorIds: new Set(),
       });
 
       const data = result.get('unknown-user');
@@ -77,7 +78,15 @@ describe('buildPostCardDataMap', () => {
         { id: 'user-1', nickname: 'Cool Nick', real_name: 'Real Name', profile_photo_url: 'https://photo.url' },
       ];
 
-      const result = buildPostCardDataMap({ authorIds: ['user-1'], users, commentRows: [], replyRows: [], postRows: [], streakWorkingDays: workingDays });
+      const result = buildPostCardDataMap({
+        authorIds: ['user-1'],
+        users,
+        commentRows: [],
+        replyRows: [],
+        postRows: [],
+        streakWorkingDays: workingDays,
+        donatorIds: new Set(),
+      });
 
       expect(result.get('user-1')!.authorData.displayName).toBe('Cool Nick');
       expect(result.get('user-1')!.authorData.profileImageURL).toBe('https://photo.url');
@@ -90,7 +99,15 @@ describe('buildPostCardDataMap', () => {
         { id: 'user-1', nickname: null, real_name: 'Real Name', profile_photo_url: null },
       ];
 
-      const result = buildPostCardDataMap({ authorIds: ['user-1'], users, commentRows: [], replyRows: [], postRows: [], streakWorkingDays: workingDays });
+      const result = buildPostCardDataMap({
+        authorIds: ['user-1'],
+        users,
+        commentRows: [],
+        replyRows: [],
+        postRows: [],
+        streakWorkingDays: workingDays,
+        donatorIds: new Set(),
+      });
 
       expect(result.get('user-1')!.authorData.displayName).toBe('Real Name');
       expect(result.get('user-1')!.authorData.profileImageURL).toBe('');
@@ -103,7 +120,15 @@ describe('buildPostCardDataMap', () => {
         { id: 'user-1', nickname: '   ', real_name: 'Real Name', profile_photo_url: null },
       ];
 
-      const result = buildPostCardDataMap({ authorIds: ['user-1'], users, commentRows: [], replyRows: [], postRows: [], streakWorkingDays: workingDays });
+      const result = buildPostCardDataMap({
+        authorIds: ['user-1'],
+        users,
+        commentRows: [],
+        replyRows: [],
+        postRows: [],
+        streakWorkingDays: workingDays,
+        donatorIds: new Set(),
+      });
 
       expect(result.get('user-1')!.authorData.displayName).toBe('Real Name');
     });
@@ -122,6 +147,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows: [],
         streakWorkingDays: workingDays,
+        donatorIds: new Set(),
       });
 
       expect(result.size).toBe(2);
@@ -150,6 +176,7 @@ describe('buildPostCardDataMap', () => {
         replyRows,
         postRows: [],
         streakWorkingDays: workingDays,
+        donatorIds: new Set(),
       });
 
       expect(result.get('user-1')!.badges.length).toBeGreaterThan(0);
@@ -162,7 +189,15 @@ describe('buildPostCardDataMap', () => {
         { id: 'user-1', nickname: 'Alice', real_name: null, profile_photo_url: null },
       ];
 
-      const result = buildPostCardDataMap({ authorIds: ['user-1'], users, commentRows: [], replyRows: [], postRows: [], streakWorkingDays: workingDays });
+      const result = buildPostCardDataMap({
+        authorIds: ['user-1'],
+        users,
+        commentRows: [],
+        replyRows: [],
+        postRows: [],
+        streakWorkingDays: workingDays,
+        donatorIds: new Set(),
+      });
 
       expect(result.get('user-1')!.badges).toEqual([]);
     });
@@ -185,6 +220,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows,
         streakWorkingDays: workingDays,
+        donatorIds: new Set(),
       });
 
       const streak = result.get('user-1')!.streak;
@@ -194,6 +230,28 @@ describe('buildPostCardDataMap', () => {
       expect(streak[2]).toBe(true);  // 04-23
       expect(streak[3]).toBe(false); // 04-24
       expect(streak[4]).toBe(false); // 04-25
+    });
+  });
+
+  describe('donator status', () => {
+    it('marks author as donator when id is in donatorIds set', () => {
+      const users: BasicUserRow[] = [
+        { id: 'user-1', nickname: 'Alice', real_name: null, profile_photo_url: null },
+        { id: 'user-2', nickname: 'Bob', real_name: null, profile_photo_url: null },
+      ];
+
+      const result = buildPostCardDataMap({
+        authorIds: ['user-1', 'user-2'],
+        users,
+        commentRows: [],
+        replyRows: [],
+        postRows: [],
+        streakWorkingDays: workingDays,
+        donatorIds: new Set(['user-1']),
+      });
+
+      expect(result.get('user-1')!.isDonator).toBe(true);
+      expect(result.get('user-2')!.isDonator).toBe(false);
     });
   });
 });

--- a/apps/web/src/post/hooks/__tests__/useBatchPostCardData.test.ts
+++ b/apps/web/src/post/hooks/__tests__/useBatchPostCardData.test.ts
@@ -62,7 +62,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows: [],
         streakWorkingDays: workingDays,
-        donatorIds: new Set(),
+        donatorIds: new Set<string>(),
       });
 
       const data = result.get('unknown-user');
@@ -85,7 +85,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows: [],
         streakWorkingDays: workingDays,
-        donatorIds: new Set(),
+        donatorIds: new Set<string>(),
       });
 
       expect(result.get('user-1')!.authorData.displayName).toBe('Cool Nick');
@@ -106,7 +106,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows: [],
         streakWorkingDays: workingDays,
-        donatorIds: new Set(),
+        donatorIds: new Set<string>(),
       });
 
       expect(result.get('user-1')!.authorData.displayName).toBe('Real Name');
@@ -127,7 +127,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows: [],
         streakWorkingDays: workingDays,
-        donatorIds: new Set(),
+        donatorIds: new Set<string>(),
       });
 
       expect(result.get('user-1')!.authorData.displayName).toBe('Real Name');
@@ -147,7 +147,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows: [],
         streakWorkingDays: workingDays,
-        donatorIds: new Set(),
+        donatorIds: new Set<string>(),
       });
 
       expect(result.size).toBe(2);
@@ -176,7 +176,7 @@ describe('buildPostCardDataMap', () => {
         replyRows,
         postRows: [],
         streakWorkingDays: workingDays,
-        donatorIds: new Set(),
+        donatorIds: new Set<string>(),
       });
 
       expect(result.get('user-1')!.badges.length).toBeGreaterThan(0);
@@ -196,7 +196,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows: [],
         streakWorkingDays: workingDays,
-        donatorIds: new Set(),
+        donatorIds: new Set<string>(),
       });
 
       expect(result.get('user-1')!.badges).toEqual([]);
@@ -220,7 +220,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows,
         streakWorkingDays: workingDays,
-        donatorIds: new Set(),
+        donatorIds: new Set<string>(),
       });
 
       const streak = result.get('user-1')!.streak;
@@ -247,7 +247,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows: [],
         streakWorkingDays: workingDays,
-        donatorIds: new Set(['user-1']),
+        donatorIds: new Set<string>(['user-1']),
       });
 
       expect(result.get('user-1')!.isDonator).toBe(true);
@@ -267,7 +267,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows: [],
         streakWorkingDays: workingDays,
-        donatorIds: new Set(),
+        donatorIds: new Set<string>(),
       });
 
       expect(result.get('user-1')!.isDonator).toBe(false);
@@ -284,7 +284,7 @@ describe('buildPostCardDataMap', () => {
         replyRows: [],
         postRows: [],
         streakWorkingDays: workingDays,
-        donatorIds: new Set(['unknown-user']),
+        donatorIds: new Set<string>(['unknown-user']),
       });
 
       expect(result.get('unknown-user')!.isDonator).toBe(true);

--- a/apps/web/src/post/hooks/__tests__/useBatchPostCardData.test.ts
+++ b/apps/web/src/post/hooks/__tests__/useBatchPostCardData.test.ts
@@ -253,5 +253,42 @@ describe('buildPostCardDataMap', () => {
       expect(result.get('user-1')!.isDonator).toBe(true);
       expect(result.get('user-2')!.isDonator).toBe(false);
     });
+
+    it('returns isDonator=false for every author when donatorIds is empty', () => {
+      const users: BasicUserRow[] = [
+        { id: 'user-1', nickname: 'Alice', real_name: null, profile_photo_url: null },
+        { id: 'user-2', nickname: 'Bob', real_name: null, profile_photo_url: null },
+      ];
+
+      const result = buildPostCardDataMap({
+        authorIds: ['user-1', 'user-2'],
+        users,
+        commentRows: [],
+        replyRows: [],
+        postRows: [],
+        streakWorkingDays: workingDays,
+        donatorIds: new Set(),
+      });
+
+      expect(result.get('user-1')!.isDonator).toBe(false);
+      expect(result.get('user-2')!.isDonator).toBe(false);
+    });
+
+    it('marks author as donator even when their user row is missing', () => {
+      // Donator status comes from a separate table; missing user data
+      // should not suppress the donator flag.
+      const result = buildPostCardDataMap({
+        authorIds: ['unknown-user'],
+        users: [],
+        commentRows: [],
+        replyRows: [],
+        postRows: [],
+        streakWorkingDays: workingDays,
+        donatorIds: new Set(['unknown-user']),
+      });
+
+      expect(result.get('unknown-user')!.isDonator).toBe(true);
+      expect(result.get('unknown-user')!.authorData.displayName).toBe('??');
+    });
   });
 });

--- a/apps/web/src/post/hooks/useBatchPostCardData.ts
+++ b/apps/web/src/post/hooks/useBatchPostCardData.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
+import { fetchActiveDonatorIds } from '@/donator/api/donator';
 import type { Post } from '@/post/model/Post';
 import {
   buildPostCardDataMap,
@@ -53,11 +54,12 @@ async function fetchBatchPostCardData(
   const temperatureDateRange = getDateRange(temperatureWorkingDays);
   const streakDateRange = getDateRange(streakWorkingDays);
 
-  const [users, commentRows, replyRows, postRows] = await Promise.all([
+  const [users, commentRows, replyRows, postRows, donatorIdList] = await Promise.all([
     fetchBatchUsersBasic(authorIds),
     fetchBatchCommentUserIdsByDateRange(authorIds, temperatureDateRange.start, temperatureDateRange.end),
     fetchBatchReplyUserIdsByDateRange(authorIds, temperatureDateRange.start, temperatureDateRange.end),
     fetchBatchPostDatesByDateRange(authorIds, streakDateRange.start, streakDateRange.end),
+    fetchActiveDonatorIds(authorIds),
   ]);
 
   return buildPostCardDataMap({
@@ -67,5 +69,6 @@ async function fetchBatchPostCardData(
     replyRows,
     postRows,
     streakWorkingDays,
+    donatorIds: new Set(donatorIdList),
   });
 }

--- a/apps/web/src/post/hooks/usePostCard.ts
+++ b/apps/web/src/post/hooks/usePostCard.ts
@@ -16,6 +16,7 @@ export interface UsePostCardReturn {
   streak?: boolean[];
   isStreakLoading: boolean;
   isPrivate: boolean;
+  isDonator: boolean;
   contentPreview: string | null;
 }
 
@@ -63,6 +64,7 @@ export const usePostCard = (
     streak: prefetched ? prefetched.streak : streakData?.streak,
     isStreakLoading: prefetched ? false : isStreakLoading,
     isPrivate,
+    isDonator: prefetched?.isDonator ?? false,
     contentPreview,
   };
 };

--- a/apps/web/src/post/hooks/usePostCard.ts
+++ b/apps/web/src/post/hooks/usePostCard.ts
@@ -21,6 +21,10 @@ export interface UsePostCardReturn {
   contentPreview: string | null;
 }
 
+// Grace period that gives the parent batch query time to resolve before we
+// treat an undefined prefetched entry as a persistent map miss.
+const BATCH_DATA_MISS_GRACE_MS = 1500;
+
 /**
  * @param post - Post data
  * @param prefetched - Batch-fetched data (when available)
@@ -59,18 +63,21 @@ export const usePostCard = (
   }, [prefetched, post.authorId, userData, post.authorName, post.authorProfileImageURL]);
 
   // Diagnostic: batch mode active but no prefetched data for this author.
-  // Fires during initial load (transient) AND on persistent map-misses (real bug).
-  // Production no-op via devLog. Accept dev-mode noise as the tradeoff for catching
-  // silent regressions where a fetcher gets dropped from the Promise.all.
+  // The grace period suppresses transient loading-phase misses — if prefetched
+  // arrives within BATCH_DATA_MISS_GRACE_MS, the cleanup cancels the log.
+  // A persistent miss (fetcher dropped from Promise.all, author missing from map)
+  // still fires after the grace period. Production no-op via devLog.
   useEffect(() => {
-    if (isBatchMode && !prefetched && post.authorId) {
+    if (!isBatchMode || prefetched || !post.authorId) return;
+    const timer = setTimeout(() => {
       devLog({
         category: 'usePostCard',
         event: 'batch-data-miss',
         level: 'warn',
         data: { authorId: post.authorId },
       });
-    }
+    }, BATCH_DATA_MISS_GRACE_MS);
+    return () => clearTimeout(timer);
   }, [isBatchMode, prefetched, post.authorId]);
 
   return {

--- a/apps/web/src/post/hooks/usePostCard.ts
+++ b/apps/web/src/post/hooks/usePostCard.ts
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { PostAuthorData } from '@/post/components/PostUserProfile';
 import type { PostCardPrefetchedData } from '@/post/hooks/useBatchPostCardData';
 import { type Post, PostVisibility } from '@/post/model/Post';
 import { renderPostPreviewHtml } from '@/post/utils/contentUtils';
+import { devLog } from '@/shared/utils/devLog';
 import { usePostingStreak } from '@/stats/hooks/usePostingStreak';
 import { usePostProfileBadges } from '@/stats/hooks/usePostProfileBadges';
 import type { WritingBadge } from '@/stats/model/WritingStats';
@@ -56,6 +57,21 @@ export const usePostCard = (
       profileImageURL: userData?.profilePhotoURL || post.authorProfileImageURL || '',
     };
   }, [prefetched, post.authorId, userData, post.authorName, post.authorProfileImageURL]);
+
+  // Diagnostic: batch mode active but no prefetched data for this author.
+  // Fires during initial load (transient) AND on persistent map-misses (real bug).
+  // Production no-op via devLog. Accept dev-mode noise as the tradeoff for catching
+  // silent regressions where a fetcher gets dropped from the Promise.all.
+  useEffect(() => {
+    if (isBatchMode && !prefetched && post.authorId) {
+      devLog({
+        category: 'usePostCard',
+        event: 'batch-data-miss',
+        level: 'warn',
+        data: { authorId: post.authorId },
+      });
+    }
+  }, [isBatchMode, prefetched, post.authorId]);
 
   return {
     authorData,

--- a/apps/web/src/post/utils/batchPostCardDataUtils.ts
+++ b/apps/web/src/post/utils/batchPostCardDataUtils.ts
@@ -10,6 +10,7 @@ export interface PostCardPrefetchedData {
   authorData: PostAuthorData;
   badges: WritingBadge[];
   streak: boolean[];
+  isDonator: boolean;
 }
 
 export function deduplicateAuthorIds(posts: Post[]): string[] {
@@ -23,6 +24,7 @@ export interface BuildPostCardDataMapInput {
   replyRows: UserIdRow[];
   postRows: PostDateRow[];
   streakWorkingDays: Date[];
+  donatorIds: Set<string>;
 }
 
 export function buildPostCardDataMap({
@@ -32,6 +34,7 @@ export function buildPostCardDataMap({
   replyRows,
   postRows,
   streakWorkingDays,
+  donatorIds,
 }: BuildPostCardDataMapInput): Map<string, PostCardPrefetchedData> {
   const usersMap = new Map(users.map(u => [u.id, u]));
 
@@ -65,7 +68,12 @@ export function buildPostCardDataMap({
     const postDates = postDatesMap.get(authorId) ?? new Set<string>();
     const streak = streakWorkingDays.map(day => postDates.has(getDateKey(day)));
 
-    result.set(authorId, { authorData, badges, streak });
+    result.set(authorId, {
+      authorData,
+      badges,
+      streak,
+      isDonator: donatorIds.has(authorId),
+    });
   }
 
   return result;

--- a/apps/web/src/user/components/UserProfile.tsx
+++ b/apps/web/src/user/components/UserProfile.tsx
@@ -1,7 +1,7 @@
 import { Edit } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { DonatorBadge } from '@/donator/components/DonatorBadge';
-import { useDonatorStatus } from '@/donator/hooks/useDonatorStatus';
+import { useDonatorStatusBatch } from '@/donator/hooks/useDonatorStatus';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
 import { Button } from '@/shared/ui/button';
@@ -15,7 +15,8 @@ interface UserProfileProps {
 
 export default function UserProfile({ uid }: UserProfileProps) {
   const { userData, isLoading } = useUser(uid);
-  const { isDonator } = useDonatorStatus(uid);
+  const { activeUserIds } = useDonatorStatusBatch([uid]);
+  const isDonator = activeUserIds.has(uid);
 
   if (isLoading) {
     return (

--- a/apps/web/src/user/components/UserProfile.tsx
+++ b/apps/web/src/user/components/UserProfile.tsx
@@ -1,7 +1,8 @@
+import { useQuery } from '@tanstack/react-query';
 import { Edit } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { DonatorBadge } from '@/donator/components/DonatorBadge';
-import { useDonatorStatusBatch } from '@/donator/hooks/useDonatorStatus';
+import { fetchActiveDonatorIds } from '@/donator/api/donator';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
 import { Button } from '@/shared/ui/button';
@@ -9,14 +10,28 @@ import { Skeleton } from '@/shared/ui/skeleton';
 import { getUserDisplayName } from '@/shared/utils/userUtils';
 import { useUser } from '@/user/hooks/useUser';
 
+const DONATOR_STATUS_STALE_TIME_MS = 5 * 60 * 1000;
+
+// Page-local single-context hook — intentionally not exported.
+// List views must batch through useBatchPostCardData; a shared singular
+// export would reopen the N+1 trap when reused inside a list .map().
+function useDonatorStatusForProfile(uid: string): boolean {
+  const { data } = useQuery({
+    queryKey: ['donator-status-profile', uid],
+    queryFn: () => fetchActiveDonatorIds([uid]),
+    staleTime: DONATOR_STATUS_STALE_TIME_MS,
+    enabled: !!uid,
+  });
+  return data?.includes(uid) ?? false;
+}
+
 interface UserProfileProps {
   uid: string;
 }
 
 export default function UserProfile({ uid }: UserProfileProps) {
   const { userData, isLoading } = useUser(uid);
-  const { activeUserIds } = useDonatorStatusBatch([uid]);
-  const isDonator = activeUserIds.has(uid);
+  const isDonator = useDonatorStatusForProfile(uid);
 
   if (isLoading) {
     return (

--- a/docs/plans/2026-05-16-prevent-client-n-plus-one-design.md
+++ b/docs/plans/2026-05-16-prevent-client-n-plus-one-design.md
@@ -1,0 +1,171 @@
+# Preventing Client-Side N+1 API Calls
+
+**Date:** 2026-05-16
+**Status:** Proposed
+**Triggering incident:** Sentry issue 7471070471 (board `b969e11a-…`, Samsung Internet on Android 10)
+
+## Context
+
+A production Sentry trace showed seven separate HTTP calls to `/donator_status?user_id=in.(SINGLE_ID)` for seven distinct post authors on one board view. The endpoint already accepts a batched `in.(id1, …, id7)` query. On a 4G mobile network the seven serial round-trips added roughly 700ms of dead time before the page became interactive.
+
+This is the canonical N+1 shape: one call fetches the list, then one call fires per item.
+
+## Root cause
+
+`apps/web/src/donator/hooks/useDonatorStatus.ts` exposes both a correct batch hook and a singular wrapper that delegates to it with a single-element array:
+
+```ts
+// Correct primitive — one fetch for all ids
+export function useDonatorStatusBatch(userIds: string[]) {
+  return useQuery({
+    queryKey: ['donator-status', stableIds(userIds)],
+    queryFn: () => fetchActiveDonatorIds(userIds),
+  });
+}
+
+// The N+1 vector — unique queryKey per userId
+export function useDonatorStatus(userId: string | undefined) {
+  const ids = useMemo(() => (userId ? [userId] : []), [userId]);
+  return useDonatorStatusBatch(ids);
+}
+```
+
+Each row calls `useDonatorStatus(authorId)`. Each call produces a distinct `queryKey` (`['donator-status', ['authorId']]`). React Query cannot dedupe distinct keys, so every row fires its own HTTP request.
+
+The TODO at line 8–11 of the same file already named the problem: "a feed of N unique authors still fires N parallel donator_status lookups on first load." The fix was deferred and the trap kept shipping.
+
+## Research: how the React community prevents this
+
+| Approach | 2025–2026 status | Verdict for our stack |
+|----------|------------------|-----------------------|
+| `dataloader` on the client | Niche; fragile under React 18 Concurrent rendering | Discard |
+| TanStack Query `useQueries` | Parallelizes; does not batch network calls (maintainer points users to third-party `batshit`) | Wrong tool |
+| tRPC `httpBatchLink` | Standard inside tRPC only; tightly coupled to its protocol | Out of scope |
+| React Server Components + `React.cache()` | Dedupes identical requests; does not batch N distinct keys; our page is client-rendered | Wrong layer |
+| ESLint rules | No off-the-shelf rule catches `.map(x => useHook(x.id))` | Custom only |
+| Supabase `.in()` + one `useQuery` | Documented standard; our endpoint already supports it | Adopt |
+
+The community standard is structural, not exotic: one fetcher takes `ids: string[]` and uses `.in()`. React itself ships no built-in coalescer because none is required when the data layer exposes the right shape.
+
+## Rule
+
+> **Expose list-context data fetchers as one batch hook taking `ids: string[]` and returning `Set<id>` or `Map<id, T>`. Do not create a singular wrapper that delegates to the batch hook with a single-element array.**
+
+A singular wrapper passes code review because each row uses one hook in isolation. N+1 emerges only when many rows mount together. Removing the wrapper removes the trap at the source.
+
+### Single-id contexts
+
+A page that legitimately fetches one record (profile page, settings) calls the raw fetcher inline within a page-local hook. Shared singular hooks are forbidden because a future list view will reuse them and reopen the trap.
+
+## Enforcement
+
+Two structural layers; one deferred.
+
+**Layer 1 — File-level encapsulation.** A feature's `hooks/use*.ts` exposes only the batch hook. Singular wrappers do not exist as exports.
+
+**Layer 2 — Return type.** Batch hooks return `Set<id>` or `Map<id, T>` rather than a single value. The caller must lift the fetch to the list parent and pass `.has(id)` or `.get(id)` results down as props.
+
+**Deferred — Custom ESLint rule.** Detecting `.map(x => useHook(x.id))` requires a custom AST rule with maintenance cost. Layers 1 and 2 are structural and remove the vector; we revisit only if N+1s recur after six months.
+
+## Where the rule lives
+
+The rule is encoded in the `api-layer` project skill at `.claude/skills/api-layer/SKILL.md`. The skill auto-loads when an agent modifies files in any `*/api/` directory.
+
+`AGENTS.md` gains a fact-only Skills section that points at `.claude/skills/`. No inline rules — AGENTS.md remains an index.
+
+## Implementation plan
+
+Each step is its own commit.
+
+1. **Design doc** (this file) — committed first as the durable record.
+2. **api-layer skill** — append the "N+1 Prevention" section. Text in Appendix A.
+3. **AGENTS.md** — insert the Skills section between Configuration Files and Related Docs. Text in Appendix B.
+4. **Fix the donator_status N+1:**
+   - Delete `useDonatorStatus(userId)` from `apps/web/src/donator/hooks/useDonatorStatus.ts`.
+   - Identify callers (`PostUserProfile` and any row component).
+   - Lift `useDonatorStatusBatch(authors.map(a => a.id))` to the nearest list parent.
+   - Pass `isDonator` as a prop to each row.
+5. **Audit** — run the recipe in Appendix C and produce a candidate list. Fixes ship as separate PRs.
+
+## Appendix A — Text added to `api-layer` skill
+
+````markdown
+## N+1 Prevention: Batch-First Hook Convention
+
+### Rule
+
+Expose list-context data fetchers as one batch hook taking `ids: string[]` and returning `Set<id>` or `Map<id, T>`. Do not create a singular wrapper that delegates to the batch hook with a single-element array.
+
+### Anti-pattern
+
+```ts
+// N+1 vector — unique queryKey per id, React Query cannot dedupe
+export function useDonatorStatus(userId: string) {
+  const { activeUserIds } = useDonatorStatusBatch([userId]);
+  return activeUserIds.has(userId);
+}
+```
+
+A row component calling this passes review. Mount 100 rows and you get 100 HTTP calls.
+
+### Correct shape
+
+```ts
+// Only the batch hook is exposed.
+// The list parent fetches once; rows read from props.
+const { activeUserIds } = useDonatorStatusBatch(authors.map(a => a.id));
+// Pass isDonator={activeUserIds.has(author.id)} to each row.
+```
+
+### Single-id contexts (profile page, etc.)
+
+Call the raw fetcher (`fetchActiveDonatorIds([id])`) inline within a page-local hook. Do not export a shared singular hook — a future list will reuse it and reopen the trap.
+
+### Why
+
+A singular wrapper passes code review because each row uses one hook in isolation. N+1 emerges only when many rows mount together. Removing the wrapper removes the trap at the source.
+````
+
+## Appendix B — Text added to `AGENTS.md`
+
+````markdown
+## Skills
+
+`.claude/skills/` contains project-specific coding conventions. Each skill auto-loads via its frontmatter trigger.
+
+| Skill | Domain |
+|-------|--------|
+| `api-layer` | Data fetchers, API functions, list-fetching hooks (N+1 prevention) |
+| `react-component` | `.tsx` component structure |
+| `react-hook` | Custom hook patterns, exhaustive-deps |
+| `firebase-functions` | Cloud Functions in `/functions` |
+| `daily-writing-friends-design` | UI / Tailwind conventions |
+| `testing` | TDD, output-based test patterns |
+| `refactoring` | Functional Core / Imperative Shell extraction |
+| `type-system` | Type safety reviews |
+| `verify-runtime` | Verifying data-flow changes via dev logs |
+| `code-style` | Naming and clarity rules |
+````
+
+## Appendix C — Audit recipe
+
+Run from the repo root:
+
+```bash
+rg "Batch\(\s*ids\s*\)" apps/web/src --type ts
+rg "useMemo\(\(\) => \(.*\? \[.*\] : \[\]\)" apps/web/src --type ts
+```
+
+Priority directories:
+
+- `user/` — posting / replying / commenting per-user data
+- `post/` — likes per-post
+- `comment/` — reactions per-comment
+- `notification/` — per-notification metadata
+
+For each finding, apply the same recipe: delete the singular hook, lift the batch hook to the list parent, pass results down as props.
+
+## Open questions
+
+- Are there list views that intentionally need per-row independence (e.g., progressive disclosure where each row's data is requested only on hover)? If yes, those need a distinct pattern; document them as exceptions in the audit findings.
+- React Query v4 vs v5 split between `web` and `admin` — does the same rule transfer to `admin`? Likely yes; verify when auditing.

--- a/docs/plans/2026-05-16-prevent-client-n-plus-one-design.md
+++ b/docs/plans/2026-05-16-prevent-client-n-plus-one-design.md
@@ -42,7 +42,7 @@ The TODO at line 8–11 of the same file already named the problem: "a feed of N
 | TanStack Query `useQueries` | Parallelizes; does not batch network calls (maintainer points users to third-party `batshit`) | Wrong tool |
 | tRPC `httpBatchLink` | Standard inside tRPC only; tightly coupled to its protocol | Out of scope |
 | React Server Components + `React.cache()` | Dedupes identical requests; does not batch N distinct keys; our page is client-rendered | Wrong layer |
-| ESLint rules | No off-the-shelf rule catches `.map(x => useHook(x.id))` | Custom only |
+| ESLint rules | No off-the-shelf rule we found catches `.map(x => useHook(x.id))`; `no-await-in-loop` does not match this shape | Custom only |
 | Supabase `.in()` + one `useQuery` | Documented standard; our endpoint already supports it | Adopt |
 
 The community standard is structural, not exotic: one fetcher takes `ids: string[]` and uses `.in()`. React itself ships no built-in coalescer because none is required when the data layer exposes the right shape.


### PR DESCRIPTION
## Summary

- 프로덕션 board 페이지의 `/donator_status` N+1 (7회 호출 → 1회) 픽스. 단수 wrapper가 batch hook을 single-element array로 호출해 React Query dedupe를 무력화하던 vector를 제거하고, `useBatchPostCardData`의 Promise.all에 흡수
- 재발 방지를 위해 `api-layer` skill에 "Batch-First Hook Convention" 룰 인코딩 + AGENTS.md에 Skills 인덱스 추가 — agent가 `*/api/` 또는 `*/hooks/` 편집 시 자동 로드
- 코드 리뷰 두 에이전트 (`superpowers:code-reviewer`, `pr-review-toolkit:code-reviewer`)의 Critical/Important 피드백 모두 반영

Full design: [`docs/plans/2026-05-16-prevent-client-n-plus-one-design.md`](docs/plans/2026-05-16-prevent-client-n-plus-one-design.md). Sentry: issue 7471070471.

## Test plan

- [x] \`pnpm --filter web type-check\` exit 0
- [x] \`pnpm --filter web test:run\` — 전체 757 테스트 통과 (donator status 엣지케이스 3개 신규 포함)
- [ ] **사람 확인:** board 페이지 로드 시 Sentry breadcrumb에서 \`donator_status\` 호출이 1회만 잡히는지
- [ ] **사람 확인:** UserProfile 페이지 donator 배지 정상 표시 (page-local hook으로 교체됨)
- [ ] **사람 확인:** PostCard donator 배지 정상 표시 (batch에서 흡수됨)
- [ ] **사람 확인 (옵션):** dev 모드에서 \`batch-data-miss\` 경고 로그가 의도대로 fire되는지