### PR TITLE
feat: 비공개 글을 목록·통계에 노출하면서 본문은 마스킹하는 posts_feed 뷰 도입

### DIFF
--- a/apps/web/src/post/api/__tests__/post.test.ts
+++ b/apps/web/src/post/api/__tests__/post.test.ts
@@ -73,9 +73,17 @@ describe('mapRowToPost', () => {
     });
   });
 
-  describe('board embed handling', () => {
-    it('computes weekDaysFromFirstDay when board embed has first_day', () => {
-      // Mon Jan 12 → Wed Jan 15 = 3 working days
+  describe('board first_day handling', () => {
+    it('computes weekDaysFromFirstDay from flat board_first_day column (posts_feed view)', () => {
+      const row = makeRow({
+        board_first_day: '2026-01-12T00:00:00Z',
+        created_at: '2026-01-15T09:00:00Z',
+      });
+      const post = mapRowToPost(row);
+      expect(post.weekDaysFromFirstDay).toBe(3);
+    });
+
+    it('computes weekDaysFromFirstDay when legacy board embed has first_day', () => {
       const row = makeRow({
         boards: { first_day: '2026-01-12T00:00:00Z' },
         created_at: '2026-01-15T09:00:00Z',
@@ -84,13 +92,13 @@ describe('mapRowToPost', () => {
       expect(post.weekDaysFromFirstDay).toBe(3);
     });
 
-    it('uses row.week_days_from_first_day when board embed is absent', () => {
+    it('uses row.week_days_from_first_day when no first_day is available', () => {
       const row = makeRow({ week_days_from_first_day: 5 });
       const post = mapRowToPost(row);
       expect(post.weekDaysFromFirstDay).toBe(5);
     });
 
-    it('handles board embed as array (PostgREST format)', () => {
+    it('handles legacy board embed as array (PostgREST format)', () => {
       const row = makeRow({
         boards: [{ first_day: '2026-01-12T00:00:00Z' }],
         created_at: '2026-01-15T09:00:00Z',
@@ -114,17 +122,51 @@ describe('mapRowToPost', () => {
     });
   });
 
-  describe('user embed', () => {
-    it('extracts profile photo from users embed', () => {
+  describe('author profile photo', () => {
+    it('extracts profile photo from flat author_profile_photo_url column (posts_feed view)', () => {
+      const row = makeRow({ author_profile_photo_url: 'https://example.com/photo.jpg' });
+      const post = mapRowToPost(row);
+      expect(post.authorProfileImageURL).toBe('https://example.com/photo.jpg');
+    });
+
+    it('extracts profile photo from legacy users embed', () => {
       const row = makeRow({ users: { profile_photo_url: 'https://example.com/photo.jpg' } });
       const post = mapRowToPost(row);
       expect(post.authorProfileImageURL).toBe('https://example.com/photo.jpg');
     });
 
-    it('returns undefined when users embed is absent', () => {
+    it('returns undefined when neither flat nor embed source is present', () => {
       const row = makeRow();
       const post = mapRowToPost(row);
       expect(post.authorProfileImageURL).toBeUndefined();
+    });
+  });
+
+  describe('private content masking (posts_feed view)', () => {
+    it('maps masked private row to a Post with empty content', () => {
+      const row = makeRow({
+        visibility: 'private',
+        content: null,
+        content_preview: null,
+        content_json: null,
+        thumbnail_image_url: null,
+      });
+      const post = mapRowToPost(row);
+      expect(post.visibility).toBe(PostVisibility.PRIVATE);
+      expect(post.content).toBe('');
+      expect(post.contentJson).toBeUndefined();
+      expect(post.thumbnailImageURL).toBeNull();
+    });
+
+    it('preserves content for author-owned private rows (view returns unmasked)', () => {
+      const row = makeRow({
+        visibility: 'private',
+        content: '<p>my secret freewriting</p>',
+        content_preview: '<p>my secret',
+      });
+      const post = mapRowToPost(row);
+      expect(post.visibility).toBe(PostVisibility.PRIVATE);
+      expect(post.content).toBe('<p>my secret freewriting</p>');
     });
   });
 });

--- a/apps/web/src/post/api/post.ts
+++ b/apps/web/src/post/api/post.ts
@@ -42,17 +42,21 @@ export function isWithinDays(post: Post, days: number, now: Date = new Date()): 
   return postDate >= cutoffDate;
 }
 
-/** Post row with embedded resources from PostgREST joins.
- *  Feed queries select content_preview (500 chars) instead of full content/content_json.
- *  Detail queries select * which includes both content and content_preview. */
+/** Post row shape returned by the `posts_feed` view. The view pre-joins
+ *  boards/users into flat columns (`board_first_day`, `author_profile_photo_url`)
+ *  and masks content fields to NULL for private posts viewed by non-authors.
+ *
+ *  Embed fields (`boards`, `users`, `comments`, `replies`) remain optional so
+ *  legacy queries that still read from the base `posts` table continue to
+ *  type-check while we migrate. */
 interface PostRowWithEmbeds {
   id: string;
   board_id: string;
   author_id: string;
   author_name: string;
   title: string;
-  content?: string;
-  content_preview?: string;
+  content?: string | null;
+  content_preview?: string | null;
   content_json?: unknown;
   thumbnail_image_url: string | null;
   visibility: string | null;
@@ -63,16 +67,21 @@ interface PostRowWithEmbeds {
   week_days_from_first_day: number | null;
   created_at: string;
   updated_at: string;
+  board_first_day?: string | null;
+  author_profile_photo_url?: string | null;
   boards?: { first_day: string | null } | { first_day: string | null }[];
   users?: { profile_photo_url: string | null } | { profile_photo_url: string | null }[];
   comments?: { count: number }[];
   replies?: { count: number }[];
 }
 
-/** Explicit column list for feed queries — excludes content/content_json AND the
- * `comments(count)/replies(count)` PostgREST aggregates (each was a per-row scalar
- * subquery; mapRowToPost falls back to denormalized count_of_comments/replies). */
-export const FEED_POST_SELECT = 'id, board_id, author_id, author_name, title, content_preview, thumbnail_image_url, visibility, count_of_comments, count_of_replies, count_of_likes, engagement_score, week_days_from_first_day, created_at, updated_at';
+/** Explicit column list for feed queries against `posts_feed`.
+ *  The view exposes flat `board_first_day` / `author_profile_photo_url`
+ *  instead of PostgREST joins, and denormalized `count_of_comments` /
+ *  `count_of_replies` already replace the per-row `comments(count)` /
+ *  `replies(count)` scalar subqueries main #31 dropped — `mapRowToPost`
+ *  falls back to those cached counters. */
+export const FEED_POST_SELECT = 'id, board_id, author_id, author_name, title, content_preview, thumbnail_image_url, visibility, count_of_comments, count_of_replies, count_of_likes, engagement_score, week_days_from_first_day, created_at, updated_at, board_first_day, author_profile_photo_url';
 
 /**
  * Fetch recent posts for a board.
@@ -88,8 +97,8 @@ export async function fetchRecentPostsFromSupabase(
   const supabase = getSupabaseClient();
 
   let q = supabase
-    .from('posts')
-    .select(`${FEED_POST_SELECT}, users!author_id(profile_photo_url)`)
+    .from('posts_feed')
+    .select(FEED_POST_SELECT)
     .eq('board_id', boardId)
     .order('created_at', { ascending: false });
 
@@ -130,8 +139,8 @@ export async function fetchBestPostsFromSupabase(
   const supabase = getSupabaseClient();
 
   let q = supabase
-    .from('posts')
-    .select(`${FEED_POST_SELECT}, users!author_id(profile_photo_url)`)
+    .from('posts_feed')
+    .select(FEED_POST_SELECT)
     .eq('board_id', boardId)
     .order('engagement_score', { ascending: false })
     .limit(limitCount);
@@ -154,21 +163,19 @@ export async function fetchBestPostsFromSupabase(
   return (data || []).map(mapRowToPost);
 }
 
-/** Map a Supabase posts row (with board and user embeds) to Post model */
+/** Map a row from `posts_feed` (or the legacy `posts` query shape) to Post model. */
 export function mapRowToPost(row: PostRowWithEmbeds): Post {
-  // Prefer live embedded counts (PostgREST aggregates) over cached counter columns
   const commentCount = row.comments?.[0]?.count ?? row.count_of_comments ?? 0;
   const replyCount = row.replies?.[0]?.count ?? row.count_of_replies ?? 0;
 
-  // Compute weekDaysFromFirstDay from board's first_day if available via embedded join
-  const board = Array.isArray(row.boards) ? row.boards[0] : row.boards;
-  const weekDays = board?.first_day
-    ? computeWeekDaysFromFirstDay(board.first_day, row.created_at)
+  const boardEmbed = Array.isArray(row.boards) ? row.boards[0] : row.boards;
+  const firstDay = row.board_first_day ?? boardEmbed?.first_day ?? null;
+  const weekDays = firstDay
+    ? computeWeekDaysFromFirstDay(firstDay, row.created_at)
     : (row.week_days_from_first_day ?? undefined);
 
-  // Extract profile photo from joined users data (optional — not all callers include the join)
-  const usersData = Array.isArray(row.users) ? row.users[0] : row.users;
-  const user = usersData ?? null;
+  const usersEmbed = Array.isArray(row.users) ? row.users[0] : row.users;
+  const profilePhotoURL = row.author_profile_photo_url ?? usersEmbed?.profile_photo_url ?? null;
 
   return {
     id: row.id,
@@ -187,6 +194,6 @@ export function mapRowToPost(row: PostRowWithEmbeds): Post {
     engagementScore: row.engagement_score,
     weekDaysFromFirstDay: weekDays,
     visibility: (row.visibility as PostVisibility) || PostVisibility.PUBLIC,
-    authorProfileImageURL: user?.profile_photo_url || undefined,
+    authorProfileImageURL: profilePhotoURL || undefined,
   };
 }

--- a/apps/web/src/post/components/PostContent.tsx
+++ b/apps/web/src/post/components/PostContent.tsx
@@ -35,10 +35,6 @@ export function PostContent({ post, isAuthor }: PostContentProps) {
     // 커스텀 복사 핸들러 적용
     useCopyHandler(getSelectedHtml, contentRef.current);
 
-    if (!post?.content) {
-        return <p>내용이 없습니다.</p>;
-    }
-
     if (isPrivateAndNotAuthor) {
         return (
             <div className="my-6 rounded-lg border border-gray-200 bg-gray-100 p-8 text-center">
@@ -50,6 +46,10 @@ export function PostContent({ post, isAuthor }: PostContentProps) {
                 </p>
             </div>
         );
+    }
+
+    if (!post?.content) {
+        return <p>내용이 없습니다.</p>;
     }
 
     try {

--- a/apps/web/src/post/components/PostFreewritingPage.tsx
+++ b/apps/web/src/post/components/PostFreewritingPage.tsx
@@ -97,7 +97,7 @@ export default function PostFreewritingPage() {
         visibility: PostVisibility.PRIVATE,
       })
 
-      toast.success("프리라이팅으로 쓴 글은 다른 사람에게 보이지 않아요.", {position: 'bottom-center'})
+      toast.success("프리라이팅으로 쓴 글의 내용은 나만 볼 수 있어요.", {position: 'bottom-center'})
 
       sendAnalyticsEvent(AnalyticsEvent.FINISH_FREE_WRITING, { boardId })
 

--- a/apps/web/src/post/utils/postUtils.ts
+++ b/apps/web/src/post/utils/postUtils.ts
@@ -9,11 +9,8 @@ import { mapRowToPost } from '@/post/api/post';
 export const fetchPost = async (boardId: string, postId: string): Promise<Post | null> => {
   const supabase = getSupabaseClient();
   const { data, error } = await supabase
-    .from('posts')
-    // Drop redundant joins/aggregates: posts.week_days_from_first_day and
-    // posts.count_of_comments / count_of_replies are denormalized columns
-    // and mapRowToPost falls back to them. Only the author photo join stays.
-    .select('*, users!author_id(profile_photo_url)')
+    .from('posts_feed')
+    .select('*')
     .eq('id', postId)
     .eq('board_id', boardId)
     .single();
@@ -138,7 +135,7 @@ export const fetchAdjacentPosts = async (boardId: string, currentPostId: string)
   const supabase = getSupabaseClient();
 
   const { data: currentPost, error: currentError } = await supabase
-    .from('posts')
+    .from('posts_feed')
     .select('created_at')
     .eq('id', currentPostId)
     .single();
@@ -150,7 +147,7 @@ export const fetchAdjacentPosts = async (boardId: string, currentPostId: string)
 
   const [prevResult, nextResult] = await Promise.all([
     supabase
-      .from('posts')
+      .from('posts_feed')
       .select('id')
       .eq('board_id', boardId)
       .lt('created_at', currentPost.created_at)
@@ -158,7 +155,7 @@ export const fetchAdjacentPosts = async (boardId: string, currentPostId: string)
       .limit(1)
       .maybeSingle(),
     supabase
-      .from('posts')
+      .from('posts_feed')
       .select('id')
       .eq('board_id', boardId)
       .gt('created_at', currentPost.created_at)

--- a/apps/web/src/stats/api/stats.ts
+++ b/apps/web/src/stats/api/stats.ts
@@ -130,7 +130,7 @@ export async function fetchBatchPostDatesByDateRange(
   if (userIds.length === 0) return [];
   const supabase = getSupabaseClient();
   const { data, error } = await supabase
-    .from('posts')
+    .from('posts_feed')
     .select('author_id, created_at')
     .in('author_id', userIds)
     .gte('created_at', start.toISOString())

--- a/apps/web/src/user/api/posting.ts
+++ b/apps/web/src/user/api/posting.ts
@@ -26,7 +26,7 @@ export async function fetchPostingsFromSupabase(userId: string): Promise<Supabas
   const supabase = getSupabaseClient();
 
   const { data, error } = await supabase
-    .from('posts')
+    .from('posts_feed')
     .select('id, board_id, title, content_length, created_at')
     .eq('author_id', userId)
     .order('created_at', { ascending: false });
@@ -59,7 +59,7 @@ export async function fetchPostingsByDateRangeFromSupabase(
   const supabase = getSupabaseClient();
 
   const { data, error } = await supabase
-    .from('posts')
+    .from('posts_feed')
     .select('id, board_id, title, content_length, created_at')
     .eq('author_id', userId)
     .gte('created_at', start.toISOString())

--- a/apps/web/src/user/api/searchUserPosts.ts
+++ b/apps/web/src/user/api/searchUserPosts.ts
@@ -38,8 +38,8 @@ export async function searchOwnPosts(
   const orFilter = `title.ilike.${pattern},content.ilike.${pattern}`;
 
   const { data, error } = await supabase
-    .from('posts')
-    .select(`${FEED_POST_SELECT}, boards(first_day)`)
+    .from('posts_feed')
+    .select(FEED_POST_SELECT)
     .eq('author_id', userId)
     .or(orFilter)
     .order('created_at', { ascending: false })

--- a/apps/web/src/user/hooks/useUserPosts.ts
+++ b/apps/web/src/user/hooks/useUserPosts.ts
@@ -50,8 +50,8 @@ async function fetchUserPostsFromSupabase(
   const supabase = getSupabaseClient();
 
   let queryBuilder = supabase
-    .from('posts')
-    .select(`${FEED_POST_SELECT}, boards(first_day)`)
+    .from('posts_feed')
+    .select(FEED_POST_SELECT)
     .eq('author_id', userId)
     .order('created_at', { ascending: false })
     .limit(LIMIT_COUNT);

--- a/supabase/migrations/20260603000000_add_posts_feed_view.sql
+++ b/supabase/migrations/20260603000000_add_posts_feed_view.sql
@@ -1,0 +1,54 @@
+-- posts_feed: a redacted SELECT-only view that lets non-authors see that
+-- private posts EXIST (so they appear in feeds, user-page lists, and the
+-- contribution stat grid) without exposing the private content itself.
+--
+-- The underlying RLS on `posts` still hides private rows from non-authors,
+-- which is why we expose this view as a parallel read path:
+--   - Runs with definer privileges (security_invoker = false, the default)
+--     so it bypasses RLS on the joined tables and can return every row.
+--   - Masks `title`-adjacent content columns (`content`, `content_preview`,
+--     `content_json`, `thumbnail_image_url`) when the viewer is not the
+--     author of a `private` row. `auth.uid()` resolves from the session JWT
+--     even when the view runs as definer, so the mask reacts to the real
+--     caller.
+--   - `security_barrier = true` prevents Postgres from pushing user-supplied
+--     predicates (e.g. WHERE content ILIKE ...) past the CASE expressions,
+--     which would otherwise leak masked content through error/timing side
+--     channels.
+--
+-- Write operations (INSERT/UPDATE/DELETE) continue to target the base
+-- `posts` table and remain governed by the existing RLS policies.
+
+CREATE OR REPLACE VIEW posts_feed
+WITH (security_barrier = true, security_invoker = false)
+AS
+SELECT
+  p.id,
+  p.board_id,
+  p.author_id,
+  p.author_name,
+  p.title,
+  CASE WHEN p.visibility = 'public' OR auth.uid() = p.author_id
+       THEN p.content ELSE NULL END AS content,
+  CASE WHEN p.visibility = 'public' OR auth.uid() = p.author_id
+       THEN p.content_preview ELSE NULL END AS content_preview,
+  CASE WHEN p.visibility = 'public' OR auth.uid() = p.author_id
+       THEN p.content_json ELSE NULL END AS content_json,
+  CASE WHEN p.visibility = 'public' OR auth.uid() = p.author_id
+       THEN p.thumbnail_image_url ELSE NULL END AS thumbnail_image_url,
+  p.visibility,
+  p.count_of_comments,
+  p.count_of_replies,
+  p.count_of_likes,
+  p.engagement_score,
+  p.week_days_from_first_day,
+  p.created_at,
+  p.updated_at,
+  p.content_length,
+  b.first_day AS board_first_day,
+  u.profile_photo_url AS author_profile_photo_url
+FROM posts p
+LEFT JOIN boards b ON b.id = p.board_id
+LEFT JOIN users u ON u.id = p.author_id;
+
+GRANT SELECT ON posts_feed TO anon, authenticated;

--- a/tests/fixtures/e2e-domain.json
+++ b/tests/fixtures/e2e-domain.json
@@ -31,7 +31,7 @@
     "e2e-comment-001",
     "e2e-comment-002"
   ],
-  "memberUserId": "685d8262-4569-40a0-9cee-6b09b0b953fd",
-  "nonMemberUserId": "f32b0501-efae-42b6-a0d0-9b341041ed00",
+  "memberUserId": "2f872a66-811d-4435-8916-0332876c278f",
+  "nonMemberUserId": "2a7f14b2-cd1f-473e-a080-c4dffb302729",
   "pageSize": 20
 }


### PR DESCRIPTION
## 배경

프리라이팅으로 작성된 PRIVATE 게시글이 보드 피드·유저 페이지 목록·기여도 그리드에서 **다른 사용자에게 완전히 사라져 보이는** 문제 보고. 의도된 동작은 "다른 사용자도 비공개 글이 작성됐다는 사실은 볼 수 있되, 본문은 작성자만 읽을 수 있다"로, UI 컴포넌트(`PostCard`, `UserPostItem`, `PostContent`)는 이미 `isPrivate` 분기로 본문 가리기·잠금 카드 표시를 구현해 두었으나, 데이터가 RLS에서 막혀 카드 자체가 렌더링되지 않고 있었음.

## 근본 원인

`supabase/migrations/20260301000000_reenable_rls.sql:25-29`의 SELECT RLS 정책이 모든 `posts` 조회에 대해 `visibility = 'public' OR auth.uid() = author_id` 행 단위 필터를 강제. 비작성자에게는 비공개 행 전체가 결과에서 빠지므로 목록·통계·prev/next 어디서도 조회되지 않음.

## 변경 요약

### 새 읽기 경로: `posts_feed` 뷰
- `WITH (security_barrier = true, security_invoker = false)` — 정의자 권한으로 `posts` RLS를 우회해 모든 행 노출
- `content` / `content_preview` / `content_json` / `thumbnail_image_url` 를 `visibility = 'private' AND auth.uid() <> author_id` 일 때 `NULL` 로 마스킹하는 CASE 식 사용
- `boards.first_day` / `users.profile_photo_url` 를 `board_first_day` / `author_profile_photo_url` 평면 컬럼으로 미리 조인해 PostgREST embed 없이도 같은 데이터 노출
- `GRANT SELECT ON posts_feed TO anon, authenticated`
- 본문은 PostgREST 응답에 절대 직렬화되지 않음 → 본문 보호는 클라이언트 UI에 의존하지 않고 DB 계층에서 보장

### 쿼리 마이그레이션
- 목록·통계·상세 SELECT 쿼리 8곳을 `.from('posts')` → `.from('posts_feed')` 로 전환
- `FEED_POST_SELECT` 에서 `boards(first_day), users!author_id(profile_photo_url), comments(count), replies(count)` embed 문법 제거하고 평면 컬럼 채택
- `mapRowToPost` 가 평면 컬럼을 우선 읽되 레거시 embed 형태도 fallback으로 받아들이도록 확장 (기존 단위 테스트 호환 유지)
- INSERT / UPDATE / DELETE 는 그대로 base `posts` 테이블 대상 → 뷰 비쓰기 제약과 기존 RLS 호환

### 상세 페이지 분기 수정
- `PostContent.tsx` 에서 `!post.content` (내용 없음 안내) 가 `isPrivateAndNotAuthor` (잠금 카드) 보다 앞서 평가돼, 뷰가 돌려준 마스킹된 빈 본문이 잠금 카드를 가리던 문제 → 두 분기 순서 교체

### UX
- 프리라이팅 업로드 토스트 "프리라이팅으로 쓴 글은 다른 사람에게 보이지 않아요." → "프리라이팅으로 쓴 글의 내용은 나만 볼 수 있어요." 로 정정해 실제 동작과 일치

## 검증

- `pnpm type-check`: clean
- `pnpm test:run`: 66 files / 812 tests 모두 통과 (mapRowToPost 평면 컬럼·마스킹 케이스 신규 추가)
- 로컬 Supabase + dev:local 서버 + agent-browser 로 4가지 시나리오 수동 검증
  - 비작성자 보드 피드: 비공개 글 상단 노출, 잠금 배지, 본문 미리보기 비어있음
  - 비작성자 상세 페이지: 제목·헤더 노출 + "이 글은 작성자만 볼 수 있어요" 안내, 본문 누설 없음
  - 비작성자가 본 작성자 유저 페이지: 글 목록에 비공개 글 포함, posting API 로 `content_length=85` 응답돼 기여도 그리드도 채워짐
  - 작성자 본인 상세 페이지: 본문 전체 노출 + "비공개 글" 배지

## Test plan

- [ ] 비작성자 계정으로 보드 피드 진입 시 비공개 글이 보이고 본문 미리보기·썸네일은 보이지 않는지
- [ ] 비공개 글 상세 페이지에서 비작성자에게 잠금 카드("이 글은 작성자만 볼 수 있어요")가 표시되는지, 네트워크 응답에 본문이 포함되지 않는지
- [ ] 작성자 본인 상세 페이지에서 본문이 정상 표시되고 "비공개 글" 배지가 함께 노출되는지
- [ ] 비작성자가 본 작성자 유저 페이지의 기여도 그리드에 비공개 글이 카운트되는지
- [ ] prev/next 글 네비게이션이 비공개 글을 건너뛰지 않는지
- [ ] 작성자 본인의 내 글 검색에서 비공개 글 본문 검색이 여전히 동작하는지