### PR TITLE
이미지 업로드 압축 파이프라인 안정화 + TipTap 기본화

### DIFF
--- a/apps/web/src/post/components/EditorTiptap.tsx
+++ b/apps/web/src/post/components/EditorTiptap.tsx
@@ -36,7 +36,7 @@ export const EditorTiptap = forwardRef<EditorTiptapHandle, EditorTiptapProps>(
     });
 
     // Image upload functionality
-    const { openFilePicker, handlePaste, handleDrop, isUploading, uploadProgress } = useTiptapImageUpload({
+    const { openFilePicker, handlePaste, handleDrop, isUploading, stage, uploadProgress } = useTiptapImageUpload({
       editor,
     });
 
@@ -124,7 +124,7 @@ export const EditorTiptap = forwardRef<EditorTiptapHandle, EditorTiptapProps>(
           <EditorContentArea editor={editor} isMobile={isMobile} />
 
           {/* Upload progress overlay */}
-          <UploadProgress isUploading={isUploading} uploadProgress={uploadProgress} />
+          <UploadProgress stage={stage} uploadProgress={uploadProgress} />
 
           {/* Mobile toolbar at bottom */}
           <div className='md:hidden'>

--- a/apps/web/src/post/components/PostEditor.tsx
+++ b/apps/web/src/post/components/PostEditor.tsx
@@ -24,12 +24,12 @@ export function PostEditor({
   const { value: flagEnabled, isLoading } = useRemoteConfig('tiptap_editor_enabled');
 
   // Lock in the editor choice on first resolved render to prevent mid-session remounts.
-  // Default to 'quill' while loading to avoid a blank flash.
-  const lockedEditorRef = useRef<'tiptap' | 'quill'>('quill');
-  if (!isLoading && lockedEditorRef.current === 'quill' && flagEnabled) {
-    lockedEditorRef.current = 'tiptap';
+  // TipTap is the default; the flag is now a kill switch for falling back to Quill.
+  const lockedEditorRef = useRef<'tiptap' | 'quill' | null>(null);
+  if (!isLoading && lockedEditorRef.current === null) {
+    lockedEditorRef.current = flagEnabled ? 'tiptap' : 'quill';
   }
-  const editorChoice = forceEditor ?? lockedEditorRef.current;
+  const editorChoice = forceEditor ?? lockedEditorRef.current ?? 'tiptap';
 
   if (editorChoice === 'tiptap') {
     return (

--- a/apps/web/src/post/components/UploadProgress.tsx
+++ b/apps/web/src/post/components/UploadProgress.tsx
@@ -1,23 +1,42 @@
 import { Progress } from '@/shared/ui/progress';
 
+type UploadStage = 'idle' | 'converting' | 'resizing' | 'uploading';
+
 interface UploadProgressProps {
-  isUploading: boolean;
+  stage: UploadStage;
   uploadProgress: number;
 }
 
+const STAGE_LABELS: Record<Exclude<UploadStage, 'idle'>, string> = {
+  converting: '이미지 변환 중...',
+  resizing: '이미지 압축 중...',
+  uploading: '이미지 업로드 중...',
+};
+
 /**
- * Upload progress overlay component
- * Shows a progress bar when files are being uploaded
+ * Upload progress overlay component.
+ * Shows distinct copy + indicator per stage so users know what is happening.
  */
-export function UploadProgress({ isUploading, uploadProgress }: UploadProgressProps) {
-  if (!isUploading) return null;
+export function UploadProgress({ stage, uploadProgress }: UploadProgressProps) {
+  if (stage === 'idle') return null;
+
+  const label = STAGE_LABELS[stage];
+  const showRealProgress = stage === 'uploading';
+  const roundedPercent = Math.round(uploadProgress);
 
   return (
     <div className="absolute inset-0 z-10 flex flex-col items-center justify-center rounded-lg bg-background/80 backdrop-blur-sm">
       <div className="w-4/5 max-w-md space-y-3 p-4">
-        <Progress value={uploadProgress} className="h-2" />
+        {showRealProgress ? (
+          <Progress value={uploadProgress} className="h-2" />
+        ) : (
+          <div className="h-2 w-full overflow-hidden rounded-full bg-secondary">
+            <div className="h-full w-full animate-pulse bg-primary" />
+          </div>
+        )}
         <p className="text-center text-sm font-medium text-foreground">
-          이미지 업로드 중... {uploadProgress}%
+          {label}
+          {showRealProgress ? ` ${roundedPercent}%` : ''}
         </p>
       </div>
     </div>

--- a/apps/web/src/post/hooks/__tests__/useImageUpload.test.ts
+++ b/apps/web/src/post/hooks/__tests__/useImageUpload.test.ts
@@ -24,10 +24,19 @@ vi.mock('sonner', () => ({
 
 vi.mock('@sentry/react', () => ({
   captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
 }));
 
 vi.mock('@/post/utils/ImageUtils', () => ({
-  processImageForUpload: vi.fn((file: File) => Promise.resolve(file)),
+  processImageForUpload: vi.fn((file: File) =>
+    Promise.resolve({
+      file,
+      rawSize: file.size,
+      processedSize: file.size,
+      wasHeic: false,
+      didResize: false,
+    }),
+  ),
 }));
 
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
@@ -67,7 +76,15 @@ describe('useImageUpload', () => {
     vi.mocked(ref).mockReturnValue({} as ReturnType<typeof ref>);
     vi.mocked(uploadBytes).mockResolvedValue({ ref: {} } as Awaited<ReturnType<typeof uploadBytes>>);
     vi.mocked(getDownloadURL).mockResolvedValue('https://storage.example.com/image.jpg');
-    vi.mocked(processImageForUpload).mockImplementation((file) => Promise.resolve(file));
+    vi.mocked(processImageForUpload).mockImplementation((file) =>
+      Promise.resolve({
+        file,
+        rawSize: file.size,
+        processedSize: file.size,
+        wasHeic: false,
+        didResize: false,
+      }),
+    );
   });
 
   describe('single file upload flow', () => {

--- a/apps/web/src/post/hooks/__tests__/useImageUpload.test.ts
+++ b/apps/web/src/post/hooks/__tests__/useImageUpload.test.ts
@@ -35,6 +35,8 @@ vi.mock('@/post/utils/ImageUtils', () => ({
       processedSize: file.size,
       wasHeic: false,
       didResize: false,
+      heicConversionFailed: false,
+      resizeFailed: false,
     }),
   ),
 }));
@@ -83,6 +85,8 @@ describe('useImageUpload', () => {
         processedSize: file.size,
         wasHeic: false,
         didResize: false,
+        heicConversionFailed: false,
+        resizeFailed: false,
       }),
     );
   });
@@ -101,7 +105,7 @@ describe('useImageUpload', () => {
         await new Promise((r) => setTimeout(r, 10));
       });
 
-      expect(processImageForUpload).toHaveBeenCalledWith(file);
+      expect(processImageForUpload).toHaveBeenCalledWith(file, expect.any(Object));
       expect(uploadBytes).toHaveBeenCalled();
       expect(getDownloadURL).toHaveBeenCalled();
       expect(insertImage).toHaveBeenCalledWith('https://storage.example.com/image.jpg', 5);

--- a/apps/web/src/post/hooks/useImageUpload.ts
+++ b/apps/web/src/post/hooks/useImageUpload.ts
@@ -26,45 +26,53 @@ export function useImageUpload({ insertImage, editorRoot, getCursorIndex }: UseI
 
   const uploadAndInsertFile = useCallback(
     async (file: File, insertIndex?: number): Promise<boolean> => {
-      // Validate file type
+      if (!storage) {
+        toast.error('스토리지에 연결할 수 없습니다.', { position: 'bottom-center' });
+        return false;
+      }
+
       const typeResult = validateFileType(file);
       if (!typeResult.valid) {
+        logValidationRejection(typeResult.reason, file.size, false);
         toast.error(getValidationMessage(typeResult.reason), { position: 'bottom-center' });
         return false;
       }
 
-      // Validate raw file size (20MB)
       const sizeResult = validateFileSize(file);
       if (!sizeResult.valid) {
+        logValidationRejection(sizeResult.reason, file.size, false);
         toast.error(getValidationMessage(sizeResult.reason), { position: 'bottom-center' });
         return false;
       }
 
-      // Process image (HEIC conversion + resize)
-      const processedFile = await processImageForUpload(file);
+      const processed = await processImageForUpload(file);
 
-      // Validate processed file size (5MB)
-      const processedSizeResult = validateProcessedFileSize(processedFile);
+      const processedSizeResult = validateProcessedFileSize(processed.file);
       if (!processedSizeResult.valid) {
+        logValidationRejection(
+          processedSizeResult.reason,
+          processed.rawSize,
+          processed.wasHeic,
+          processed.processedSize,
+        );
         toast.error(getValidationMessage(processedSizeResult.reason), {
           position: 'bottom-center',
         });
         return false;
       }
 
-      // Generate storage path
       const now = new Date();
       const { dateFolder, timePrefix } = formatDate(now);
-      const fileName = `${timePrefix}_${processedFile.name}`;
+      const fileName = `${timePrefix}_${processed.file.name}`;
       const storageRef = ref(storage, `postImages/${dateFolder}/${fileName}`);
 
-      // Upload file with explicit contentType metadata
-      const snapshot = await uploadBytes(storageRef, processedFile, {
-        contentType: processedFile.type || 'image/jpeg',
+      const snapshot = await uploadBytes(storageRef, processed.file, {
+        contentType: processed.file.type || 'image/jpeg',
       });
       const downloadURL = await getDownloadURL(snapshot.ref);
 
-      // Insert image into editor
+      logUploadSuccess(processed);
+
       insertImage(downloadURL, insertIndex);
       return true;
     },
@@ -260,6 +268,42 @@ export function useImageUpload({ insertImage, editorRoot, getCursorIndex }: UseI
 
   return { imageHandler, isUploading, isDragOver };
 }
+
+const logValidationRejection = (
+  reason: string,
+  rawSize: number,
+  wasHeic: boolean,
+  processedSize?: number,
+) => {
+  Sentry.addBreadcrumb({
+    category: 'image_upload',
+    message: 'validation_reject',
+    level: 'warning',
+    data: { reason, raw_size: rawSize, processed_size: processedSize, was_heic: wasHeic },
+  });
+};
+
+const logUploadSuccess = (processed: {
+  rawSize: number;
+  processedSize: number;
+  wasHeic: boolean;
+  didResize: boolean;
+}) => {
+  const compressionRatio =
+    processed.rawSize > 0 ? processed.processedSize / processed.rawSize : 1;
+  Sentry.addBreadcrumb({
+    category: 'image_upload',
+    message: 'upload_success',
+    level: 'info',
+    data: {
+      raw_size: processed.rawSize,
+      processed_size: processed.processedSize,
+      compression_ratio: Number(compressionRatio.toFixed(3)),
+      was_heic: processed.wasHeic,
+      did_resize: processed.didResize,
+    },
+  });
+};
 
 const formatDate = (date: Date) => {
   const year = date.getFullYear();

--- a/apps/web/src/post/hooks/useImageUpload.ts
+++ b/apps/web/src/post/hooks/useImageUpload.ts
@@ -11,6 +11,10 @@ import {
   aggregateResults,
   getValidationMessage,
 } from '@/post/utils/ImageValidation';
+import {
+  captureProcessingFailure,
+  HEIC_FAILURE_MESSAGE,
+} from '@/post/utils/imageUploadTelemetry';
 import { sanitizeStorageFileName } from '@/post/utils/storageFileName';
 
 interface UseImageUploadProps {
@@ -46,7 +50,14 @@ export function useImageUpload({ insertImage, editorRoot, getCursorIndex }: UseI
         return false;
       }
 
-      const processed = await processImageForUpload(file);
+      const processed = await processImageForUpload(file, {
+        onError: captureProcessingFailure,
+      });
+
+      if (processed.wasHeic && processed.heicConversionFailed) {
+        toast.error(HEIC_FAILURE_MESSAGE, { position: 'bottom-center' });
+        return false;
+      }
 
       const processedSizeResult = validateProcessedFileSize(processed.file);
       if (!processedSizeResult.valid) {
@@ -289,6 +300,8 @@ const logUploadSuccess = (processed: {
   processedSize: number;
   wasHeic: boolean;
   didResize: boolean;
+  heicConversionFailed: boolean;
+  resizeFailed: boolean;
 }) => {
   const compressionRatio =
     processed.rawSize > 0 ? processed.processedSize / processed.rawSize : 1;
@@ -302,6 +315,8 @@ const logUploadSuccess = (processed: {
       compression_ratio: Number(compressionRatio.toFixed(3)),
       was_heic: processed.wasHeic,
       did_resize: processed.didResize,
+      heic_conversion_failed: processed.heicConversionFailed,
+      resize_failed: processed.resizeFailed,
     },
   });
 };

--- a/apps/web/src/post/hooks/useImageUpload.ts
+++ b/apps/web/src/post/hooks/useImageUpload.ts
@@ -11,6 +11,7 @@ import {
   aggregateResults,
   getValidationMessage,
 } from '@/post/utils/ImageValidation';
+import { sanitizeStorageFileName } from '@/post/utils/storageFileName';
 
 interface UseImageUploadProps {
   insertImage: (url: string, index?: number) => void;
@@ -63,7 +64,7 @@ export function useImageUpload({ insertImage, editorRoot, getCursorIndex }: UseI
 
       const now = new Date();
       const { dateFolder, timePrefix } = formatDate(now);
-      const fileName = `${timePrefix}_${processed.file.name}`;
+      const fileName = `${timePrefix}_${sanitizeStorageFileName(processed.file.name)}`;
       const storageRef = ref(storage, `postImages/${dateFolder}/${fileName}`);
 
       const snapshot = await uploadBytes(storageRef, processed.file, {

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -1,57 +1,94 @@
 import * as Sentry from '@sentry/react';
-import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { ref } from 'firebase/storage';
 import { useState, useCallback } from 'react';
 import { toast } from 'sonner';
 import { storage } from '@/firebase';
-import { processImageForUpload } from '@/post/utils/ImageUtils';
+import { processImageForUpload, type ProcessingStage } from '@/post/utils/ImageUtils';
+import {
+  validateFileSize,
+  validateProcessedFileSize,
+  validateFileType,
+  getValidationMessage,
+} from '@/post/utils/ImageValidation';
 import { formatDate } from '@/post/utils/sanitizeHtml';
+import { uploadFileWithProgress } from '@/post/utils/uploadWithProgress';
 import type { Editor } from '@tiptap/react';
+
+type UploadStage = 'idle' | ProcessingStage | 'uploading';
+
+const STAGE_RESET_DELAY_MS = 500;
 
 interface UseTiptapImageUploadProps {
   editor: Editor | null;
 }
 
 export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
-  const [isUploading, setIsUploading] = useState(false);
+  const [stage, setStage] = useState<UploadStage>('idle');
   const [uploadProgress, setUploadProgress] = useState(0);
 
-  /**
-   * Upload a file to Firebase Storage
-   * Returns the download URL or throws an error
-   */
   const uploadFile = useCallback(async (file: File): Promise<string> => {
-    // File size check (5MB) - check original file before processing
-    if (file.size > 5 * 1024 * 1024) {
-      throw new Error('File size exceeds 5MB limit');
+    if (!storage) {
+      throw new Error('스토리지에 연결할 수 없습니다.');
     }
 
-    // File type check (allow HEIC by extension since some browsers don't set MIME type)
-    const isHeicByExtension = /\.(heic|heif)$/i.test(file.name);
-    if (!file.type.startsWith('image/') && !isHeicByExtension) {
-      throw new Error('Only image files are allowed');
+    const typeResult = validateFileType(file);
+    if (!typeResult.valid) {
+      logValidationRejection(typeResult.reason, file.size, false);
+      throw new Error(getValidationMessage(typeResult.reason));
     }
 
-    // Process image (HEIC conversion + resize)
-    const { file: processedFile } = await processImageForUpload(file);
+    const rawSizeResult = validateFileSize(file);
+    if (!rawSizeResult.valid) {
+      logValidationRejection(rawSizeResult.reason, file.size, false);
+      throw new Error(getValidationMessage(rawSizeResult.reason));
+    }
 
-    // Generate storage path
+    const processed = await processImageForUpload(file, { onStage: setStage });
+
+    const processedResult = validateProcessedFileSize(processed.file);
+    if (!processedResult.valid) {
+      logValidationRejection(
+        processedResult.reason,
+        processed.rawSize,
+        processed.wasHeic,
+        processed.processedSize,
+      );
+      throw new Error(getValidationMessage(processedResult.reason));
+    }
+
+    setStage('uploading');
+    setUploadProgress(0);
+
     const now = new Date();
     const { dateFolder, timePrefix } = formatDate(now);
-    const fileName = `${timePrefix}_${processedFile.name}`;
+    const fileName = `${timePrefix}_${processed.file.name}`;
     const storageRef = ref(storage, `postImages/${dateFolder}/${fileName}`);
 
-    // Upload file
-    const snapshot = await uploadBytes(storageRef, processedFile);
+    const downloadURL = await uploadFileWithProgress(storageRef, processed.file, {
+      metadata: { contentType: processed.file.type || 'image/jpeg' },
+      onProgress: setUploadProgress,
+    });
 
-    // Get download URL
-    const downloadURL = await getDownloadURL(snapshot.ref);
+    logUploadSuccess(processed);
 
     return downloadURL;
   }, []);
 
-  /**
-   * Open file picker and handle image upload
-   */
+  const resetStageAfterDelay = useCallback(() => {
+    setTimeout(() => {
+      setStage('idle');
+      setUploadProgress(0);
+    }, STAGE_RESET_DELAY_MS);
+  }, []);
+
+  const insertImageIntoEditor = useCallback(
+    (downloadURL: string, alt: string) => {
+      if (!editor) return;
+      editor.chain().focus().setImage({ src: downloadURL, alt }).run();
+    },
+    [editor],
+  );
+
   const openFilePicker = useCallback(async () => {
     const input = document.createElement('input');
     input.setAttribute('type', 'file');
@@ -63,61 +100,24 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
       if (!file) return;
 
       try {
-        setIsUploading(true);
-        setUploadProgress(0);
-
-        // Simulate progress updates
-        setUploadProgress(20);
-        
         const downloadURL = await uploadFile(file);
-        
-        setUploadProgress(70);
-
-        // Insert image into editor
-        if (editor) {
-          editor
-            .chain()
-            .focus()
-            .setImage({ src: downloadURL, alt: file.name })
-            .run();
-        }
-
-        setUploadProgress(100);
-        toast.success('이미지가 업로드되었습니다.', {
-          position: 'bottom-center',
-        });
-
+        insertImageIntoEditor(downloadURL, file.name);
+        toast.success('이미지가 업로드되었습니다.', { position: 'bottom-center' });
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : '이미지 업로드에 실패했습니다.';
-        
-        Sentry.captureException(error, {
-          tags: { feature: 'image_upload', operation: 'upload_process' },
-          extra: { fileName: file?.name, fileSize: file?.size, fileType: file?.type }
-        });
-        
-        toast.error(errorMessage, {
-          position: 'bottom-center',
-        });
+        handleUploadError(error, 'file_picker', file);
       } finally {
-        // Reset loading state with slight delay for UX
-        setTimeout(() => {
-          setIsUploading(false);
-          setUploadProgress(0);
-        }, 500);
+        resetStageAfterDelay();
       }
     };
-  }, [editor, uploadFile]);
+  }, [insertImageIntoEditor, resetStageAfterDelay, uploadFile]);
 
-  /**
-   * Handle paste event for image upload
-   * Can be used directly in TipTap's paste handler
-   */
-  const handlePaste = useCallback(async (event: ClipboardEvent): Promise<boolean> => {
-    const items = event.clipboardData?.items;
-    if (!items) return false;
+  const handlePaste = useCallback(
+    async (event: ClipboardEvent): Promise<boolean> => {
+      const items = event.clipboardData?.items;
+      if (!items) return false;
 
-    for (const item of Array.from(items)) {
-      if (item.type.startsWith('image/')) {
+      for (const item of Array.from(items)) {
+        if (!item.type.startsWith('image/')) continue;
         event.preventDefault();
         event.stopPropagation();
 
@@ -125,124 +125,107 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
         if (!file) continue;
 
         try {
-          setIsUploading(true);
-          setUploadProgress(0);
-
-          // Simulate progress
-          setUploadProgress(20);
-
           const downloadURL = await uploadFile(file);
-
-          setUploadProgress(70);
-
-          // Insert image into editor
-          if (editor) {
-            editor
-              .chain()
-              .focus()
-              .setImage({ src: downloadURL, alt: 'Pasted image' })
-              .run();
-          }
-
-          setUploadProgress(100);
-          toast.success('이미지가 업로드되었습니다.', {
-            position: 'bottom-center',
-          });
-
-          return true; // Handled the paste
-
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : '이미지 업로드에 실패했습니다.';
-          
-          Sentry.captureException(error, {
-            tags: { feature: 'image_upload', operation: 'paste_upload' },
-            extra: { fileSize: file?.size, fileType: file?.type }
-          });
-          
-          toast.error(errorMessage, {
-            position: 'bottom-center',
-          });
-        } finally {
-          setTimeout(() => {
-            setIsUploading(false);
-            setUploadProgress(0);
-          }, 500);
-        }
-      }
-    }
-
-    return false; // Not handled
-  }, [editor, uploadFile]);
-
-  /**
-   * Handle drop event for image upload
-   */
-  const handleDrop = useCallback(async (event: DragEvent): Promise<boolean> => {
-    const items = event.dataTransfer?.items;
-    if (!items) return false;
-
-    for (const item of Array.from(items)) {
-      if (item.kind === 'file' && item.type.startsWith('image/')) {
-        event.preventDefault();
-        event.stopPropagation();
-
-        const file = item.getAsFile();
-        if (!file) continue;
-
-        try {
-          setIsUploading(true);
-          setUploadProgress(0);
-
-          setUploadProgress(20);
-
-          const downloadURL = await uploadFile(file);
-
-          setUploadProgress(70);
-
-          if (editor) {
-            editor
-              .chain()
-              .focus()
-              .setImage({ src: downloadURL, alt: file.name })
-              .run();
-          }
-
-          setUploadProgress(100);
-          toast.success('이미지가 업로드되었습니다.', {
-            position: 'bottom-center',
-          });
-
+          insertImageIntoEditor(downloadURL, 'Pasted image');
+          toast.success('이미지가 업로드되었습니다.', { position: 'bottom-center' });
           return true;
-
         } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : '이미지 업로드에 실패했습니다.';
-
-          Sentry.captureException(error, {
-            tags: { feature: 'image_upload', operation: 'drop_upload' },
-            extra: { fileSize: file?.size, fileType: file?.type }
-          });
-
-          toast.error(errorMessage, {
-            position: 'bottom-center',
-          });
+          handleUploadError(error, 'paste_upload', file);
         } finally {
-          setTimeout(() => {
-            setIsUploading(false);
-            setUploadProgress(0);
-          }, 500);
+          resetStageAfterDelay();
         }
       }
-    }
 
-    return false;
-  }, [editor, uploadFile]);
+      return false;
+    },
+    [insertImageIntoEditor, resetStageAfterDelay, uploadFile],
+  );
+
+  const handleDrop = useCallback(
+    async (event: DragEvent): Promise<boolean> => {
+      const items = event.dataTransfer?.items;
+      if (!items) return false;
+
+      for (const item of Array.from(items)) {
+        if (item.kind !== 'file' || !item.type.startsWith('image/')) continue;
+        event.preventDefault();
+        event.stopPropagation();
+
+        const file = item.getAsFile();
+        if (!file) continue;
+
+        try {
+          const downloadURL = await uploadFile(file);
+          insertImageIntoEditor(downloadURL, file.name);
+          toast.success('이미지가 업로드되었습니다.', { position: 'bottom-center' });
+          return true;
+        } catch (error) {
+          handleUploadError(error, 'drop_upload', file);
+        } finally {
+          resetStageAfterDelay();
+        }
+      }
+
+      return false;
+    },
+    [insertImageIntoEditor, resetStageAfterDelay, uploadFile],
+  );
 
   return {
     openFilePicker,
     uploadFile,
     handlePaste,
     handleDrop,
-    isUploading,
+    isUploading: stage !== 'idle',
+    stage,
     uploadProgress,
   };
 }
+
+const handleUploadError = (error: unknown, operation: string, file: File) => {
+  const errorMessage =
+    error instanceof Error ? error.message : '이미지 업로드에 실패했습니다.';
+
+  Sentry.captureException(error, {
+    tags: { feature: 'image_upload', operation },
+    extra: { fileName: file?.name, fileSize: file?.size, fileType: file?.type },
+  });
+
+  toast.error(errorMessage, { position: 'bottom-center' });
+};
+
+const logValidationRejection = (
+  reason: string,
+  rawSize: number,
+  wasHeic: boolean,
+  processedSize?: number,
+) => {
+  Sentry.addBreadcrumb({
+    category: 'image_upload',
+    message: 'validation_reject',
+    level: 'warning',
+    data: { reason, raw_size: rawSize, processed_size: processedSize, was_heic: wasHeic },
+  });
+};
+
+const logUploadSuccess = (processed: {
+  rawSize: number;
+  processedSize: number;
+  wasHeic: boolean;
+  didResize: boolean;
+}) => {
+  const compressionRatio =
+    processed.rawSize > 0 ? processed.processedSize / processed.rawSize : 1;
+  Sentry.addBreadcrumb({
+    category: 'image_upload',
+    message: 'upload_success',
+    level: 'info',
+    data: {
+      raw_size: processed.rawSize,
+      processed_size: processed.processedSize,
+      compression_ratio: Number(compressionRatio.toFixed(3)),
+      was_heic: processed.wasHeic,
+      did_resize: processed.didResize,
+    },
+  });
+};

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -32,7 +32,7 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
     }
 
     // Process image (HEIC conversion + resize)
-    const processedFile = await processImageForUpload(file);
+    const { file: processedFile } = await processImageForUpload(file);
 
     // Generate storage path
     const now = new Date();

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react';
 import { ref } from 'firebase/storage';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
 import { storage } from '@/firebase';
 import { processImageForUpload, type ProcessingStage } from '@/post/utils/ImageUtils';
@@ -22,6 +22,7 @@ import type { Editor } from '@tiptap/react';
 type UploadStage = 'idle' | ProcessingStage | 'uploading';
 
 const STAGE_RESET_DELAY_MS = 500;
+const UPLOAD_IN_PROGRESS_MESSAGE = '이미 업로드가 진행 중입니다. 잠시 후 다시 시도해주세요.';
 
 interface UseTiptapImageUploadProps {
   editor: Editor | null;
@@ -30,66 +31,84 @@ interface UseTiptapImageUploadProps {
 export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
   const [stage, setStage] = useState<UploadStage>('idle');
   const [uploadProgress, setUploadProgress] = useState(0);
+  const isUploadingRef = useRef(false);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const uploadFile = useCallback(async (file: File): Promise<string> => {
-    if (!storage) {
-      throw new Error('스토리지에 연결할 수 없습니다.');
+    if (isUploadingRef.current) {
+      throw new Error(UPLOAD_IN_PROGRESS_MESSAGE);
     }
-
-    const typeResult = validateFileType(file);
-    if (!typeResult.valid) {
-      logValidationRejection(typeResult.reason, file.size, false);
-      throw new Error(getValidationMessage(typeResult.reason));
+    if (resetTimeoutRef.current) {
+      clearTimeout(resetTimeoutRef.current);
+      resetTimeoutRef.current = null;
     }
+    isUploadingRef.current = true;
 
-    const rawSizeResult = validateFileSize(file);
-    if (!rawSizeResult.valid) {
-      logValidationRejection(rawSizeResult.reason, file.size, false);
-      throw new Error(getValidationMessage(rawSizeResult.reason));
+    try {
+      if (!storage) {
+        throw new Error('스토리지에 연결할 수 없습니다.');
+      }
+
+      const typeResult = validateFileType(file);
+      if (!typeResult.valid) {
+        logValidationRejection(typeResult.reason, file.size, false);
+        throw new Error(getValidationMessage(typeResult.reason));
+      }
+
+      const rawSizeResult = validateFileSize(file);
+      if (!rawSizeResult.valid) {
+        logValidationRejection(rawSizeResult.reason, file.size, false);
+        throw new Error(getValidationMessage(rawSizeResult.reason));
+      }
+
+      const processed = await processImageForUpload(file, {
+        onStage: setStage,
+        onError: captureProcessingFailure,
+      });
+
+      if (processed.wasHeic && processed.heicConversionFailed) {
+        throw new Error(HEIC_FAILURE_MESSAGE);
+      }
+
+      const processedResult = validateProcessedFileSize(processed.file);
+      if (!processedResult.valid) {
+        logValidationRejection(
+          processedResult.reason,
+          processed.rawSize,
+          processed.wasHeic,
+          processed.processedSize,
+        );
+        throw new Error(getValidationMessage(processedResult.reason));
+      }
+
+      setStage('uploading');
+      setUploadProgress(0);
+
+      const now = new Date();
+      const { dateFolder, timePrefix } = formatDate(now);
+      const fileName = `${timePrefix}_${sanitizeStorageFileName(processed.file.name)}`;
+      const storageRef = ref(storage, `postImages/${dateFolder}/${fileName}`);
+
+      const downloadURL = await uploadFileWithProgress(storageRef, processed.file, {
+        metadata: { contentType: processed.file.type || 'image/jpeg' },
+        onProgress: setUploadProgress,
+      });
+
+      logUploadSuccess(processed);
+      return downloadURL;
+    } finally {
+      isUploadingRef.current = false;
     }
-
-    const processed = await processImageForUpload(file, {
-      onStage: setStage,
-      onError: captureProcessingFailure,
-    });
-
-    if (processed.wasHeic && processed.heicConversionFailed) {
-      throw new Error(HEIC_FAILURE_MESSAGE);
-    }
-
-    const processedResult = validateProcessedFileSize(processed.file);
-    if (!processedResult.valid) {
-      logValidationRejection(
-        processedResult.reason,
-        processed.rawSize,
-        processed.wasHeic,
-        processed.processedSize,
-      );
-      throw new Error(getValidationMessage(processedResult.reason));
-    }
-
-    setStage('uploading');
-    setUploadProgress(0);
-
-    const now = new Date();
-    const { dateFolder, timePrefix } = formatDate(now);
-    const fileName = `${timePrefix}_${sanitizeStorageFileName(processed.file.name)}`;
-    const storageRef = ref(storage, `postImages/${dateFolder}/${fileName}`);
-
-    const downloadURL = await uploadFileWithProgress(storageRef, processed.file, {
-      metadata: { contentType: processed.file.type || 'image/jpeg' },
-      onProgress: setUploadProgress,
-    });
-
-    logUploadSuccess(processed);
-
-    return downloadURL;
   }, []);
 
   const resetStageAfterDelay = useCallback(() => {
-    setTimeout(() => {
+    if (resetTimeoutRef.current) {
+      clearTimeout(resetTimeoutRef.current);
+    }
+    resetTimeoutRef.current = setTimeout(() => {
       setStage('idle');
       setUploadProgress(0);
+      resetTimeoutRef.current = null;
     }, STAGE_RESET_DELAY_MS);
   }, []);
 

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react';
 import { ref } from 'firebase/storage';
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 import { storage } from '@/firebase';
 import { processImageForUpload, type ProcessingStage } from '@/post/utils/ImageUtils';
@@ -33,6 +33,15 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
   const [uploadProgress, setUploadProgress] = useState(0);
   const isUploadingRef = useRef(false);
   const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current) {
+        clearTimeout(resetTimeoutRef.current);
+        resetTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   const uploadFile = useCallback(async (file: File): Promise<string> => {
     if (isUploadingRef.current) {

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -43,6 +43,20 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
     };
   }, []);
 
+  // Schedules an idle reset only on behalf of the call that actually owned the upload.
+  // Kept out of the entry-point catch blocks so a synchronous "already in progress" guard
+  // throw from a second caller never clobbers the first upload's stage mid-flight.
+  const scheduleStageReset = useCallback(() => {
+    if (resetTimeoutRef.current) {
+      clearTimeout(resetTimeoutRef.current);
+    }
+    resetTimeoutRef.current = setTimeout(() => {
+      setStage('idle');
+      setUploadProgress(0);
+      resetTimeoutRef.current = null;
+    }, STAGE_RESET_DELAY_MS);
+  }, []);
+
   const uploadFile = useCallback(async (file: File): Promise<string> => {
     if (isUploadingRef.current) {
       throw new Error(UPLOAD_IN_PROGRESS_MESSAGE);
@@ -107,19 +121,9 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
       return downloadURL;
     } finally {
       isUploadingRef.current = false;
+      scheduleStageReset();
     }
-  }, []);
-
-  const resetStageAfterDelay = useCallback(() => {
-    if (resetTimeoutRef.current) {
-      clearTimeout(resetTimeoutRef.current);
-    }
-    resetTimeoutRef.current = setTimeout(() => {
-      setStage('idle');
-      setUploadProgress(0);
-      resetTimeoutRef.current = null;
-    }, STAGE_RESET_DELAY_MS);
-  }, []);
+  }, [scheduleStageReset]);
 
   const insertImageIntoEditor = useCallback(
     (downloadURL: string, alt: string) => {
@@ -145,11 +149,9 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
         toast.success('이미지가 업로드되었습니다.', { position: 'bottom-center' });
       } catch (error) {
         handleUploadError(error, 'file_picker', file);
-      } finally {
-        resetStageAfterDelay();
       }
     };
-  }, [insertImageIntoEditor, resetStageAfterDelay, uploadFile]);
+  }, [insertImageIntoEditor, uploadFile]);
 
   const handlePaste = useCallback(
     async (event: ClipboardEvent): Promise<boolean> => {
@@ -171,14 +173,12 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
           return true;
         } catch (error) {
           handleUploadError(error, 'paste_upload', file);
-        } finally {
-          resetStageAfterDelay();
         }
       }
 
       return false;
     },
-    [insertImageIntoEditor, resetStageAfterDelay, uploadFile],
+    [insertImageIntoEditor, uploadFile],
   );
 
   const handleDrop = useCallback(
@@ -201,14 +201,12 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
           return true;
         } catch (error) {
           handleUploadError(error, 'drop_upload', file);
-        } finally {
-          resetStageAfterDelay();
         }
       }
 
       return false;
     },
-    [insertImageIntoEditor, resetStageAfterDelay, uploadFile],
+    [insertImageIntoEditor, uploadFile],
   );
 
   return {

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -10,6 +10,10 @@ import {
   validateFileType,
   getValidationMessage,
 } from '@/post/utils/ImageValidation';
+import {
+  captureProcessingFailure,
+  HEIC_FAILURE_MESSAGE,
+} from '@/post/utils/imageUploadTelemetry';
 import { formatDate } from '@/post/utils/sanitizeHtml';
 import { sanitizeStorageFileName } from '@/post/utils/storageFileName';
 import { uploadFileWithProgress } from '@/post/utils/uploadWithProgress';
@@ -44,7 +48,14 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
       throw new Error(getValidationMessage(rawSizeResult.reason));
     }
 
-    const processed = await processImageForUpload(file, { onStage: setStage });
+    const processed = await processImageForUpload(file, {
+      onStage: setStage,
+      onError: captureProcessingFailure,
+    });
+
+    if (processed.wasHeic && processed.heicConversionFailed) {
+      throw new Error(HEIC_FAILURE_MESSAGE);
+    }
 
     const processedResult = validateProcessedFileSize(processed.file);
     if (!processedResult.valid) {
@@ -214,6 +225,8 @@ const logUploadSuccess = (processed: {
   processedSize: number;
   wasHeic: boolean;
   didResize: boolean;
+  heicConversionFailed: boolean;
+  resizeFailed: boolean;
 }) => {
   const compressionRatio =
     processed.rawSize > 0 ? processed.processedSize / processed.rawSize : 1;
@@ -227,6 +240,8 @@ const logUploadSuccess = (processed: {
       compression_ratio: Number(compressionRatio.toFixed(3)),
       was_heic: processed.wasHeic,
       did_resize: processed.didResize,
+      heic_conversion_failed: processed.heicConversionFailed,
+      resize_failed: processed.resizeFailed,
     },
   });
 };

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -11,6 +11,7 @@ import {
   getValidationMessage,
 } from '@/post/utils/ImageValidation';
 import { formatDate } from '@/post/utils/sanitizeHtml';
+import { sanitizeStorageFileName } from '@/post/utils/storageFileName';
 import { uploadFileWithProgress } from '@/post/utils/uploadWithProgress';
 import type { Editor } from '@tiptap/react';
 
@@ -61,7 +62,7 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
 
     const now = new Date();
     const { dateFolder, timePrefix } = formatDate(now);
-    const fileName = `${timePrefix}_${processed.file.name}`;
+    const fileName = `${timePrefix}_${sanitizeStorageFileName(processed.file.name)}`;
     const storageRef = ref(storage, `postImages/${dateFolder}/${fileName}`);
 
     const downloadURL = await uploadFileWithProgress(storageRef, processed.file, {

--- a/apps/web/src/post/utils/ImageUtils.ts
+++ b/apps/web/src/post/utils/ImageUtils.ts
@@ -6,9 +6,11 @@ const HEIC_CONVERSION_QUALITY = 0.8;
 const PROFILE_PHOTO_SIZE = 96;
 
 type ProcessingStage = 'converting' | 'resizing';
+type ProcessingFailure = 'heic_convert' | 'resize';
 
 interface ProcessImageOptions {
     onStage?: (stage: ProcessingStage) => void;
+    onError?: (failure: ProcessingFailure, error: unknown) => void;
 }
 
 interface ProcessedImage {
@@ -17,6 +19,8 @@ interface ProcessedImage {
     processedSize: number;
     wasHeic: boolean;
     didResize: boolean;
+    heicConversionFailed: boolean;
+    resizeFailed: boolean;
 }
 
 const cropAndResizeImage = async (file: File, callback: (resizedFile: File) => void) => {
@@ -43,13 +47,16 @@ const processImageForUpload = async (
     await yieldToBrowser();
 
     let processedFile = file;
+    let heicConversionFailed = false;
+    let resizeFailed = false;
 
     if (wasHeic) {
         options.onStage?.('converting');
         try {
             processedFile = await convertHeicToJpeg(file);
         } catch (error) {
-            console.warn('HEIC conversion failed, using original file:', error);
+            heicConversionFailed = true;
+            options.onError?.('heic_convert', error);
         }
         await yieldToBrowser();
     }
@@ -61,7 +68,8 @@ const processImageForUpload = async (
         processedFile = resizeResult.file;
         didResize = resizeResult.didResize;
     } catch (error) {
-        console.warn('Image resize failed, using file as-is:', error);
+        resizeFailed = true;
+        options.onError?.('resize', error);
     }
 
     return {
@@ -70,6 +78,8 @@ const processImageForUpload = async (
         processedSize: processedFile.size,
         wasHeic,
         didResize,
+        heicConversionFailed,
+        resizeFailed,
     };
 };
 
@@ -245,4 +255,4 @@ const blobToFile = (blob: Blob, fileName: string, fileType: string): File => {
 };
 
 export { cropAndResizeImage, processImageForUpload };
-export type { ProcessedImage, ProcessImageOptions, ProcessingStage };
+export type { ProcessedImage, ProcessImageOptions, ProcessingFailure, ProcessingStage };

--- a/apps/web/src/post/utils/ImageUtils.ts
+++ b/apps/web/src/post/utils/ImageUtils.ts
@@ -2,10 +2,26 @@ import heic2any from 'heic2any';
 
 const MAX_IMAGE_DIMENSION_FOR_UPLOAD = 1200;
 const JPEG_QUALITY_FOR_UPLOAD = 0.85;
+const HEIC_CONVERSION_QUALITY = 0.8;
+const PROFILE_PHOTO_SIZE = 96;
+
+type ProcessingStage = 'converting' | 'resizing';
+
+interface ProcessImageOptions {
+    onStage?: (stage: ProcessingStage) => void;
+}
+
+interface ProcessedImage {
+    file: File;
+    rawSize: number;
+    processedSize: number;
+    wasHeic: boolean;
+    didResize: boolean;
+}
 
 const cropAndResizeImage = async (file: File, callback: (resizedFile: File) => void) => {
     try {
-        const resizedFile = await resizeImage(file, 96);
+        const resizedFile = await resizeImage(file, PROFILE_PHOTO_SIZE);
         callback(resizedFile);
     } catch (error) {
         console.error('Error processing image:', error);
@@ -13,17 +29,23 @@ const cropAndResizeImage = async (file: File, callback: (resizedFile: File) => v
 };
 
 /**
- * Process image for upload: handles HEIC conversion and resizing.
+ * Process image for upload: HEIC conversion + resize to MAX_IMAGE_DIMENSION_FOR_UPLOAD.
  * Yields to browser before heavy operations to keep UI responsive.
+ * Returns metadata about what happened so callers can log compression ratios.
  */
-const processImageForUpload = async (file: File): Promise<File> => {
-    // Yield to browser to allow loading UI to render
+const processImageForUpload = async (
+    file: File,
+    options: ProcessImageOptions = {},
+): Promise<ProcessedImage> => {
+    const rawSize = file.size;
+    const wasHeic = isHeicFile(file);
+
     await yieldToBrowser();
 
     let processedFile = file;
 
-    // Convert HEIC/HEIF to JPEG (fallback to original on failure)
-    if (isHeicFile(file)) {
+    if (wasHeic) {
+        options.onStage?.('converting');
         try {
             processedFile = await convertHeicToJpeg(file);
         } catch (error) {
@@ -32,14 +54,23 @@ const processImageForUpload = async (file: File): Promise<File> => {
         await yieldToBrowser();
     }
 
-    // Resize if image is too large (fallback to original on OOM)
+    options.onStage?.('resizing');
+    let didResize = false;
     try {
-        processedFile = await resizeImageForUpload(processedFile);
+        const resizeResult = await resizeImageForUpload(processedFile);
+        processedFile = resizeResult.file;
+        didResize = resizeResult.didResize;
     } catch (error) {
         console.warn('Image resize failed, using file as-is:', error);
     }
 
-    return processedFile;
+    return {
+        file: processedFile,
+        rawSize,
+        processedSize: processedFile.size,
+        wasHeic,
+        didResize,
+    };
 };
 
 const isHeicFile = (file: File): boolean => {
@@ -56,7 +87,7 @@ const convertHeicToJpeg = async (file: File): Promise<File> => {
     const convertedBlob = (await heic2any({
         blob: file,
         toType: 'image/jpeg',
-        quality: 0.8,
+        quality: HEIC_CONVERSION_QUALITY,
     })) as Blob;
 
     const convertedFileName = file.name.replace(/\.(heic|heif)$/i, '.jpg');
@@ -66,39 +97,83 @@ const convertHeicToJpeg = async (file: File): Promise<File> => {
     });
 };
 
-const resizeImageForUpload = async (file: File): Promise<File> => {
-    const dataURL = await readFileAsDataURL(file);
-    const img = await loadImage(dataURL);
+interface ResizeResult {
+    file: File;
+    didResize: boolean;
+}
 
-    const needsResize = img.width > MAX_IMAGE_DIMENSION_FOR_UPLOAD || img.height > MAX_IMAGE_DIMENSION_FOR_UPLOAD;
+const resizeImageForUpload = async (file: File): Promise<ResizeResult> => {
+    const dimensions = await loadImageDimensions(file);
+    const needsResize =
+        dimensions.width > MAX_IMAGE_DIMENSION_FOR_UPLOAD ||
+        dimensions.height > MAX_IMAGE_DIMENSION_FOR_UPLOAD;
+
     if (!needsResize) {
-        return file;
+        return { file, didResize: false };
     }
 
-    const canvas = drawImageScaled(img, MAX_IMAGE_DIMENSION_FOR_UPLOAD);
+    const canvas = await drawImageScaled(file, dimensions, MAX_IMAGE_DIMENSION_FOR_UPLOAD);
     const blob = await canvasToBlob(canvas, 'image/jpeg', JPEG_QUALITY_FOR_UPLOAD);
     const resizedFileName = file.name.replace(/\.[^.]+$/, '.jpg');
-    return blobToFile(blob, resizedFileName, 'image/jpeg');
+    return { file: blobToFile(blob, resizedFileName, 'image/jpeg'), didResize: true };
 };
 
-const drawImageScaled = (img: HTMLImageElement, maxSize: number): HTMLCanvasElement => {
-    const canvas = document.createElement('canvas');
-    let { width, height } = img;
+interface ImageDimensions {
+    width: number;
+    height: number;
+}
 
-    if (width > height && width > maxSize) {
-        height = Math.round((height * maxSize) / width);
-        width = maxSize;
-    } else if (height > maxSize) {
-        width = Math.round((width * maxSize) / height);
-        height = maxSize;
+const loadImageDimensions = async (file: File): Promise<ImageDimensions> => {
+    if (typeof createImageBitmap === 'function') {
+        const bitmap = await createImageBitmap(file);
+        const dimensions = { width: bitmap.width, height: bitmap.height };
+        bitmap.close?.();
+        return dimensions;
+    }
+    const dataURL = await readFileAsDataURL(file);
+    const img = await loadImage(dataURL);
+    return { width: img.width, height: img.height };
+};
+
+const drawImageScaled = async (
+    file: File,
+    dimensions: ImageDimensions,
+    maxSize: number,
+): Promise<HTMLCanvasElement> => {
+    const { width: scaledWidth, height: scaledHeight } = computeScaledDimensions(dimensions, maxSize);
+    const canvas = document.createElement('canvas');
+    canvas.width = scaledWidth;
+    canvas.height = scaledHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Canvas 2D context unavailable');
+
+    if (typeof createImageBitmap === 'function') {
+        const bitmap = await createImageBitmap(file);
+        ctx.drawImage(bitmap, 0, 0, scaledWidth, scaledHeight);
+        bitmap.close?.();
+        return canvas;
     }
 
-    canvas.width = width;
-    canvas.height = height;
-    const ctx = canvas.getContext('2d');
-    ctx?.drawImage(img, 0, 0, width, height);
-
+    const dataURL = await readFileAsDataURL(file);
+    const img = await loadImage(dataURL);
+    ctx.drawImage(img, 0, 0, scaledWidth, scaledHeight);
     return canvas;
+};
+
+const computeScaledDimensions = (
+    dimensions: ImageDimensions,
+    maxSize: number,
+): ImageDimensions => {
+    const { width, height } = dimensions;
+    const isWiderThanTall = width > height;
+
+    if (isWiderThanTall && width > maxSize) {
+        return { width: maxSize, height: Math.round((height * maxSize) / width) };
+    }
+    if (!isWiderThanTall && height > maxSize) {
+        return { width: Math.round((width * maxSize) / height), height: maxSize };
+    }
+    return dimensions;
 };
 
 const yieldToBrowser = (): Promise<void> => {
@@ -108,7 +183,7 @@ const yieldToBrowser = (): Promise<void> => {
 const resizeImage = async (file: File, maxSize: number): Promise<File> => {
     const dataURL = await readFileAsDataURL(file);
     const img = await loadImage(dataURL);
-    const canvas = drawImageOnCanvas(img, maxSize);
+    const canvas = drawImageCenterCropped(img, maxSize);
     const blob = await canvasToBlob(canvas, file.type);
     return blobToFile(blob, file.name, file.type);
 };
@@ -131,7 +206,7 @@ const loadImage = (src: string): Promise<HTMLImageElement> => {
     });
 };
 
-const drawImageOnCanvas = (img: HTMLImageElement, maxSize: number): HTMLCanvasElement => {
+const drawImageCenterCropped = (img: HTMLImageElement, maxSize: number): HTMLCanvasElement => {
     const canvas = document.createElement('canvas');
     const size = Math.min(img.width, img.height);
     const offsetX = (img.width - size) / 2;
@@ -145,15 +220,23 @@ const drawImageOnCanvas = (img: HTMLImageElement, maxSize: number): HTMLCanvasEl
     return canvas;
 };
 
-const canvasToBlob = (canvas: HTMLCanvasElement, fileType: string, quality?: number): Promise<Blob> => {
+const canvasToBlob = (
+    canvas: HTMLCanvasElement,
+    fileType: string,
+    quality?: number,
+): Promise<Blob> => {
     return new Promise((resolve, reject) => {
-        canvas.toBlob((blob) => {
-            if (blob) {
-                resolve(blob);
-            } else {
-                reject(new Error('Canvas to Blob conversion failed.'));
-            }
-        }, fileType, quality);
+        canvas.toBlob(
+            (blob) => {
+                if (blob) {
+                    resolve(blob);
+                } else {
+                    reject(new Error('Canvas to Blob conversion failed.'));
+                }
+            },
+            fileType,
+            quality,
+        );
     });
 };
 
@@ -161,4 +244,5 @@ const blobToFile = (blob: Blob, fileName: string, fileType: string): File => {
     return new File([blob], fileName, { type: fileType });
 };
 
-export { cropAndResizeImage, processImageForUpload }
+export { cropAndResizeImage, processImageForUpload };
+export type { ProcessedImage, ProcessImageOptions, ProcessingStage };

--- a/apps/web/src/post/utils/__tests__/ImageUtils.test.ts
+++ b/apps/web/src/post/utils/__tests__/ImageUtils.test.ts
@@ -58,6 +58,20 @@ describe('processImageForUpload', () => {
     expect(result.wasHeic).toBe(true);
     expect(result.rawSize).toBe(1024);
     expect(result.didResize).toBe(false);
+    expect(result.heicConversionFailed).toBe(true);
+  });
+
+  it('reports onError when HEIC conversion fails', async () => {
+    const heicFile = createFile('photo.heic', 1024, 'image/heic');
+    const conversionError = new Error('Conversion failed');
+    vi.mocked(heic2any).mockRejectedValueOnce(conversionError);
+    vi.stubGlobal('createImageBitmap', undefined);
+    mockImageAndFileReader();
+
+    const onError = vi.fn();
+    await processImageForUpload(heicFile, { onError });
+
+    expect(onError).toHaveBeenCalledWith('heic_convert', conversionError);
   });
 
   it('converts HEIC file when conversion succeeds', async () => {

--- a/apps/web/src/post/utils/__tests__/ImageUtils.test.ts
+++ b/apps/web/src/post/utils/__tests__/ImageUtils.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// Mock heic2any before importing the module
 vi.mock('heic2any', () => ({
   default: vi.fn(),
 }));
@@ -8,7 +7,6 @@ vi.mock('heic2any', () => ({
 import heic2any from 'heic2any';
 import { processImageForUpload } from '../ImageUtils';
 
-// Mock requestAnimationFrame for yieldToBrowser
 vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
   cb();
   return 0;
@@ -19,74 +17,99 @@ function createFile(name: string, size: number, type: string): File {
   return new File([buffer], name, { type });
 }
 
+function mockImageAndFileReader(width = 100, height = 100) {
+  const mockImage = {
+    width,
+    height,
+    onload: null as (() => void) | null,
+    onerror: null as (() => void) | null,
+    set src(_: string) {
+      setTimeout(() => this.onload?.(), 0);
+    },
+  };
+  vi.spyOn(globalThis, 'Image').mockImplementation(
+    () => mockImage as unknown as HTMLImageElement,
+  );
+
+  const mockReader = {
+    result: 'data:image/jpeg;base64,test',
+    onload: null as (() => void) | null,
+    onerror: null as (() => void) | null,
+    readAsDataURL() {
+      setTimeout(() => this.onload?.(), 0);
+    },
+  };
+  vi.spyOn(globalThis, 'FileReader').mockImplementation(
+    () => mockReader as unknown as FileReader,
+  );
+}
+
 describe('processImageForUpload', () => {
   it('returns original file when HEIC conversion fails', async () => {
     const heicFile = createFile('photo.heic', 1024, 'image/heic');
-
     vi.mocked(heic2any).mockRejectedValueOnce(new Error('Conversion failed'));
-
-    // Mock Image and FileReader for the resize step that still runs after HEIC failure
-    const mockImage = {
-      width: 100,
-      height: 100,
-      onload: null as (() => void) | null,
-      onerror: null as (() => void) | null,
-      set src(_: string) {
-        setTimeout(() => this.onload?.(), 0);
-      },
-    };
-    vi.spyOn(globalThis, 'Image').mockImplementation(() => mockImage as unknown as HTMLImageElement);
-
-    const mockReader = {
-      result: 'data:image/heic;base64,test',
-      onload: null as (() => void) | null,
-      onerror: null as (() => void) | null,
-      readAsDataURL() {
-        setTimeout(() => this.onload?.(), 0);
-      },
-    };
-    vi.spyOn(globalThis, 'FileReader').mockImplementation(() => mockReader as unknown as FileReader);
+    vi.stubGlobal('createImageBitmap', undefined);
+    mockImageAndFileReader();
 
     const result = await processImageForUpload(heicFile);
 
-    // Should return the original file (not throw)
-    expect(result).toBe(heicFile);
-    expect(result.name).toBe('photo.heic');
+    expect(result.file).toBe(heicFile);
+    expect(result.file.name).toBe('photo.heic');
+    expect(result.wasHeic).toBe(true);
+    expect(result.rawSize).toBe(1024);
+    expect(result.didResize).toBe(false);
   });
 
   it('converts HEIC file when conversion succeeds', async () => {
     const heicFile = createFile('photo.heic', 1024, 'image/heic');
     const convertedBlob = new Blob([new ArrayBuffer(512)], { type: 'image/jpeg' });
-
     vi.mocked(heic2any).mockResolvedValueOnce(convertedBlob);
-
-    // Mock image loading and canvas for the resize step
-    const mockImage = {
-      width: 100,
-      height: 100,
-      onload: null as (() => void) | null,
-      onerror: null as (() => void) | null,
-      set src(_: string) {
-        setTimeout(() => this.onload?.(), 0);
-      },
-    };
-    vi.spyOn(globalThis, 'Image').mockImplementation(() => mockImage as unknown as HTMLImageElement);
-
-    // FileReader mock
-    const mockReader = {
-      result: 'data:image/jpeg;base64,test',
-      onload: null as (() => void) | null,
-      onerror: null as (() => void) | null,
-      readAsDataURL() {
-        setTimeout(() => this.onload?.(), 0);
-      },
-    };
-    vi.spyOn(globalThis, 'FileReader').mockImplementation(() => mockReader as unknown as FileReader);
+    vi.stubGlobal('createImageBitmap', undefined);
+    mockImageAndFileReader();
 
     const result = await processImageForUpload(heicFile);
 
-    // Converted file should have .jpg extension
-    expect(result.name).toBe('photo.jpg');
-    expect(result.type).toBe('image/jpeg');
+    expect(result.file.name).toBe('photo.jpg');
+    expect(result.file.type).toBe('image/jpeg');
+    expect(result.wasHeic).toBe(true);
+  });
+
+  it('reports onStage callbacks for HEIC files', async () => {
+    const heicFile = createFile('photo.heic', 1024, 'image/heic');
+    const convertedBlob = new Blob([new ArrayBuffer(512)], { type: 'image/jpeg' });
+    vi.mocked(heic2any).mockResolvedValueOnce(convertedBlob);
+    vi.stubGlobal('createImageBitmap', undefined);
+    mockImageAndFileReader();
+
+    const stages: string[] = [];
+    await processImageForUpload(heicFile, {
+      onStage: (stage) => stages.push(stage),
+    });
+
+    expect(stages).toEqual(['converting', 'resizing']);
+  });
+
+  it('skips converting stage for non-HEIC files', async () => {
+    const jpegFile = createFile('photo.jpg', 1024, 'image/jpeg');
+    vi.stubGlobal('createImageBitmap', undefined);
+    mockImageAndFileReader();
+
+    const stages: string[] = [];
+    await processImageForUpload(jpegFile, {
+      onStage: (stage) => stages.push(stage),
+    });
+
+    expect(stages).toEqual(['resizing']);
+  });
+
+  it('returns didResize=false when image is within max dimension', async () => {
+    const jpegFile = createFile('small.jpg', 1024, 'image/jpeg');
+    vi.stubGlobal('createImageBitmap', undefined);
+    mockImageAndFileReader(800, 600);
+
+    const result = await processImageForUpload(jpegFile);
+
+    expect(result.didResize).toBe(false);
+    expect(result.file).toBe(jpegFile);
   });
 });

--- a/apps/web/src/post/utils/__tests__/storageFileName.test.ts
+++ b/apps/web/src/post/utils/__tests__/storageFileName.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeStorageFileName, MAX_FILENAME_LENGTH } from '../storageFileName';
+
+describe('sanitizeStorageFileName', () => {
+  it('passes a normal filename through unchanged', () => {
+    expect(sanitizeStorageFileName('photo.jpg')).toBe('photo.jpg');
+  });
+
+  it('replaces forward slashes with underscores', () => {
+    expect(sanitizeStorageFileName('foo/bar.jpg')).toBe('foo_bar.jpg');
+  });
+
+  it('replaces backslashes with underscores', () => {
+    expect(sanitizeStorageFileName('foo\\bar.jpg')).toBe('foo_bar.jpg');
+  });
+
+  it('collapses parent-traversal sequences', () => {
+    expect(sanitizeStorageFileName('..foo.jpg')).toBe('_foo.jpg');
+    expect(sanitizeStorageFileName('....foo.jpg')).toBe('_foo.jpg');
+  });
+
+  it('neutralizes a full path-traversal payload', () => {
+    expect(sanitizeStorageFileName('../../etc/passwd.jpg')).toBe('____etc_passwd.jpg');
+  });
+
+  it('strips control characters including null byte', () => {
+    expect(sanitizeStorageFileName('photo\x00.jpg')).toBe('photo.jpg');
+    expect(sanitizeStorageFileName('photo\x1f.jpg')).toBe('photo.jpg');
+    expect(sanitizeStorageFileName('photo\n.jpg')).toBe('photo.jpg');
+  });
+
+  it('preserves Korean characters', () => {
+    expect(sanitizeStorageFileName('한글사진.jpg')).toBe('한글사진.jpg');
+  });
+
+  it('preserves spaces and punctuation that Firebase Storage accepts', () => {
+    expect(sanitizeStorageFileName('my photo (1).jpg')).toBe('my photo (1).jpg');
+  });
+
+  it('clamps overly long filenames', () => {
+    const long = 'a'.repeat(200) + '.jpg';
+    const result = sanitizeStorageFileName(long);
+    expect(result.length).toBe(MAX_FILENAME_LENGTH);
+  });
+
+  it('returns fallback when the input collapses to empty', () => {
+    expect(sanitizeStorageFileName('')).toBe('image');
+    expect(sanitizeStorageFileName('\x00\x01\x02')).toBe('image');
+  });
+});

--- a/apps/web/src/post/utils/imageUploadTelemetry.ts
+++ b/apps/web/src/post/utils/imageUploadTelemetry.ts
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/react';
+import type { ProcessingFailure } from '@/post/utils/ImageUtils';
+
+const HEIC_FAILURE_MESSAGE =
+  '이 HEIC 파일을 변환할 수 없습니다. JPEG 또는 PNG로 저장 후 다시 시도해주세요.';
+
+const captureProcessingFailure = (failure: ProcessingFailure, error: unknown): void => {
+  Sentry.captureException(error, {
+    tags: { feature: 'image_upload', operation: failure },
+  });
+};
+
+export { captureProcessingFailure, HEIC_FAILURE_MESSAGE };

--- a/apps/web/src/post/utils/storageFileName.ts
+++ b/apps/web/src/post/utils/storageFileName.ts
@@ -1,0 +1,19 @@
+const MAX_FILENAME_LENGTH = 100;
+const FALLBACK_NAME = 'image';
+
+/**
+ * Sanitize a user-supplied filename before using it as a Firebase Storage path segment.
+ * Strips path separators, parent-traversal sequences, and control characters so a
+ * crafted filename cannot escape its date folder or collide with paths in other buckets.
+ * Preserves Unicode letters (e.g., Korean) so users still recognize their files.
+ */
+const sanitizeStorageFileName = (rawName: string): string => {
+  const sanitized = rawName
+    .replace(/[\\/]/g, '_')
+    .replace(/\.{2,}/g, '_')
+    .replace(/[\x00-\x1f]/g, '');
+  const clamped = sanitized.slice(0, MAX_FILENAME_LENGTH);
+  return clamped || FALLBACK_NAME;
+};
+
+export { sanitizeStorageFileName, MAX_FILENAME_LENGTH };

--- a/apps/web/src/post/utils/uploadWithProgress.ts
+++ b/apps/web/src/post/utils/uploadWithProgress.ts
@@ -1,0 +1,45 @@
+import {
+  getDownloadURL,
+  uploadBytesResumable,
+  type StorageReference,
+  type UploadMetadata,
+} from 'firebase/storage';
+
+interface UploadWithProgressOptions {
+  metadata?: UploadMetadata;
+  onProgress?: (percent: number) => void;
+}
+
+const FULL_PERCENT = 100;
+
+const toError = (reason: unknown): Error =>
+  reason instanceof Error ? reason : new Error(String(reason));
+
+const uploadFileWithProgress = (
+  storageRef: StorageReference,
+  file: File | Blob,
+  options: UploadWithProgressOptions = {},
+): Promise<string> => {
+  const { metadata, onProgress } = options;
+
+  return new Promise((resolve, reject) => {
+    const task = uploadBytesResumable(storageRef, file, metadata);
+
+    task.on(
+      'state_changed',
+      (snapshot) => {
+        if (!onProgress || snapshot.totalBytes === 0) return;
+        const percent = (snapshot.bytesTransferred / snapshot.totalBytes) * FULL_PERCENT;
+        onProgress(percent);
+      },
+      (error) => reject(toError(error)),
+      () => {
+        getDownloadURL(task.snapshot.ref)
+          .then(resolve)
+          .catch((error) => reject(toError(error)));
+      },
+    );
+  });
+};
+
+export { uploadFileWithProgress };

--- a/apps/web/src/shared/contexts/RemoteConfigContext.tsx
+++ b/apps/web/src/shared/contexts/RemoteConfigContext.tsx
@@ -26,7 +26,7 @@ export const REMOTE_CONFIG_DEFAULTS: RemoteConfigValueTypes = {
   upcoming_board_id: 'rW3Y3E2aEbpB0KqGiigd',
   stats_notice_banner_text: '',
   block_user_feature_enabled: false,
-  tiptap_editor_enabled: false,
+  tiptap_editor_enabled: true,
 };
 
 /**

--- a/apps/web/src/shared/utils/uploadFeedbackScreenshot.ts
+++ b/apps/web/src/shared/utils/uploadFeedbackScreenshot.ts
@@ -1,7 +1,13 @@
 import * as Sentry from '@sentry/react';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
-import heic2any from 'heic2any';
 import { storage } from '@/firebase';
+import { processImageForUpload } from '@/post/utils/ImageUtils';
+import {
+  validateFileSize,
+  validateProcessedFileSize,
+  validateFileType,
+  getValidationMessage,
+} from '@/post/utils/ImageValidation';
 
 interface UploadResult {
   success: boolean;
@@ -10,92 +16,60 @@ interface UploadResult {
 }
 
 /**
- * Upload feedback screenshot to Firebase Storage
+ * Upload feedback screenshot to Firebase Storage.
+ * Compresses on the client first so users can submit large iPhone HEIC photos.
  */
 export async function uploadFeedbackScreenshot(file: File): Promise<UploadResult> {
+  if (!storage) {
+    return { success: false, error: '스토리지에 연결할 수 없습니다.' };
+  }
+
+  const typeResult = validateFileType(file);
+  if (!typeResult.valid) {
+    return { success: false, error: getValidationMessage(typeResult.reason) };
+  }
+
+  const rawSizeResult = validateFileSize(file);
+  if (!rawSizeResult.valid) {
+    return { success: false, error: getValidationMessage(rawSizeResult.reason) };
+  }
+
   try {
-    // Validate file size (5MB limit)
-    if (file.size > 5 * 1024 * 1024) {
-      return {
-        success: false,
-        error: '파일 크기는 5MB를 초과할 수 없습니다.',
-      };
+    const processed = await processImageForUpload(file);
+
+    const processedSizeResult = validateProcessedFileSize(processed.file);
+    if (!processedSizeResult.valid) {
+      return { success: false, error: getValidationMessage(processedSizeResult.reason) };
     }
 
-    let processedFile = file;
+    const fileName = buildFeedbackScreenshotPath(processed.file.name);
+    const storageRef = ref(storage, fileName);
 
-    // Convert HEIC files to JPEG
-    const isHeicFile =
-      file.type === 'image/heic' ||
-      file.type === 'image/heif' ||
-      file.name.toLowerCase().endsWith('.heic') ||
-      file.name.toLowerCase().endsWith('.heif');
-
-    if (isHeicFile) {
-      try {
-        const convertedBlob = (await heic2any({
-          blob: file,
-          toType: 'image/jpeg',
-          quality: 0.8,
-        })) as Blob;
-
-        const convertedFileName = file.name.replace(/\.(heic|heif)$/i, '.jpg');
-        processedFile = new File([convertedBlob], convertedFileName, {
-          type: 'image/jpeg',
-          lastModified: Date.now(),
-        });
-      } catch (conversionError) {
-        Sentry.captureException(conversionError, {
-          tags: { feature: 'feedback_screenshot', operation: 'heic_conversion' },
-          extra: { fileName: file.name, fileSize: file.size, fileType: file.type },
-        });
-        return {
-          success: false,
-          error: 'HEIC 파일 변환에 실패했습니다.',
-        };
-      }
-    }
-
-    // Validate file type
-    if (!processedFile.type.startsWith('image/')) {
-      return {
-        success: false,
-        error: '이미지 파일만 업로드할 수 있습니다.',
-      };
-    }
-
-    // Create date-based file path
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    const hours = String(now.getHours()).padStart(2, '0');
-    const minutes = String(now.getMinutes()).padStart(2, '0');
-    const seconds = String(now.getSeconds()).padStart(2, '0');
-
-    const dateFolder = `${year}${month}${day}`;
-    const timePrefix = `${hours}${minutes}${seconds}`;
-    const fileName = `${timePrefix}_${processedFile.name}`;
-    const storageRef = ref(storage, `feedbackScreenshots/${dateFolder}/${fileName}`);
-
-    // Upload file
-    const snapshot = await uploadBytes(storageRef, processedFile);
-
-    // Get download URL
+    const snapshot = await uploadBytes(storageRef, processed.file, {
+      contentType: processed.file.type || 'image/jpeg',
+    });
     const downloadURL = await getDownloadURL(snapshot.ref);
 
-    return {
-      success: true,
-      url: downloadURL,
-    };
+    return { success: true, url: downloadURL };
   } catch (error) {
     Sentry.captureException(error, {
       tags: { feature: 'feedback_screenshot', operation: 'upload_process' },
       extra: { fileName: file?.name, fileSize: file?.size, fileType: file?.type },
     });
-    return {
-      success: false,
-      error: '스크린샷 업로드에 실패했습니다.',
-    };
+    return { success: false, error: '스크린샷 업로드에 실패했습니다.' };
   }
 }
+
+const buildFeedbackScreenshotPath = (fileName: string): string => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  const hours = String(now.getHours()).padStart(2, '0');
+  const minutes = String(now.getMinutes()).padStart(2, '0');
+  const seconds = String(now.getSeconds()).padStart(2, '0');
+
+  const dateFolder = `${year}${month}${day}`;
+  const timePrefix = `${hours}${minutes}${seconds}`;
+  return `feedbackScreenshots/${dateFolder}/${timePrefix}_${fileName}`;
+};

--- a/apps/web/src/shared/utils/uploadFeedbackScreenshot.ts
+++ b/apps/web/src/shared/utils/uploadFeedbackScreenshot.ts
@@ -8,6 +8,10 @@ import {
   validateFileType,
   getValidationMessage,
 } from '@/post/utils/ImageValidation';
+import {
+  captureProcessingFailure,
+  HEIC_FAILURE_MESSAGE,
+} from '@/post/utils/imageUploadTelemetry';
 import { sanitizeStorageFileName } from '@/post/utils/storageFileName';
 
 interface UploadResult {
@@ -36,7 +40,13 @@ export async function uploadFeedbackScreenshot(file: File): Promise<UploadResult
   }
 
   try {
-    const processed = await processImageForUpload(file);
+    const processed = await processImageForUpload(file, {
+      onError: captureProcessingFailure,
+    });
+
+    if (processed.wasHeic && processed.heicConversionFailed) {
+      return { success: false, error: HEIC_FAILURE_MESSAGE };
+    }
 
     const processedSizeResult = validateProcessedFileSize(processed.file);
     if (!processedSizeResult.valid) {

--- a/apps/web/src/shared/utils/uploadFeedbackScreenshot.ts
+++ b/apps/web/src/shared/utils/uploadFeedbackScreenshot.ts
@@ -8,6 +8,7 @@ import {
   validateFileType,
   getValidationMessage,
 } from '@/post/utils/ImageValidation';
+import { sanitizeStorageFileName } from '@/post/utils/storageFileName';
 
 interface UploadResult {
   success: boolean;
@@ -71,5 +72,5 @@ const buildFeedbackScreenshotPath = (fileName: string): string => {
 
   const dateFolder = `${year}${month}${day}`;
   const timePrefix = `${hours}${minutes}${seconds}`;
-  return `feedbackScreenshots/${dateFolder}/${timePrefix}_${fileName}`;
+  return `feedbackScreenshots/${dateFolder}/${timePrefix}_${sanitizeStorageFileName(fileName)}`;
 };

--- a/tests/data-flows/post-write-flow.spec.ts
+++ b/tests/data-flows/post-write-flow.spec.ts
@@ -23,8 +23,8 @@ test.describe('Post Write Flow', () => {
     await expect(titleInput).toBeVisible({ timeout: 30000 });
     await titleInput.fill(POST_TITLE);
 
-    // Type content in the editor area (Quill editor)
-    const editorArea = page.locator('.ql-editor');
+    // Type content in the editor area (TipTap ProseMirror)
+    const editorArea = page.locator('.ProseMirror');
     await editorArea.click();
     await editorArea.pressSequentially('This is a test post created by E2E tests.');
 


### PR DESCRIPTION
## Summary

- **Sentry "File size exceeds 5MB limit" 버그 수정**: iPhone HEIC 사진이 원본 5MB 검사에 걸려 압축 시작도 못 하고 거부되던 문제 해결. 5MB 검사를 압축 이후로 옮기고, 사전 검사는 20MB sanity cap로 분리
- **단계별 진행 UI**: 가짜 20→70→100 progress 대신 `uploadBytesResumable`의 실제 비율을 표시. 단계도 `이미지 변환 중...` / `이미지 압축 중...` / `이미지 업로드 중... XX%` 로 분리
- **HEIC 변환 실패 정확 보고**: `wasHeic` 만으로는 변환 성공 여부를 알 수 없어 디버깅을 방해했음. `heicConversionFailed`/`resizeFailed` 플래그 + `onError` 콜백으로 Sentry에 실제 예외를 보내고, 사용자에게는 "HEIC 변환 불가" 메시지를 별도로 노출
- **Storage 파일명 sanitization**: `file.name`이 그대로 Storage 경로로 들어가 `../../foo.jpg` 같은 경로 우회가 가능했음. path separator·traversal·control 문자만 제거 (한국어 파일명은 보존)
- **동시 업로드 가드 + 타이머 정리**: TipTap 훅에 `isUploadingRef`와 `clearTimeout`을 추가해 paste/drop/picker 연타 시 stage가 뒤섞이거나 0%로 튀는 문제 차단
- **TipTap 기본 에디터 전환**: Quill은 단계적 폐기 대상이므로 `tiptap_editor_enabled` 기본값을 true로 뒤집고 PostEditor 락 로직 정리

## Test plan

- [x] `npm run type-check` — 통과
- [x] `npm run test:run` — 245/245 통과 (ImageUtils, ImageValidation, storageFileName, useImageUpload 포함)
- [x] 실 브라우저 (Vite dev + 로컬 Supabase + agent-browser):
  - [x] TipTap 에디터 마운트 확인
  - [x] HEIC 변환 → JPG 업로드 성공 + 단계 UI 전환 (`이미지 변환 중...` → `이미지 업로드 중... 0% → 100%`)
  - [x] 26MB HEIC가 20MB raw cap에 의해 거부 ("파일이 너무 큽니다.")
  - [x] `../../etc/evil.png` 파일명이 Storage 경로 `____etc_evil.png` 로 sanitize됨
  - [x] 정상 PNG / 3000x2000 리사이즈 경로 동작

## Sentry breadcrumb 변화

업로드 성공/실패 시점에 다음 데이터가 breadcrumb으로 남음 (PII 없음):
`raw_size`, `processed_size`, `compression_ratio`, `was_heic`, `did_resize`, `heic_conversion_failed`, `resize_failed`, `reason`

추후 압축 효과·HEIC 실패율 모니터링이 가능해짐.

## 미해결 / 후속 작업

- `handleUploadError`가 Sentry `extras.fileName`에 원본 파일명을 보냄 (breadcrumb은 안 보냄) — 사진 파일명 PII 일관성 정리는 후속 PR
- 멀티파일 업로드 실패 시 per-file 토스트 (현재는 집계 토스트만) — 후속 PR
- 모바일 카메라 직접 캡처 affordance (`capture="environment"`) — 의도적 제외