### PR TITLE
fix(shared): stop useScrollDirection rebinding the scroll listener every update

### DIFF
--- a/apps/web/src/shared/hooks/useScrollDirection.ts
+++ b/apps/web/src/shared/hooks/useScrollDirection.ts
@@ -15,124 +15,77 @@ interface ScrollOptions {
  * @returns 현재 스크롤 방향 ('up', 'down', 'none')
  */
 export const useScrollDirection = (options?: ScrollOptions): ScrollDirection => {
-  const { 
-    throttleTime = 200, 
+  const {
+    throttleTime = 200,
     topThreshold = 10,
     ignoreSmallChanges = 5
   } = options || {};
-  
-  // 스크롤 방향 상태
+
   const [scrollDirection, setScrollDirection] = useState<ScrollDirection>('none');
-  
-  // 이전 스크롤 위치 상태
-  const [lastScrollY, setLastScrollY] = useState<number>(0);
-  
-  // 마지막 쓰로틀 시간을 추적하기 위한 ref
+
+  // Closure-only tracking values — kept in refs so updates do not rebind the listener.
+  const lastScrollYRef = useRef<number>(0);
   const lastThrottleTimeRef = useRef<number>(0);
-  
-  // 쓰로틀 타이머를 추적하기 위한 ref
-  const throttleTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const throttleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    // 컴포넌트 마운트 시 초기 스크롤 위치 설정
-    setLastScrollY(window.scrollY);
-    
-    // 스크롤 이벤트 핸들러
+    lastScrollYRef.current = window.scrollY;
+
+    const setDirectionIfChanged = (next: ScrollDirection) => {
+      setScrollDirection((prev) => (prev === next ? prev : next));
+    };
+
+    const evaluate = (currentScrollY: number, currentTime: number) => {
+      if (currentScrollY <= topThreshold) {
+        setDirectionIfChanged('up');
+        lastScrollYRef.current = currentScrollY;
+        lastThrottleTimeRef.current = currentTime;
+        return;
+      }
+
+      if (Math.abs(currentScrollY - lastScrollYRef.current) < ignoreSmallChanges) {
+        return;
+      }
+
+      if (currentScrollY > lastScrollYRef.current) {
+        setDirectionIfChanged('down');
+      } else if (currentScrollY < lastScrollYRef.current) {
+        setDirectionIfChanged('up');
+      }
+
+      lastScrollYRef.current = currentScrollY;
+      lastThrottleTimeRef.current = currentTime;
+    };
+
     const handleScroll = () => {
       const currentTime = Date.now();
       const currentScrollY = window.scrollY;
-      
-      // 페이지 최상단에 있거나 매우 가까울 경우 항상 'up'으로 설정
-      if (currentScrollY <= topThreshold) {
-        if (scrollDirection !== 'up') {
-          setScrollDirection('up');
-        }
-        setLastScrollY(currentScrollY);
-        lastThrottleTimeRef.current = currentTime;
-        return;
-      }
-      
-      // 작은 스크롤 변화는 무시 (iOS 바운스 효과 처리를 위한 것)
-      if (Math.abs(currentScrollY - lastScrollY) < ignoreSmallChanges) {
-        return;
-      }
-      
-      // 쓰로틀링 적용: 마지막 실행 이후 throttleTime이 지났는지 확인
+
       if (currentTime - lastThrottleTimeRef.current >= throttleTime) {
-        // 스크롤 방향 계산
-        if (currentScrollY > lastScrollY) {
-          // 아래로 스크롤
-          if (scrollDirection !== 'down') {
-            setScrollDirection('down');
-          }
-        } else if (currentScrollY < lastScrollY) {
-          // 위로 스크롤
-          if (scrollDirection !== 'up') {
-            setScrollDirection('up');
-          }
-        }
-        
-        // 현재 스크롤 위치 업데이트
-        setLastScrollY(currentScrollY);
-        
-        // 마지막 쓰로틀 시간 업데이트
-        lastThrottleTimeRef.current = currentTime;
-      } else {
-        // 마지막 쓰로틀 시간이 충분히 지나지 않았다면, 대기 후 실행
-        if (throttleTimerRef.current === null) {
-          throttleTimerRef.current = setTimeout(() => {
-            const newScrollY = window.scrollY;
-            
-            // 페이지 최상단에 있거나 매우 가까울 경우 항상 'up'으로 설정
-            if (newScrollY <= topThreshold) {
-              if (scrollDirection !== 'up') {
-                setScrollDirection('up');
-              }
-              setLastScrollY(newScrollY);
-              lastThrottleTimeRef.current = Date.now();
-              throttleTimerRef.current = null;
-              return;
-            }
-            
-            // 작은 스크롤 변화는 무시
-            if (Math.abs(newScrollY - lastScrollY) < ignoreSmallChanges) {
-              throttleTimerRef.current = null;
-              return;
-            }
-            
-            // 스크롤 방향 계산
-            if (newScrollY > lastScrollY) {
-              if (scrollDirection !== 'down') {
-                setScrollDirection('down');
-              }
-            } else if (newScrollY < lastScrollY) {
-              if (scrollDirection !== 'up') {
-                setScrollDirection('up');
-              }
-            }
-            
-            // 현재 스크롤 위치 업데이트
-            setLastScrollY(newScrollY);
-            
-            // 쓰로틀 타이머 초기화
-            lastThrottleTimeRef.current = Date.now();
-            throttleTimerRef.current = null;
-          }, throttleTime - (currentTime - lastThrottleTimeRef.current));
-        }
+        evaluate(currentScrollY, currentTime);
+        return;
+      }
+
+      // Trailing call: ensure the final scroll position is processed after the throttle window.
+      if (throttleTimerRef.current === null) {
+        const delay = throttleTime - (currentTime - lastThrottleTimeRef.current);
+        throttleTimerRef.current = setTimeout(() => {
+          throttleTimerRef.current = null;
+          evaluate(window.scrollY, Date.now());
+        }, delay);
       }
     };
-    
-    // 스크롤 이벤트 리스너 등록
+
     window.addEventListener('scroll', handleScroll);
-    
-    // 컴포넌트 언마운트 시 이벤트 리스너 및 타이머 정리
+
     return () => {
       window.removeEventListener('scroll', handleScroll);
       if (throttleTimerRef.current) {
         clearTimeout(throttleTimerRef.current);
+        throttleTimerRef.current = null;
       }
     };
-  }, [lastScrollY, scrollDirection, throttleTime, topThreshold, ignoreSmallChanges]);
-  
+  }, [throttleTime, topThreshold, ignoreSmallChanges]);
+
   return scrollDirection;
-}; 
+};

--- a/apps/web/src/shared/hooks/useScrollDirection.ts
+++ b/apps/web/src/shared/hooks/useScrollDirection.ts
@@ -61,6 +61,19 @@ export const useScrollDirection = (options?: ScrollOptions): ScrollDirection => 
       const currentTime = Date.now();
       const currentScrollY = window.scrollY;
 
+      // Fast-path: at/near the top — always 'up', bypass throttle.
+      if (currentScrollY <= topThreshold) {
+        setDirectionIfChanged('up');
+        lastScrollYRef.current = currentScrollY;
+        lastThrottleTimeRef.current = currentTime;
+        return;
+      }
+
+      // Fast-path: ignore small deltas (iOS bounce) without scheduling a trailing timer.
+      if (Math.abs(currentScrollY - lastScrollYRef.current) < ignoreSmallChanges) {
+        return;
+      }
+
       if (currentTime - lastThrottleTimeRef.current >= throttleTime) {
         evaluate(currentScrollY, currentTime);
         return;


### PR DESCRIPTION
## Summary

`useScrollDirection`'s effect dependency array included `lastScrollY` and `scrollDirection`, both of which the effect itself updates on every qualifying scroll event. Each update tore down and reattached the `scroll` listener and cancelled pending throttle timers, defeating the throttle and adding wasted work on every scroll. Affected every scrolling screen (feed, post detail, comment list, drawers).

## Changes

- `lastScrollY` moved from `useState` to `useRef` — it's only used inside the effect closure, never rendered.
- `setScrollDirection` now uses the functional form (`prev => ...`), so the effect no longer depends on the current value.
- Deps array reduced to `[throttleTime, topThreshold, ignoreSmallChanges]` (user-tunable primitives that don't change at runtime in any current caller). Listener attaches once on mount, detaches on unmount.
- Throttle leading/trailing-edge logic deduplicated into a single `evaluate` helper.

## Verification

- ✅ `npm run type-check` passes
- ✅ `npm run test:run` — 778/778 unit tests pass
- ⚠️ Manual smoke test on a scrolling page (DevTools Performance: confirm `add/removeEventListener` no longer repeats during scroll) — deferred for follow-up.

## Blast radius

Only consumer is `NavigationContext.tsx`, which passes stable primitive options and consumes only the returned `'up' | 'down' | 'none'` value. Public contract is unchanged.

## Test plan

- [x] Type-check + unit tests pass.
- [ ] DevTools Performance during scroll shows the listener registered/removed exactly once across a session.

Closes #597