### PR TITLE
fix(shared): tune queryClient defaults — stop iOS refetch storm + duplicate mutations

### DIFF
--- a/apps/web/src/shared/lib/queryClient.ts
+++ b/apps/web/src/shared/lib/queryClient.ts
@@ -27,13 +27,17 @@ export const queryClient = new QueryClient({
   mutationCache,
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 30, // 30 seconds
+      staleTime: 1000 * 60, // 1 minute
       cacheTime: 1000 * 60 * 5, // 5 minutes
-      refetchOnWindowFocus: true,
+      // iOS Safari fires focus aggressively → refetch storm.
+      // Opt-in per query when refetch on focus is actually wanted.
+      refetchOnWindowFocus: false,
       retry: 3,
     },
     mutations: {
-      retry: 1,
+      // Mutations are not guaranteed idempotent (likes, comments, etc).
+      // Retrying on network hiccup risks duplicate writes.
+      retry: 0,
     },
   },
 });


### PR DESCRIPTION
## Summary

- `refetchOnWindowFocus: true → false` — iOS Safari fires focus aggressively, causing refetch storms across the app. Queries that genuinely want refetch on focus (e.g. `useBestPosts`, `useRecentPosts`, `useNotifications`, `useUser`) already opt in explicitly, so behavior is preserved where intended.
- `mutations.retry: 1 → 0` — Mutations in this codebase (likes, comments, replies, etc.) are not server-side idempotent. A retry on network hiccup risks duplicate writes. No mutation overrides `retry`, so the default propagates safely.
- `staleTime: 30s → 60s` — Gentler baseline; all per-query `staleTime` overrides are untouched.

## Verification

- ✅ `npm run type-check` passes
- ✅ `npm run test:run` — 778/778 unit tests pass
- ⚠️ Manual iOS Safari smoke test deferred — the change is a documented TanStack Query config flip with no app-specific iOS code path; library semantics guarantee the behavior.

## Blast radius

- 16 queries explicitly set `refetchOnWindowFocus` (mix of `true`/`false`) — all preserved.
- Only `useDraftLoader` overrides `retry: 1` for its query — unaffected by mutation default.
- No mutation overrides `retry` — `retry: 0` becomes the universal default (intended).

## Test plan

- [x] Type-check + unit tests pass.
- [ ] Manual smoke test on iOS Safari simulator: background/foreground transition does not trigger refetch for queries that did not opt in.
- [ ] Rapid double-tap on like/comment/delete mutation results in exactly one write.

Closes #590