### PR TITLE
HEIC/GIF 업로드 차단 및 큰 파일 강제 재인코딩으로 Sentry 에러 해소

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -84,7 +84,6 @@
     "embla-carousel-react": "^8.6.0",
     "firebase": "^12.12.1",
     "framer-motion": "^12.38.0",
-    "heic2any": "^0.0.4",
     "lucide-react": "^0.453.0",
     "next-themes": "^0.4.6",
     "openai": "^4.104.0",

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -151,12 +151,12 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
       if (!items) return false;
 
       for (const item of Array.from(items)) {
-        if (!item.type.startsWith('image/')) continue;
-        event.preventDefault();
-        event.stopPropagation();
-
+        if (item.kind !== 'file') continue;
         const file = item.getAsFile();
         if (!file) continue;
+
+        event.preventDefault();
+        event.stopPropagation();
 
         try {
           const downloadURL = await uploadFile(file);
@@ -179,12 +179,12 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
       if (!items) return false;
 
       for (const item of Array.from(items)) {
-        if (item.kind !== 'file' || !item.type.startsWith('image/')) continue;
-        event.preventDefault();
-        event.stopPropagation();
-
+        if (item.kind !== 'file') continue;
         const file = item.getAsFile();
         if (!file) continue;
+
+        event.preventDefault();
+        event.stopPropagation();
 
         try {
           const downloadURL = await uploadFile(file);

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -128,7 +128,7 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
   const openFilePicker = useCallback(async () => {
     const input = document.createElement('input');
     input.setAttribute('type', 'file');
-    input.setAttribute('accept', 'image/jpeg,image/png,image/webp,image/gif');
+    input.setAttribute('accept', 'image/jpeg,image/png,image/webp');
     input.click();
 
     input.onchange = async () => {

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -11,8 +11,7 @@ import {
   getValidationMessage,
 } from '@/post/utils/ImageValidation';
 import { captureProcessingFailure } from '@/post/utils/imageUploadTelemetry';
-import { formatDate } from '@/post/utils/sanitizeHtml';
-import { sanitizeStorageFileName } from '@/post/utils/storageFileName';
+import { buildImageStoragePath } from '@/post/utils/storagePath';
 import { uploadFileWithProgress } from '@/post/utils/uploadWithProgress';
 import type { Editor } from '@tiptap/react';
 
@@ -99,10 +98,8 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
       setStage('uploading');
       setUploadProgress(0);
 
-      const now = new Date();
-      const { dateFolder, timePrefix } = formatDate(now);
-      const fileName = `${timePrefix}_${sanitizeStorageFileName(processed.file.name)}`;
-      const storageRef = ref(storage, `postImages/${dateFolder}/${fileName}`);
+      const storagePath = buildImageStoragePath('postImages', processed.file.name, new Date());
+      const storageRef = ref(storage, storagePath);
 
       const downloadURL = await uploadFileWithProgress(storageRef, processed.file, {
         metadata: { contentType: processed.file.type || 'image/jpeg' },

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -9,6 +9,7 @@ import {
   validateProcessedFileSize,
   validateFileType,
   getValidationMessage,
+  SUPPORTED_ACCEPT_ATTRIBUTE,
 } from '@/post/utils/ImageValidation';
 import { captureProcessingFailure } from '@/post/utils/imageUploadTelemetry';
 import { buildImageStoragePath } from '@/post/utils/storagePath';
@@ -125,7 +126,7 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
   const openFilePicker = useCallback(async () => {
     const input = document.createElement('input');
     input.setAttribute('type', 'file');
-    input.setAttribute('accept', 'image/jpeg,image/png,image/webp');
+    input.setAttribute('accept', SUPPORTED_ACCEPT_ATTRIBUTE);
     input.click();
 
     input.onchange = async () => {

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -86,6 +86,12 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
         onError: captureProcessingFailure,
       });
 
+      // Decode/canvas failure leaves processed.file as the original undecodable bytes.
+      // Upload would succeed but the post would render a broken <img>, so fail fast.
+      if (processed.resizeFailed) {
+        throw new Error('이미지를 처리할 수 없습니다. 다른 사진으로 다시 시도해주세요.');
+      }
+
       const processedResult = validateProcessedFileSize(processed.file);
       if (!processedResult.valid) {
         logValidationRejection(

--- a/apps/web/src/post/hooks/useTiptapImageUpload.ts
+++ b/apps/web/src/post/hooks/useTiptapImageUpload.ts
@@ -10,10 +10,7 @@ import {
   validateFileType,
   getValidationMessage,
 } from '@/post/utils/ImageValidation';
-import {
-  captureProcessingFailure,
-  HEIC_FAILURE_MESSAGE,
-} from '@/post/utils/imageUploadTelemetry';
+import { captureProcessingFailure } from '@/post/utils/imageUploadTelemetry';
 import { formatDate } from '@/post/utils/sanitizeHtml';
 import { sanitizeStorageFileName } from '@/post/utils/storageFileName';
 import { uploadFileWithProgress } from '@/post/utils/uploadWithProgress';
@@ -74,13 +71,13 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
 
       const typeResult = validateFileType(file);
       if (!typeResult.valid) {
-        logValidationRejection(typeResult.reason, file.size, false);
+        logValidationRejection(typeResult.reason, file.size);
         throw new Error(getValidationMessage(typeResult.reason));
       }
 
       const rawSizeResult = validateFileSize(file);
       if (!rawSizeResult.valid) {
-        logValidationRejection(rawSizeResult.reason, file.size, false);
+        logValidationRejection(rawSizeResult.reason, file.size);
         throw new Error(getValidationMessage(rawSizeResult.reason));
       }
 
@@ -89,16 +86,11 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
         onError: captureProcessingFailure,
       });
 
-      if (processed.wasHeic && processed.heicConversionFailed) {
-        throw new Error(HEIC_FAILURE_MESSAGE);
-      }
-
       const processedResult = validateProcessedFileSize(processed.file);
       if (!processedResult.valid) {
         logValidationRejection(
           processedResult.reason,
           processed.rawSize,
-          processed.wasHeic,
           processed.processedSize,
         );
         throw new Error(getValidationMessage(processedResult.reason));
@@ -136,7 +128,7 @@ export function useTiptapImageUpload({ editor }: UseTiptapImageUploadProps) {
   const openFilePicker = useCallback(async () => {
     const input = document.createElement('input');
     input.setAttribute('type', 'file');
-    input.setAttribute('accept', 'image/*');
+    input.setAttribute('accept', 'image/jpeg,image/png,image/webp,image/gif');
     input.click();
 
     input.onchange = async () => {
@@ -235,23 +227,20 @@ const handleUploadError = (error: unknown, operation: string, file: File) => {
 const logValidationRejection = (
   reason: string,
   rawSize: number,
-  wasHeic: boolean,
   processedSize?: number,
 ) => {
   Sentry.addBreadcrumb({
     category: 'image_upload',
     message: 'validation_reject',
     level: 'warning',
-    data: { reason, raw_size: rawSize, processed_size: processedSize, was_heic: wasHeic },
+    data: { reason, raw_size: rawSize, processed_size: processedSize },
   });
 };
 
 const logUploadSuccess = (processed: {
   rawSize: number;
   processedSize: number;
-  wasHeic: boolean;
   didResize: boolean;
-  heicConversionFailed: boolean;
   resizeFailed: boolean;
 }) => {
   const compressionRatio =
@@ -264,9 +253,7 @@ const logUploadSuccess = (processed: {
       raw_size: processed.rawSize,
       processed_size: processed.processedSize,
       compression_ratio: Number(compressionRatio.toFixed(3)),
-      was_heic: processed.wasHeic,
       did_resize: processed.didResize,
-      heic_conversion_failed: processed.heicConversionFailed,
       resize_failed: processed.resizeFailed,
     },
   });

--- a/apps/web/src/post/utils/ImageUtils.ts
+++ b/apps/web/src/post/utils/ImageUtils.ts
@@ -229,5 +229,5 @@ const blobToFile = (blob: Blob, fileName: string, fileType: string): File => {
     return new File([blob], fileName, { type: fileType });
 };
 
-export { cropAndResizeImage, needsReencoding, processImageForUpload };
-export type { ProcessedImage, ProcessImageOptions, ProcessingFailure, ProcessingStage };
+export { computeScaledDimensions, cropAndResizeImage, needsReencoding, processImageForUpload };
+export type { ImageDimensions, ProcessedImage, ProcessImageOptions, ProcessingFailure, ProcessingStage };

--- a/apps/web/src/post/utils/ImageUtils.ts
+++ b/apps/web/src/post/utils/ImageUtils.ts
@@ -1,12 +1,9 @@
-import heic2any from 'heic2any';
-
 const MAX_IMAGE_DIMENSION_FOR_UPLOAD = 1200;
 const JPEG_QUALITY_FOR_UPLOAD = 0.85;
-const HEIC_CONVERSION_QUALITY = 0.8;
 const PROFILE_PHOTO_SIZE = 96;
 
-type ProcessingStage = 'converting' | 'resizing';
-type ProcessingFailure = 'heic_convert' | 'resize';
+type ProcessingStage = 'resizing';
+type ProcessingFailure = 'resize';
 
 interface ProcessImageOptions {
     onStage?: (stage: ProcessingStage) => void;
@@ -17,9 +14,7 @@ interface ProcessedImage {
     file: File;
     rawSize: number;
     processedSize: number;
-    wasHeic: boolean;
     didResize: boolean;
-    heicConversionFailed: boolean;
     resizeFailed: boolean;
 }
 
@@ -33,38 +28,24 @@ const cropAndResizeImage = async (file: File, callback: (resizedFile: File) => v
 };
 
 /**
- * Process image for upload: HEIC conversion + resize to MAX_IMAGE_DIMENSION_FOR_UPLOAD.
- * Yields to browser before heavy operations to keep UI responsive.
- * Returns metadata about what happened so callers can log compression ratios.
+ * Process image for upload: resize to MAX_IMAGE_DIMENSION_FOR_UPLOAD.
+ * HEIC/HEIF files are rejected upstream by validateFileType, so this function
+ * only handles JPEG/PNG/WebP/GIF inputs.
  */
 const processImageForUpload = async (
     file: File,
     options: ProcessImageOptions = {},
 ): Promise<ProcessedImage> => {
     const rawSize = file.size;
-    const wasHeic = isHeicFile(file);
-
     await yieldToBrowser();
 
     let processedFile = file;
-    let heicConversionFailed = false;
+    let didResize = false;
     let resizeFailed = false;
 
-    if (wasHeic) {
-        options.onStage?.('converting');
-        try {
-            processedFile = await convertHeicToJpeg(file);
-        } catch (error) {
-            heicConversionFailed = true;
-            options.onError?.('heic_convert', error);
-        }
-        await yieldToBrowser();
-    }
-
     options.onStage?.('resizing');
-    let didResize = false;
     try {
-        const resizeResult = await resizeImageForUpload(processedFile);
+        const resizeResult = await resizeImageForUpload(file);
         processedFile = resizeResult.file;
         didResize = resizeResult.didResize;
     } catch (error) {
@@ -76,35 +57,9 @@ const processImageForUpload = async (
         file: processedFile,
         rawSize,
         processedSize: processedFile.size,
-        wasHeic,
         didResize,
-        heicConversionFailed,
         resizeFailed,
     };
-};
-
-const isHeicFile = (file: File): boolean => {
-    const fileName = file.name.toLowerCase();
-    return (
-        file.type === 'image/heic' ||
-        file.type === 'image/heif' ||
-        fileName.endsWith('.heic') ||
-        fileName.endsWith('.heif')
-    );
-};
-
-const convertHeicToJpeg = async (file: File): Promise<File> => {
-    const convertedBlob = (await heic2any({
-        blob: file,
-        toType: 'image/jpeg',
-        quality: HEIC_CONVERSION_QUALITY,
-    })) as Blob;
-
-    const convertedFileName = file.name.replace(/\.(heic|heif)$/i, '.jpg');
-    return new File([convertedBlob], convertedFileName, {
-        type: 'image/jpeg',
-        lastModified: Date.now(),
-    });
 };
 
 interface ResizeResult {

--- a/apps/web/src/post/utils/ImageUtils.ts
+++ b/apps/web/src/post/utils/ImageUtils.ts
@@ -31,8 +31,8 @@ const cropAndResizeImage = async (file: File, callback: (resizedFile: File) => v
 
 /**
  * Process image for upload: resize to MAX_IMAGE_DIMENSION_FOR_UPLOAD.
- * HEIC/HEIF files are rejected upstream by validateFileType, so this function
- * only handles JPEG/PNG/WebP/GIF inputs.
+ * HEIC/HEIF/GIF are rejected upstream by validateFileType, so this function
+ * only handles JPEG/PNG/WebP inputs.
  */
 const processImageForUpload = async (
     file: File,
@@ -47,7 +47,7 @@ const processImageForUpload = async (
 
     options.onStage?.('resizing');
     try {
-        const resizeResult = await resizeImageForUpload(file);
+        const resizeResult = await resizeImageForUpload(processedFile);
         processedFile = resizeResult.file;
         didResize = resizeResult.didResize;
     } catch (error) {

--- a/apps/web/src/post/utils/ImageUtils.ts
+++ b/apps/web/src/post/utils/ImageUtils.ts
@@ -1,3 +1,5 @@
+import { MAX_PROCESSED_FILE_SIZE } from '@/post/utils/ImageValidation';
+
 const MAX_IMAGE_DIMENSION_FOR_UPLOAD = 1200;
 const JPEG_QUALITY_FOR_UPLOAD = 0.85;
 const PROFILE_PHOTO_SIZE = 96;
@@ -67,13 +69,31 @@ interface ResizeResult {
     didResize: boolean;
 }
 
+/**
+ * Decide whether an image must go through the canvas re-encode path.
+ * Re-encoding is required when EITHER the pixel dimensions exceed the upload
+ * cap OR the raw byte size already exceeds the post-processing limit — a
+ * small-pixel-but-large-byte file (e.g., uncompressed PNG screenshot) would
+ * otherwise sail past the resize step and fail validateProcessedFileSize.
+ */
+const needsReencoding = (
+    fileSize: number,
+    dimensions: ImageDimensions,
+    maxDimension: number,
+    maxBytes: number,
+): boolean => {
+    const exceedsDimensions =
+        dimensions.width > maxDimension || dimensions.height > maxDimension;
+    const exceedsByteSize = fileSize > maxBytes;
+    return exceedsDimensions || exceedsByteSize;
+};
+
 const resizeImageForUpload = async (file: File): Promise<ResizeResult> => {
     const dimensions = await loadImageDimensions(file);
-    const needsResize =
-        dimensions.width > MAX_IMAGE_DIMENSION_FOR_UPLOAD ||
-        dimensions.height > MAX_IMAGE_DIMENSION_FOR_UPLOAD;
 
-    if (!needsResize) {
+    if (
+        !needsReencoding(file.size, dimensions, MAX_IMAGE_DIMENSION_FOR_UPLOAD, MAX_PROCESSED_FILE_SIZE)
+    ) {
         return { file, didResize: false };
     }
 
@@ -209,5 +229,5 @@ const blobToFile = (blob: Blob, fileName: string, fileType: string): File => {
     return new File([blob], fileName, { type: fileType });
 };
 
-export { cropAndResizeImage, processImageForUpload };
+export { cropAndResizeImage, needsReencoding, processImageForUpload };
 export type { ProcessedImage, ProcessImageOptions, ProcessingFailure, ProcessingStage };

--- a/apps/web/src/post/utils/ImageValidation.ts
+++ b/apps/web/src/post/utils/ImageValidation.ts
@@ -1,9 +1,13 @@
 const MAX_RAW_FILE_SIZE = 20 * 1024 * 1024; // 20MB
 const MAX_PROCESSED_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
-type ValidationResult =
-  | { valid: true }
-  | { valid: false; reason: 'exceeds_raw_limit' | 'exceeds_processed_limit' | 'not_image' };
+type ValidationReason =
+  | 'exceeds_raw_limit'
+  | 'exceeds_processed_limit'
+  | 'not_image'
+  | 'unsupported_format';
+
+type ValidationResult = { valid: true } | { valid: false; reason: ValidationReason };
 
 function validateFileSize(
   file: File | Blob,
@@ -26,10 +30,14 @@ function validateProcessedFileSize(
 }
 
 function validateFileType(file: File): ValidationResult {
-  const isImageMime = file.type.startsWith('image/');
   const isHeicByExtension = /\.(heic|heif)$/i.test(file.name);
+  const isHeicByMime = file.type === 'image/heic' || file.type === 'image/heif';
+  if (isHeicByExtension || isHeicByMime) {
+    return { valid: false, reason: 'unsupported_format' };
+  }
 
-  if (!isImageMime && !isHeicByExtension) {
+  const isImageMime = file.type.startsWith('image/');
+  if (!isImageMime) {
     return { valid: false, reason: 'not_image' };
   }
   return { valid: true };
@@ -54,6 +62,7 @@ const validationMessages: Record<string, string> = {
   exceeds_raw_limit: '파일이 너무 큽니다.',
   exceeds_processed_limit: '처리 후에도 파일이 큽니다.',
   not_image: '이미지 파일만 업로드할 수 있습니다.',
+  unsupported_format: 'HEIC/HEIF는 지원하지 않습니다. JPEG 또는 PNG로 저장 후 다시 시도해주세요.',
 };
 
 function getValidationMessage(reason: string): string {

--- a/apps/web/src/post/utils/ImageValidation.ts
+++ b/apps/web/src/post/utils/ImageValidation.ts
@@ -29,8 +29,22 @@ function validateProcessedFileSize(
   return { valid: true };
 }
 
-const SUPPORTED_EXTENSION_PATTERN = /\.(jpe?g|png|webp)$/i;
-const SUPPORTED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+// Single source of truth for supported upload formats.
+// Adding a format = one row here; picker accept, validation, and user message all follow.
+const SUPPORTED_FORMATS = [
+  { mime: 'image/jpeg', extensionPattern: 'jpe?g', label: 'JPEG' },
+  { mime: 'image/png', extensionPattern: 'png', label: 'PNG' },
+  { mime: 'image/webp', extensionPattern: 'webp', label: 'WebP' },
+] as const;
+
+const SUPPORTED_MIME_TYPES = new Set<string>(SUPPORTED_FORMATS.map((f) => f.mime));
+const SUPPORTED_EXTENSION_PATTERN = new RegExp(
+  `\\.(${SUPPORTED_FORMATS.map((f) => f.extensionPattern).join('|')})$`,
+  'i',
+);
+const SUPPORTED_ACCEPT_ATTRIBUTE = SUPPORTED_FORMATS.map((f) => f.mime).join(',');
+const SUPPORTED_FORMAT_LABEL = SUPPORTED_FORMATS.map((f) => f.label).join(', ');
+
 // Drives the more specific "지원하지 않는 형식" message when MIME is missing
 // (e.g., HEIC dragged from Photos.app on macOS often arrives with empty type).
 const KNOWN_UNSUPPORTED_IMAGE_EXTENSION_PATTERN = /\.(heic|heif|gif)$/i;
@@ -67,7 +81,7 @@ const validationMessages: Record<string, string> = {
   exceeds_raw_limit: '파일이 너무 큽니다.',
   exceeds_processed_limit: '처리 후에도 파일이 큽니다.',
   not_image: '이미지 파일만 업로드할 수 있습니다.',
-  unsupported_format: '지원하지 않는 형식입니다. JPEG, PNG, WebP로 저장 후 다시 시도해주세요.',
+  unsupported_format: `지원하지 않는 형식입니다. ${SUPPORTED_FORMAT_LABEL}로 저장 후 다시 시도해주세요.`,
 };
 
 function getValidationMessage(reason: string): string {
@@ -82,5 +96,7 @@ export {
   getValidationMessage,
   MAX_RAW_FILE_SIZE,
   MAX_PROCESSED_FILE_SIZE,
+  SUPPORTED_ACCEPT_ATTRIBUTE,
+  SUPPORTED_FORMAT_LABEL,
 };
 export type { ValidationResult, MultiFileResult };

--- a/apps/web/src/post/utils/ImageValidation.ts
+++ b/apps/web/src/post/utils/ImageValidation.ts
@@ -29,21 +29,23 @@ function validateProcessedFileSize(
   return { valid: true };
 }
 
-const UNSUPPORTED_EXTENSION_PATTERN = /\.(heic|heif|gif)$/i;
-const UNSUPPORTED_MIME_TYPES = new Set(['image/heic', 'image/heif', 'image/gif']);
+const SUPPORTED_EXTENSION_PATTERN = /\.(jpe?g|png|webp)$/i;
+const SUPPORTED_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+// Drives the more specific "지원하지 않는 형식" message when MIME is missing
+// (e.g., HEIC dragged from Photos.app on macOS often arrives with empty type).
+const KNOWN_UNSUPPORTED_IMAGE_EXTENSION_PATTERN = /\.(heic|heif|gif)$/i;
 
 function validateFileType(file: File): ValidationResult {
-  const isUnsupportedExtension = UNSUPPORTED_EXTENSION_PATTERN.test(file.name);
-  const isUnsupportedMime = UNSUPPORTED_MIME_TYPES.has(file.type);
-  if (isUnsupportedExtension || isUnsupportedMime) {
-    return { valid: false, reason: 'unsupported_format' };
+  if (SUPPORTED_MIME_TYPES.has(file.type) || SUPPORTED_EXTENSION_PATTERN.test(file.name)) {
+    return { valid: true };
   }
 
   const isImageMime = file.type.startsWith('image/');
-  if (!isImageMime) {
-    return { valid: false, reason: 'not_image' };
+  const isKnownUnsupportedExtension = KNOWN_UNSUPPORTED_IMAGE_EXTENSION_PATTERN.test(file.name);
+  if (isImageMime || isKnownUnsupportedExtension) {
+    return { valid: false, reason: 'unsupported_format' };
   }
-  return { valid: true };
+  return { valid: false, reason: 'not_image' };
 }
 
 interface MultiFileResult {

--- a/apps/web/src/post/utils/ImageValidation.ts
+++ b/apps/web/src/post/utils/ImageValidation.ts
@@ -29,10 +29,13 @@ function validateProcessedFileSize(
   return { valid: true };
 }
 
+const UNSUPPORTED_EXTENSION_PATTERN = /\.(heic|heif|gif)$/i;
+const UNSUPPORTED_MIME_TYPES = new Set(['image/heic', 'image/heif', 'image/gif']);
+
 function validateFileType(file: File): ValidationResult {
-  const isHeicByExtension = /\.(heic|heif)$/i.test(file.name);
-  const isHeicByMime = file.type === 'image/heic' || file.type === 'image/heif';
-  if (isHeicByExtension || isHeicByMime) {
+  const isUnsupportedExtension = UNSUPPORTED_EXTENSION_PATTERN.test(file.name);
+  const isUnsupportedMime = UNSUPPORTED_MIME_TYPES.has(file.type);
+  if (isUnsupportedExtension || isUnsupportedMime) {
     return { valid: false, reason: 'unsupported_format' };
   }
 
@@ -62,7 +65,7 @@ const validationMessages: Record<string, string> = {
   exceeds_raw_limit: '파일이 너무 큽니다.',
   exceeds_processed_limit: '처리 후에도 파일이 큽니다.',
   not_image: '이미지 파일만 업로드할 수 있습니다.',
-  unsupported_format: 'HEIC/HEIF는 지원하지 않습니다. JPEG 또는 PNG로 저장 후 다시 시도해주세요.',
+  unsupported_format: '지원하지 않는 형식입니다. JPEG, PNG, WebP로 저장 후 다시 시도해주세요.',
 };
 
 function getValidationMessage(reason: string): string {

--- a/apps/web/src/post/utils/ImageValidation.ts
+++ b/apps/web/src/post/utils/ImageValidation.ts
@@ -48,9 +48,16 @@ const SUPPORTED_FORMAT_LABEL = SUPPORTED_FORMATS.map((f) => f.label).join(', ');
 // Drives the more specific "지원하지 않는 형식" message when MIME is missing
 // (e.g., HEIC dragged from Photos.app on macOS often arrives with empty type).
 const KNOWN_UNSUPPORTED_IMAGE_EXTENSION_PATTERN = /\.(heic|heif|gif)$/i;
+// Browsers fall back to these when the OS cannot determine a real MIME.
+const UNKNOWN_MIME_TYPES = new Set(['', 'application/octet-stream']);
 
 function validateFileType(file: File): ValidationResult {
-  if (SUPPORTED_MIME_TYPES.has(file.type) || SUPPORTED_EXTENSION_PATTERN.test(file.name)) {
+  if (SUPPORTED_MIME_TYPES.has(file.type)) {
+    return { valid: true };
+  }
+  // Extension-based allow only kicks in when the browser provided no usable MIME,
+  // so a renamed `notes.jpg` (with `text/plain`) can't sneak past validation.
+  if (UNKNOWN_MIME_TYPES.has(file.type) && SUPPORTED_EXTENSION_PATTERN.test(file.name)) {
     return { valid: true };
   }
 

--- a/apps/web/src/post/utils/__tests__/ImageUtils.test.ts
+++ b/apps/web/src/post/utils/__tests__/ImageUtils.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { processImageForUpload } from '../ImageUtils';
+import { needsReencoding, processImageForUpload } from '../ImageUtils';
+
+const FIVE_MB = 5 * 1024 * 1024;
+const MAX_DIM = 1200;
 
 vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
   cb();
@@ -86,5 +89,39 @@ describe('processImageForUpload', () => {
 
     expect(result.resizeFailed).toBe(true);
     expect(onError).toHaveBeenCalledWith('resize', expect.anything());
+  });
+});
+
+describe('needsReencoding', () => {
+  it('returns false when dimensions and byte size are both within limits', () => {
+    expect(needsReencoding(1024, { width: 800, height: 600 }, MAX_DIM, FIVE_MB)).toBe(false);
+  });
+
+  it('returns true when width exceeds the dimension cap', () => {
+    expect(needsReencoding(1024, { width: MAX_DIM + 1, height: 600 }, MAX_DIM, FIVE_MB)).toBe(
+      true,
+    );
+  });
+
+  it('returns true when height exceeds the dimension cap', () => {
+    expect(needsReencoding(1024, { width: 600, height: MAX_DIM + 1 }, MAX_DIM, FIVE_MB)).toBe(
+      true,
+    );
+  });
+
+  it('returns true when byte size exceeds the cap even if dimensions are small', () => {
+    expect(needsReencoding(FIVE_MB + 1, { width: 800, height: 800 }, MAX_DIM, FIVE_MB)).toBe(
+      true,
+    );
+  });
+
+  it('returns false at the exact byte cap', () => {
+    expect(needsReencoding(FIVE_MB, { width: 800, height: 800 }, MAX_DIM, FIVE_MB)).toBe(false);
+  });
+
+  it('returns false at the exact dimension cap', () => {
+    expect(needsReencoding(1024, { width: MAX_DIM, height: MAX_DIM }, MAX_DIM, FIVE_MB)).toBe(
+      false,
+    );
   });
 });

--- a/apps/web/src/post/utils/__tests__/ImageUtils.test.ts
+++ b/apps/web/src/post/utils/__tests__/ImageUtils.test.ts
@@ -1,10 +1,4 @@
 import { describe, it, expect, vi } from 'vitest';
-
-vi.mock('heic2any', () => ({
-  default: vi.fn(),
-}));
-
-import heic2any from 'heic2any';
 import { processImageForUpload } from '../ImageUtils';
 
 vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
@@ -45,65 +39,7 @@ function mockImageAndFileReader(width = 100, height = 100) {
 }
 
 describe('processImageForUpload', () => {
-  it('returns original file when HEIC conversion fails', async () => {
-    const heicFile = createFile('photo.heic', 1024, 'image/heic');
-    vi.mocked(heic2any).mockRejectedValueOnce(new Error('Conversion failed'));
-    vi.stubGlobal('createImageBitmap', undefined);
-    mockImageAndFileReader();
-
-    const result = await processImageForUpload(heicFile);
-
-    expect(result.file).toBe(heicFile);
-    expect(result.file.name).toBe('photo.heic');
-    expect(result.wasHeic).toBe(true);
-    expect(result.rawSize).toBe(1024);
-    expect(result.didResize).toBe(false);
-    expect(result.heicConversionFailed).toBe(true);
-  });
-
-  it('reports onError when HEIC conversion fails', async () => {
-    const heicFile = createFile('photo.heic', 1024, 'image/heic');
-    const conversionError = new Error('Conversion failed');
-    vi.mocked(heic2any).mockRejectedValueOnce(conversionError);
-    vi.stubGlobal('createImageBitmap', undefined);
-    mockImageAndFileReader();
-
-    const onError = vi.fn();
-    await processImageForUpload(heicFile, { onError });
-
-    expect(onError).toHaveBeenCalledWith('heic_convert', conversionError);
-  });
-
-  it('converts HEIC file when conversion succeeds', async () => {
-    const heicFile = createFile('photo.heic', 1024, 'image/heic');
-    const convertedBlob = new Blob([new ArrayBuffer(512)], { type: 'image/jpeg' });
-    vi.mocked(heic2any).mockResolvedValueOnce(convertedBlob);
-    vi.stubGlobal('createImageBitmap', undefined);
-    mockImageAndFileReader();
-
-    const result = await processImageForUpload(heicFile);
-
-    expect(result.file.name).toBe('photo.jpg');
-    expect(result.file.type).toBe('image/jpeg');
-    expect(result.wasHeic).toBe(true);
-  });
-
-  it('reports onStage callbacks for HEIC files', async () => {
-    const heicFile = createFile('photo.heic', 1024, 'image/heic');
-    const convertedBlob = new Blob([new ArrayBuffer(512)], { type: 'image/jpeg' });
-    vi.mocked(heic2any).mockResolvedValueOnce(convertedBlob);
-    vi.stubGlobal('createImageBitmap', undefined);
-    mockImageAndFileReader();
-
-    const stages: string[] = [];
-    await processImageForUpload(heicFile, {
-      onStage: (stage) => stages.push(stage),
-    });
-
-    expect(stages).toEqual(['converting', 'resizing']);
-  });
-
-  it('skips converting stage for non-HEIC files', async () => {
+  it('emits only the resizing stage', async () => {
     const jpegFile = createFile('photo.jpg', 1024, 'image/jpeg');
     vi.stubGlobal('createImageBitmap', undefined);
     mockImageAndFileReader();
@@ -124,6 +60,31 @@ describe('processImageForUpload', () => {
     const result = await processImageForUpload(jpegFile);
 
     expect(result.didResize).toBe(false);
+    expect(result.resizeFailed).toBe(false);
     expect(result.file).toBe(jpegFile);
+    expect(result.rawSize).toBe(1024);
+  });
+
+  it('reports onError with resize failure when canvas decoding throws', async () => {
+    const jpegFile = createFile('photo.jpg', 1024, 'image/jpeg');
+    const decodeError = new Error('decode failed');
+    vi.stubGlobal('createImageBitmap', undefined);
+    vi.spyOn(globalThis, 'FileReader').mockImplementation(
+      () =>
+        ({
+          result: 'data:image/jpeg;base64,test',
+          onload: null,
+          onerror: null,
+          readAsDataURL() {
+            setTimeout(() => (this as unknown as FileReader).onerror?.(decodeError as unknown as ProgressEvent<FileReader>), 0);
+          },
+        }) as unknown as FileReader,
+    );
+
+    const onError = vi.fn();
+    const result = await processImageForUpload(jpegFile, { onError });
+
+    expect(result.resizeFailed).toBe(true);
+    expect(onError).toHaveBeenCalledWith('resize', expect.anything());
   });
 });

--- a/apps/web/src/post/utils/__tests__/ImageUtils.test.ts
+++ b/apps/web/src/post/utils/__tests__/ImageUtils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { needsReencoding, processImageForUpload } from '../ImageUtils';
+import {
+  computeScaledDimensions,
+  needsReencoding,
+  processImageForUpload,
+} from '../ImageUtils';
 
 const FIVE_MB = 5 * 1024 * 1024;
 const MAX_DIM = 1200;
@@ -123,5 +127,55 @@ describe('needsReencoding', () => {
     expect(needsReencoding(1024, { width: MAX_DIM, height: MAX_DIM }, MAX_DIM, FIVE_MB)).toBe(
       false,
     );
+  });
+});
+
+describe('computeScaledDimensions', () => {
+  it('returns dimensions unchanged when both axes are within the cap', () => {
+    expect(computeScaledDimensions({ width: 800, height: 600 }, MAX_DIM)).toEqual({
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it('scales a landscape image by width and preserves aspect ratio', () => {
+    expect(computeScaledDimensions({ width: 2400, height: 1200 }, MAX_DIM)).toEqual({
+      width: 1200,
+      height: 600,
+    });
+  });
+
+  it('scales a portrait image by height and preserves aspect ratio', () => {
+    expect(computeScaledDimensions({ width: 1200, height: 2400 }, MAX_DIM)).toEqual({
+      width: 600,
+      height: 1200,
+    });
+  });
+
+  it('scales a square image by either axis to the cap', () => {
+    expect(computeScaledDimensions({ width: 2000, height: 2000 }, MAX_DIM)).toEqual({
+      width: 1200,
+      height: 1200,
+    });
+  });
+
+  it('rounds the dependent axis to the nearest integer', () => {
+    // 1000 / 1500 * 1200 = 800
+    expect(computeScaledDimensions({ width: 1500, height: 1000 }, MAX_DIM)).toEqual({
+      width: 1200,
+      height: 800,
+    });
+    // odd ratio: 1999 / 3000 * 1200 = 799.6 → rounds to 800
+    expect(computeScaledDimensions({ width: 3000, height: 1999 }, MAX_DIM)).toEqual({
+      width: 1200,
+      height: 800,
+    });
+  });
+
+  it('does not upscale when both axes are smaller than the cap', () => {
+    expect(computeScaledDimensions({ width: 100, height: 50 }, MAX_DIM)).toEqual({
+      width: 100,
+      height: 50,
+    });
   });
 });

--- a/apps/web/src/post/utils/__tests__/ImageValidation.test.ts
+++ b/apps/web/src/post/utils/__tests__/ImageValidation.test.ts
@@ -75,14 +75,24 @@ describe('validateFileType', () => {
     expect(validateFileType(file)).toEqual({ valid: true });
   });
 
-  it('allows .heic by extension even without image MIME', () => {
-    const file = createFile('photo.heic', 100, 'application/octet-stream');
-    expect(validateFileType(file)).toEqual({ valid: true });
+  it('rejects .heic by extension even when MIME is image/heic', () => {
+    const file = createFile('photo.heic', 100, 'image/heic');
+    expect(validateFileType(file)).toEqual({ valid: false, reason: 'unsupported_format' });
   });
 
-  it('allows .heif by extension even without image MIME', () => {
+  it('rejects .heif by extension regardless of MIME', () => {
     const file = createFile('photo.HEIF', 100, '');
-    expect(validateFileType(file)).toEqual({ valid: true });
+    expect(validateFileType(file)).toEqual({ valid: false, reason: 'unsupported_format' });
+  });
+
+  it('rejects image/heic MIME without .heic extension', () => {
+    const file = createFile('photo', 100, 'image/heic');
+    expect(validateFileType(file)).toEqual({ valid: false, reason: 'unsupported_format' });
+  });
+
+  it('rejects image/heif MIME without .heif extension', () => {
+    const file = createFile('photo', 100, 'image/heif');
+    expect(validateFileType(file)).toEqual({ valid: false, reason: 'unsupported_format' });
   });
 
   it('rejects non-image files', () => {
@@ -134,6 +144,12 @@ describe('getValidationMessage', () => {
 
   it('returns correct message for not_image', () => {
     expect(getValidationMessage('not_image')).toBe('이미지 파일만 업로드할 수 있습니다.');
+  });
+
+  it('returns correct message for unsupported_format', () => {
+    expect(getValidationMessage('unsupported_format')).toBe(
+      'HEIC/HEIF는 지원하지 않습니다. JPEG 또는 PNG로 저장 후 다시 시도해주세요.',
+    );
   });
 
   it('returns fallback for unknown reason', () => {

--- a/apps/web/src/post/utils/__tests__/ImageValidation.test.ts
+++ b/apps/web/src/post/utils/__tests__/ImageValidation.test.ts
@@ -127,6 +127,22 @@ describe('validateFileType', () => {
     expect(validateFileType(file)).toEqual({ valid: true });
   });
 
+  it('allows JPEG by extension when MIME is application/octet-stream', () => {
+    const file = createFile('photo.jpg', 100, 'application/octet-stream');
+    expect(validateFileType(file)).toEqual({ valid: true });
+  });
+
+  it('rejects supported extension when MIME is a non-image type', () => {
+    // e.g. notes.txt renamed to notes.jpg — extension alone must not bypass MIME check
+    const file = createFile('notes.jpg', 100, 'text/plain');
+    expect(validateFileType(file)).toEqual({ valid: false, reason: 'not_image' });
+  });
+
+  it('rejects supported extension when MIME is application/pdf', () => {
+    const file = createFile('doc.png', 100, 'application/pdf');
+    expect(validateFileType(file)).toEqual({ valid: false, reason: 'not_image' });
+  });
+
   it('rejects non-image files', () => {
     const file = createFile('document.pdf', 100, 'application/pdf');
     expect(validateFileType(file)).toEqual({ valid: false, reason: 'not_image' });

--- a/apps/web/src/post/utils/__tests__/ImageValidation.test.ts
+++ b/apps/web/src/post/utils/__tests__/ImageValidation.test.ts
@@ -7,6 +7,8 @@ import {
   getValidationMessage,
   MAX_RAW_FILE_SIZE,
   MAX_PROCESSED_FILE_SIZE,
+  SUPPORTED_ACCEPT_ATTRIBUTE,
+  SUPPORTED_FORMAT_LABEL,
 } from '../ImageValidation';
 
 function createFile(name: string, size: number, type: string): File {
@@ -184,5 +186,30 @@ describe('getValidationMessage', () => {
 
   it('returns fallback for unknown reason', () => {
     expect(getValidationMessage('unknown')).toBe('파일을 업로드할 수 없습니다.');
+  });
+});
+
+describe('supported-formats coherence (single source of truth)', () => {
+  const ACCEPTED_MIMES = SUPPORTED_ACCEPT_ATTRIBUTE.split(',');
+
+  it('every MIME advertised in the picker attribute also passes validateFileType', () => {
+    for (const mime of ACCEPTED_MIMES) {
+      const file = new File([new ArrayBuffer(1)], 'photo', { type: mime });
+      expect(validateFileType(file)).toEqual({ valid: true });
+    }
+  });
+
+  it('every format named in the user-facing label is also in the picker attribute', () => {
+    // e.g. label "JPEG, PNG, WebP" → picker advertises image/jpeg, image/png, image/webp
+    const labels = SUPPORTED_FORMAT_LABEL.split(', ');
+    expect(labels.length).toBe(ACCEPTED_MIMES.length);
+    for (const label of labels) {
+      const expectedMime = `image/${label.toLowerCase()}`;
+      expect(ACCEPTED_MIMES).toContain(expectedMime);
+    }
+  });
+
+  it('unsupported_format message advertises exactly the same formats as the picker', () => {
+    expect(getValidationMessage('unsupported_format')).toContain(SUPPORTED_FORMAT_LABEL);
   });
 });

--- a/apps/web/src/post/utils/__tests__/ImageValidation.test.ts
+++ b/apps/web/src/post/utils/__tests__/ImageValidation.test.ts
@@ -65,9 +65,14 @@ describe('validateFileType', () => {
     expect(validateFileType(file)).toEqual({ valid: true });
   });
 
-  it('allows image/gif', () => {
+  it('rejects image/gif', () => {
     const file = createFile('photo.gif', 100, 'image/gif');
-    expect(validateFileType(file)).toEqual({ valid: true });
+    expect(validateFileType(file)).toEqual({ valid: false, reason: 'unsupported_format' });
+  });
+
+  it('rejects .gif by extension regardless of MIME', () => {
+    const file = createFile('photo.GIF', 100, '');
+    expect(validateFileType(file)).toEqual({ valid: false, reason: 'unsupported_format' });
   });
 
   it('allows image/webp', () => {
@@ -148,7 +153,7 @@ describe('getValidationMessage', () => {
 
   it('returns correct message for unsupported_format', () => {
     expect(getValidationMessage('unsupported_format')).toBe(
-      'HEIC/HEIF는 지원하지 않습니다. JPEG 또는 PNG로 저장 후 다시 시도해주세요.',
+      '지원하지 않는 형식입니다. JPEG, PNG, WebP로 저장 후 다시 시도해주세요.',
     );
   });
 

--- a/apps/web/src/post/utils/__tests__/ImageValidation.test.ts
+++ b/apps/web/src/post/utils/__tests__/ImageValidation.test.ts
@@ -100,6 +100,31 @@ describe('validateFileType', () => {
     expect(validateFileType(file)).toEqual({ valid: false, reason: 'unsupported_format' });
   });
 
+  it('rejects image/avif as unsupported_format (not in allow-list)', () => {
+    const file = createFile('photo.avif', 100, 'image/avif');
+    expect(validateFileType(file)).toEqual({ valid: false, reason: 'unsupported_format' });
+  });
+
+  it('rejects image/svg+xml as unsupported_format (not in allow-list)', () => {
+    const file = createFile('drawing.svg', 100, 'image/svg+xml');
+    expect(validateFileType(file)).toEqual({ valid: false, reason: 'unsupported_format' });
+  });
+
+  it('rejects image/tiff as unsupported_format (not in allow-list)', () => {
+    const file = createFile('scan.tif', 100, 'image/tiff');
+    expect(validateFileType(file)).toEqual({ valid: false, reason: 'unsupported_format' });
+  });
+
+  it('allows .jpg extension as JPEG alias', () => {
+    const file = createFile('photo.jpg', 100, 'image/jpeg');
+    expect(validateFileType(file)).toEqual({ valid: true });
+  });
+
+  it('allows JPEG by extension when MIME is empty', () => {
+    const file = createFile('photo.jpeg', 100, '');
+    expect(validateFileType(file)).toEqual({ valid: true });
+  });
+
   it('rejects non-image files', () => {
     const file = createFile('document.pdf', 100, 'application/pdf');
     expect(validateFileType(file)).toEqual({ valid: false, reason: 'not_image' });

--- a/apps/web/src/post/utils/__tests__/dateFormat.test.ts
+++ b/apps/web/src/post/utils/__tests__/dateFormat.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate } from '../dateFormat';
+
+describe('formatDate', () => {
+  it('should return dateFolder in YYYYMMDD format', () => {
+    const date = new Date(2025, 0, 15); // January 15, 2025
+    const result = formatDate(date);
+    expect(result.dateFolder).toBe('20250115');
+  });
+
+  it('should return timePrefix in HHMMSS format', () => {
+    const date = new Date(2025, 0, 15, 14, 30, 45);
+    const result = formatDate(date);
+    expect(result.timePrefix).toBe('143045');
+  });
+
+  it('should pad single digit months with zero', () => {
+    const date = new Date(2025, 4, 8); // May 8
+    const result = formatDate(date);
+    expect(result.dateFolder).toBe('20250508');
+  });
+
+  it('should pad single digit days with zero', () => {
+    const date = new Date(2025, 11, 5); // December 5
+    const result = formatDate(date);
+    expect(result.dateFolder).toBe('20251205');
+  });
+
+  it('should pad single digit hours with zero', () => {
+    const date = new Date(2025, 0, 15, 9, 30, 45);
+    const result = formatDate(date);
+    expect(result.timePrefix).toBe('093045');
+  });
+
+  it('should pad single digit minutes with zero', () => {
+    const date = new Date(2025, 0, 15, 14, 5, 45);
+    const result = formatDate(date);
+    expect(result.timePrefix).toBe('140545');
+  });
+
+  it('should pad single digit seconds with zero', () => {
+    const date = new Date(2025, 0, 15, 14, 30, 5);
+    const result = formatDate(date);
+    expect(result.timePrefix).toBe('143005');
+  });
+
+  it('should handle midnight correctly', () => {
+    const date = new Date(2025, 0, 15, 0, 0, 0);
+    const result = formatDate(date);
+    expect(result.timePrefix).toBe('000000');
+  });
+
+  it('should handle end of day correctly', () => {
+    const date = new Date(2025, 0, 15, 23, 59, 59);
+    const result = formatDate(date);
+    expect(result.timePrefix).toBe('235959');
+  });
+
+  it('should return object with both properties', () => {
+    const date = new Date(2025, 0, 15, 14, 30, 45);
+    const result = formatDate(date);
+    expect(result).toHaveProperty('dateFolder');
+    expect(result).toHaveProperty('timePrefix');
+  });
+});

--- a/apps/web/src/post/utils/__tests__/storagePath.test.ts
+++ b/apps/web/src/post/utils/__tests__/storagePath.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { buildImageStoragePath } from '../storagePath';
+
+const FIXED_DATE = new Date('2026-05-28T09:07:03Z');
+
+describe('buildImageStoragePath', () => {
+  it('formats path as {prefix}/{YYYYMMDD}/{HHMMSS}_{fileName}', () => {
+    const now = new Date(2026, 4, 28, 9, 7, 3); // local 2026-05-28 09:07:03
+    expect(buildImageStoragePath('postImages', 'photo.jpg', now)).toBe(
+      'postImages/20260528/090703_photo.jpg',
+    );
+  });
+
+  it('zero-pads month, day, hour, minute, second below 10', () => {
+    const now = new Date(2026, 0, 5, 3, 4, 9); // local 2026-01-05 03:04:09
+    expect(buildImageStoragePath('feedbackScreenshots', 'shot.png', now)).toBe(
+      'feedbackScreenshots/20260105/030409_shot.png',
+    );
+  });
+
+  it('sanitizes filenames containing path separators', () => {
+    const result = buildImageStoragePath('postImages', '../escape/photo.jpg', FIXED_DATE);
+    expect(result.endsWith('__escape_photo.jpg')).toBe(true);
+    expect(result).not.toContain('..');
+    expect(result).not.toContain('/escape/');
+  });
+
+  it('falls back to a default name when the sanitized filename would be empty', () => {
+    const result = buildImageStoragePath('postImages', '\x01\x02\x03', FIXED_DATE);
+    expect(result.endsWith('_image')).toBe(true);
+  });
+
+  it('preserves Unicode (Korean) characters in the filename', () => {
+    const result = buildImageStoragePath('postImages', '오늘의일기.jpg', FIXED_DATE);
+    expect(result.endsWith('_오늘의일기.jpg')).toBe(true);
+  });
+
+  it('produces a different path for different prefixes given the same time and filename', () => {
+    const postsPath = buildImageStoragePath('postImages', 'a.jpg', FIXED_DATE);
+    const screenshotsPath = buildImageStoragePath('feedbackScreenshots', 'a.jpg', FIXED_DATE);
+    expect(postsPath.startsWith('postImages/')).toBe(true);
+    expect(screenshotsPath.startsWith('feedbackScreenshots/')).toBe(true);
+    expect(postsPath).not.toBe(screenshotsPath);
+  });
+});

--- a/apps/web/src/post/utils/dateFormat.ts
+++ b/apps/web/src/post/utils/dateFormat.ts
@@ -1,0 +1,19 @@
+/**
+ * Format a Date into zero-padded `YYYYMMDD` + `HHMMSS` parts used in
+ * storage paths and post folder names. Kept in its own DOM-free module so
+ * pure callers (e.g., storage path builders) don't transitively pull in
+ * heavier dependencies like DOMPurify via sanitizeHtml.ts.
+ */
+export function formatDate(date: Date): { dateFolder: string; timePrefix: string } {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+
+  return {
+    dateFolder: `${year}${month}${day}`,
+    timePrefix: `${hours}${minutes}${seconds}`,
+  };
+}

--- a/apps/web/src/post/utils/imageUploadTelemetry.ts
+++ b/apps/web/src/post/utils/imageUploadTelemetry.ts
@@ -1,13 +1,10 @@
 import * as Sentry from '@sentry/react';
 import type { ProcessingFailure } from '@/post/utils/ImageUtils';
 
-const HEIC_FAILURE_MESSAGE =
-  '이 HEIC 파일을 변환할 수 없습니다. JPEG 또는 PNG로 저장 후 다시 시도해주세요.';
-
 const captureProcessingFailure = (failure: ProcessingFailure, error: unknown): void => {
   Sentry.captureException(error, {
     tags: { feature: 'image_upload', operation: failure },
   });
 };
 
-export { captureProcessingFailure, HEIC_FAILURE_MESSAGE };
+export { captureProcessingFailure };

--- a/apps/web/src/post/utils/sanitizeHtml.test.ts
+++ b/apps/web/src/post/utils/sanitizeHtml.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sanitize, isValidHttpUrl, formatDate } from './sanitizeHtml';
+import { sanitize, isValidHttpUrl } from './sanitizeHtml';
 
 describe('sanitizeHtml', () => {
   describe('sanitize', () => {
@@ -206,76 +206,4 @@ describe('sanitizeHtml', () => {
     });
   });
 
-  describe('formatDate', () => {
-    it('should return dateFolder in YYYYMMDD format', () => {
-      const date = new Date(2025, 0, 15); // January 15, 2025
-      const result = formatDate(date);
-
-      expect(result.dateFolder).toBe('20250115');
-    });
-
-    it('should return timePrefix in HHMMSS format', () => {
-      const date = new Date(2025, 0, 15, 14, 30, 45);
-      const result = formatDate(date);
-
-      expect(result.timePrefix).toBe('143045');
-    });
-
-    it('should pad single digit months with zero', () => {
-      const date = new Date(2025, 4, 8); // May 8
-      const result = formatDate(date);
-
-      expect(result.dateFolder).toBe('20250508');
-    });
-
-    it('should pad single digit days with zero', () => {
-      const date = new Date(2025, 11, 5); // December 5
-      const result = formatDate(date);
-
-      expect(result.dateFolder).toBe('20251205');
-    });
-
-    it('should pad single digit hours with zero', () => {
-      const date = new Date(2025, 0, 15, 9, 30, 45);
-      const result = formatDate(date);
-
-      expect(result.timePrefix).toBe('093045');
-    });
-
-    it('should pad single digit minutes with zero', () => {
-      const date = new Date(2025, 0, 15, 14, 5, 45);
-      const result = formatDate(date);
-
-      expect(result.timePrefix).toBe('140545');
-    });
-
-    it('should pad single digit seconds with zero', () => {
-      const date = new Date(2025, 0, 15, 14, 30, 5);
-      const result = formatDate(date);
-
-      expect(result.timePrefix).toBe('143005');
-    });
-
-    it('should handle midnight correctly', () => {
-      const date = new Date(2025, 0, 15, 0, 0, 0);
-      const result = formatDate(date);
-
-      expect(result.timePrefix).toBe('000000');
-    });
-
-    it('should handle end of day correctly', () => {
-      const date = new Date(2025, 0, 15, 23, 59, 59);
-      const result = formatDate(date);
-
-      expect(result.timePrefix).toBe('235959');
-    });
-
-    it('should return object with both properties', () => {
-      const date = new Date(2025, 0, 15, 14, 30, 45);
-      const result = formatDate(date);
-
-      expect(result).toHaveProperty('dateFolder');
-      expect(result).toHaveProperty('timePrefix');
-    });
-  });
 });

--- a/apps/web/src/post/utils/sanitizeHtml.ts
+++ b/apps/web/src/post/utils/sanitizeHtml.ts
@@ -58,19 +58,3 @@ export function isValidHttpUrl(url: string): boolean {
   }
 }
 
-/**
- * Format date for Firebase storage path: YYYYMMDD folder + HHMMSS prefix.
- */
-export function formatDate(date: Date): { dateFolder: string; timePrefix: string } {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-  const seconds = String(date.getSeconds()).padStart(2, '0');
-
-  return {
-    dateFolder: `${year}${month}${day}`,
-    timePrefix: `${hours}${minutes}${seconds}`
-  };
-}

--- a/apps/web/src/post/utils/storagePath.ts
+++ b/apps/web/src/post/utils/storagePath.ts
@@ -1,4 +1,4 @@
-import { formatDate } from '@/post/utils/sanitizeHtml';
+import { formatDate } from '@/post/utils/dateFormat';
 import { sanitizeStorageFileName } from '@/post/utils/storageFileName';
 
 /**

--- a/apps/web/src/post/utils/storagePath.ts
+++ b/apps/web/src/post/utils/storagePath.ts
@@ -1,0 +1,15 @@
+import { formatDate } from '@/post/utils/sanitizeHtml';
+import { sanitizeStorageFileName } from '@/post/utils/storageFileName';
+
+/**
+ * Compose the Firebase Storage path for an uploaded image.
+ * Takes `now` as a parameter so the function is pure and date-deterministic for tests.
+ *
+ * Path shape: {prefix}/{YYYYMMDD}/{HHMMSS}_{sanitizedFileName}
+ */
+const buildImageStoragePath = (prefix: string, fileName: string, now: Date): string => {
+  const { dateFolder, timePrefix } = formatDate(now);
+  return `${prefix}/${dateFolder}/${timePrefix}_${sanitizeStorageFileName(fileName)}`;
+};
+
+export { buildImageStoragePath };

--- a/apps/web/src/shared/utils/uploadFeedbackScreenshot.ts
+++ b/apps/web/src/shared/utils/uploadFeedbackScreenshot.ts
@@ -9,7 +9,7 @@ import {
   getValidationMessage,
 } from '@/post/utils/ImageValidation';
 import { captureProcessingFailure } from '@/post/utils/imageUploadTelemetry';
-import { sanitizeStorageFileName } from '@/post/utils/storageFileName';
+import { buildImageStoragePath } from '@/post/utils/storagePath';
 
 interface UploadResult {
   success: boolean;
@@ -46,8 +46,12 @@ export async function uploadFeedbackScreenshot(file: File): Promise<UploadResult
       return { success: false, error: getValidationMessage(processedSizeResult.reason) };
     }
 
-    const fileName = buildFeedbackScreenshotPath(processed.file.name);
-    const storageRef = ref(storage, fileName);
+    const storagePath = buildImageStoragePath(
+      'feedbackScreenshots',
+      processed.file.name,
+      new Date(),
+    );
+    const storageRef = ref(storage, storagePath);
 
     const snapshot = await uploadBytes(storageRef, processed.file, {
       contentType: processed.file.type || 'image/jpeg',
@@ -64,16 +68,3 @@ export async function uploadFeedbackScreenshot(file: File): Promise<UploadResult
   }
 }
 
-const buildFeedbackScreenshotPath = (fileName: string): string => {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  const day = String(now.getDate()).padStart(2, '0');
-  const hours = String(now.getHours()).padStart(2, '0');
-  const minutes = String(now.getMinutes()).padStart(2, '0');
-  const seconds = String(now.getSeconds()).padStart(2, '0');
-
-  const dateFolder = `${year}${month}${day}`;
-  const timePrefix = `${hours}${minutes}${seconds}`;
-  return `feedbackScreenshots/${dateFolder}/${timePrefix}_${sanitizeStorageFileName(fileName)}`;
-};

--- a/apps/web/src/shared/utils/uploadFeedbackScreenshot.ts
+++ b/apps/web/src/shared/utils/uploadFeedbackScreenshot.ts
@@ -8,10 +8,7 @@ import {
   validateFileType,
   getValidationMessage,
 } from '@/post/utils/ImageValidation';
-import {
-  captureProcessingFailure,
-  HEIC_FAILURE_MESSAGE,
-} from '@/post/utils/imageUploadTelemetry';
+import { captureProcessingFailure } from '@/post/utils/imageUploadTelemetry';
 import { sanitizeStorageFileName } from '@/post/utils/storageFileName';
 
 interface UploadResult {
@@ -22,7 +19,7 @@ interface UploadResult {
 
 /**
  * Upload feedback screenshot to Firebase Storage.
- * Compresses on the client first so users can submit large iPhone HEIC photos.
+ * Compresses on the client first to stay under the 5MB processed-size cap.
  */
 export async function uploadFeedbackScreenshot(file: File): Promise<UploadResult> {
   if (!storage) {
@@ -43,10 +40,6 @@ export async function uploadFeedbackScreenshot(file: File): Promise<UploadResult
     const processed = await processImageForUpload(file, {
       onError: captureProcessingFailure,
     });
-
-    if (processed.wasHeic && processed.heicConversionFailed) {
-      return { success: false, error: HEIC_FAILURE_MESSAGE };
-    }
 
     const processedSizeResult = validateProcessedFileSize(processed.file);
     if (!processedSizeResult.valid) {

--- a/apps/web/src/shared/utils/uploadFeedbackScreenshot.ts
+++ b/apps/web/src/shared/utils/uploadFeedbackScreenshot.ts
@@ -41,6 +41,10 @@ export async function uploadFeedbackScreenshot(file: File): Promise<UploadResult
       onError: captureProcessingFailure,
     });
 
+    if (processed.resizeFailed) {
+      return { success: false, error: '이미지를 처리할 수 없습니다. 다른 사진으로 다시 시도해주세요.' };
+    }
+
     const processedSizeResult = validateProcessedFileSize(processed.file);
     if (!processedSizeResult.valid) {
       return { success: false, error: getValidationMessage(processedSizeResult.reason) };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,9 +300,6 @@ importers:
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      heic2any:
-        specifier: ^0.0.4
-        version: 0.0.4
       lucide-react:
         specifier: ^0.453.0
         version: 0.453.0(react@18.3.1)
@@ -4352,9 +4349,6 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
-
-  heic2any@0.0.4:
-    resolution: {integrity: sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -10485,7 +10479,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -10526,7 +10520,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -10595,7 +10589,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11355,8 +11349,6 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
-
-  heic2any@0.0.4: {}
 
   hermes-estree@0.25.1: {}
 


### PR DESCRIPTION
## Summary

- macOS Chrome에서 HEIC 사진 1장 업로드가 Sentry 이슈 3건(`heic_convert` + `resize` + `file_picker`)을 만들고 있던 캐스케이드를 차단. 원인은 `heic2any@0.0.4`가 iOS 17/18의 HEIC 변종(HDR 게인맵, 10-bit HEVC, 다중 보조 이미지)을 디코딩하지 못하고, 실패해도 파이프라인이 멈추지 않고 원본 HEIC를 그대로 resize까지 보냈기 때문.
- Android Chrome Mobile의 "처리 후에도 파일이 큽니다" 이슈는 `resizeImageForUpload`가 픽셀 크기만 보고 1200px 이하면 재인코딩을 건너뛰어 5MB 초과 PNG 스크린샷이 그대로 5MB 검증에 걸리던 문제. 픽셀이 작아도 5MB 초과면 강제 재인코딩하도록 결정 로직(`needsReencoding`)을 순수 함수로 추출.
- GIF는 JPEG 재인코딩 시 애니메이션 손실이 불가피하므로 같은 `unsupported_format` 사유로 입구에서 거부하는 편을 선택. `heic2any` 의존성 제거로 번들도 작아짐.

해소되는 Sentry 이슈: 7505050794, 7505050828, 7506228177, 7505050906

## Test plan

- [ ] `pnpm type-check` 통과
- [ ] `pnpm vitest run src/post/utils/__tests__` 53/53 통과 (`needsReencoding` 6건 + GIF 거부 2건 추가)
- [ ] macOS Chrome에서 HEIC 파일이 파일 피커에 회색 처리되는지 수동 확인
- [ ] HEIC를 드래그/붙여넣기로 우회해도 "지원하지 않는 형식입니다. JPEG, PNG, WebP로 저장 후 다시 시도해주세요." 토스트가 즉시 뜨는지 확인
- [ ] 5MB 초과 PNG 스크린샷(1200px 미만)이 자동 재인코딩 후 업로드 성공하는지 확인
- [ ] JPEG/PNG/WebP 정상 업로드 회귀 없음 확인