### PR TITLE
feat(web): react-doctor 에러 0건 달성 + 메트릭 도입

### DIFF
--- a/apps/web/doctor.config.json
+++ b/apps/web/doctor.config.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.react.doctor/schema/config.json",
+  "categories": {
+    "Maintainability": "off",
+    "Performance": "off"
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,7 +37,8 @@
     "devlog:check": "npx tsx ../../scripts/devlog.ts check",
     "devlog:trace": "npx tsx ../../scripts/devlog.ts trace",
     "validate": "npm run type-check && npm run lint && npm run test:run",
-    "validate:full": "npm run type-check && npm run lint && npm run test:run && npm run devlog:check"
+    "validate:full": "npm run type-check && npm run lint && npm run test:run && npm run devlog:check",
+    "doctor": "npx --yes react-doctor@latest --no-telemetry"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.77",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -213,3 +213,14 @@
     @apply rounded-sm bg-muted px-1 py-0.5 text-sm;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/apps/web/src/login/components/ActiveUserProfileList.tsx
+++ b/apps/web/src/login/components/ActiveUserProfileList.tsx
@@ -14,42 +14,42 @@ export default function ActiveUserProfileList({ users, className }: ActiveUserPr
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const [canScrollLeft, setCanScrollLeft] = useState(false)
   const [canScrollRight, setCanScrollRight] = useState(false)
-  
-  const checkScrollability = () => {
-    if (!scrollContainerRef.current) return
-
-    const { scrollLeft, scrollWidth, clientWidth } = scrollContainerRef.current
-
-    // Can scroll left if scrolled more than 1px from the beginning
-    setCanScrollLeft(scrollLeft > 1)
-
-    // Can scroll right if not at the end
-    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1) // -1 for rounding errors
-  }
 
   useEffect(() => {
     const scrollContainer = scrollContainerRef.current
     if (!scrollContainer) return
 
-    // Check initial scrollability
+    const checkScrollability = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = scrollContainer
+      setCanScrollLeft(scrollLeft > 1)
+      setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1)
+    }
+
     checkScrollability()
-
-    // Add scroll event listener
     scrollContainer.addEventListener("scroll", checkScrollability)
-
-    // Add resize event listener to recheck on window resize
     window.addEventListener("resize", checkScrollability)
+
+    // Re-measure when children change size or are added/removed (e.g., users prop changes).
+    const resizeObserver = new ResizeObserver(checkScrollability)
+    resizeObserver.observe(scrollContainer)
+    for (const child of Array.from(scrollContainer.children)) {
+      resizeObserver.observe(child)
+    }
+    const mutationObserver = new MutationObserver(() => {
+      checkScrollability()
+      for (const child of Array.from(scrollContainer.children)) {
+        resizeObserver.observe(child)
+      }
+    })
+    mutationObserver.observe(scrollContainer, { childList: true })
 
     return () => {
       scrollContainer.removeEventListener("scroll", checkScrollability)
       window.removeEventListener("resize", checkScrollability)
+      resizeObserver.disconnect()
+      mutationObserver.disconnect()
     }
   }, [])
-
-  // Recheck scrollability when users change
-  useEffect(() => {
-    checkScrollability()
-  }, [users])
 
   if (users.length === 0) return null
 

--- a/apps/web/src/login/components/ReviewCarousel.tsx
+++ b/apps/web/src/login/components/ReviewCarousel.tsx
@@ -20,10 +20,12 @@ export default function ReviewCarousel() {
       return;
     }
 
-    setSelectedIndex(api.selectedScrollSnap());
-    api.on('select', () => {
-      setSelectedIndex(api.selectedScrollSnap());
-    });
+    const handleSelect = () => setSelectedIndex(api.selectedScrollSnap());
+    handleSelect();
+    api.on('select', handleSelect);
+    return () => {
+      api.off('select', handleSelect);
+    };
   }, [api]);
 
   const handleDotClick = (index: number) => {

--- a/apps/web/src/post/components/PostCompletionContent.tsx
+++ b/apps/web/src/post/components/PostCompletionContent.tsx
@@ -25,6 +25,16 @@ export function PostCompletionContent({
 }: PostCompletionPageProps) {
     const [isClient, setIsClient] = useState(false)
     const [showLoading, setShowLoading] = useState(true)
+    const [prevIsLoading, setPrevIsLoading] = useState(isLoading)
+
+    // Snap showLoading=true the moment isLoading flips back to true,
+    // during render, so the user never sees a flash of post-loading UI.
+    if (isLoading !== prevIsLoading) {
+        setPrevIsLoading(isLoading)
+        if (isLoading) {
+            setShowLoading(true)
+        }
+    }
 
     useEffect(() => {
         setIsClient(true)
@@ -32,21 +42,15 @@ export function PostCompletionContent({
 
     // 최소 1초 로딩 보장
     useEffect(() => {
-        let timer: NodeJS.Timeout | null = null
-        if (!isLoading) {
-            timer = setTimeout(() => {
-                setShowLoading(false)
-                // 로딩이 끝난 후 햅틱 피드백
-                if (navigator.vibrate) {
-                    navigator.vibrate([100, 50, 200])
-                }
-            }, 1000)
-        } else {
-            setShowLoading(true)
-        }
-        return () => {
-            if (timer) clearTimeout(timer)
-        }
+        if (isLoading) return
+        const timer = setTimeout(() => {
+            setShowLoading(false)
+            // 로딩이 끝난 후 햅틱 피드백
+            if (navigator.vibrate) {
+                navigator.vibrate([100, 50, 200])
+            }
+        }, 1000)
+        return () => clearTimeout(timer)
     }, [isLoading])
 
     if (!isClient) return null // Prevent hydration errors
@@ -133,7 +137,6 @@ function highlightMessageParts(message: string, highlight: CompletionHighlight) 
     const parts = message.split(pattern)
     return parts.map((part, i) =>
         sortedKeywords.includes(part) ? (
-            // eslint-disable-next-line tailwindcss/no-custom-classname -- dynamic color class
             <span key={`${part}-${i}`} className={`font-bold text-${highlight.color}-500`}>{part}</span>
         ) : (
             <span key={`${part}-${i}`}>{part}</span>

--- a/apps/web/src/shared/components/ConfettiEffect.tsx
+++ b/apps/web/src/shared/components/ConfettiEffect.tsx
@@ -2,39 +2,46 @@ import { useEffect } from "react"
 
 export function ConfettiEffect() {
     useEffect(() => {
-      // Trigger subtle confetti animation
-      if (typeof window !== "undefined") {
-        // Import confetti dynamically to avoid SSR issues
-        import("canvas-confetti").then((confettiModule) => {
-          const confetti = confettiModule.default
-  
-          // Fire just once from each side with fewer particles
-          setTimeout(() => {
-            confetti({
-              particleCount: 15, // Fewer particles
-              angle: 60,
-              spread: 40, // Narrower spread
-              origin: { x: 0.2, y: 0.5 }, // More centered
-              gravity: 1.2, // Faster fall
-              scalar: 0.7, // Smaller confetti pieces
-              colors: ["#FFD700", "#FFC0CB", "#87CEFA"],
-              disableForReducedMotion: true, // Accessibility
-            })
-  
-            confetti({
-              particleCount: 15, // Fewer particles
-              angle: 120,
-              spread: 40, // Narrower spread
-              origin: { x: 0.8, y: 0.5 }, // More centered
-              gravity: 1.2, // Faster fall
-              scalar: 0.7, // Smaller confetti pieces
-              colors: ["#FFD700", "#FFC0CB", "#87CEFA"],
-              disableForReducedMotion: true, // Accessibility
-            })
-          }, 300) // Small delay for better timing with animations
-        })
+      if (typeof window === "undefined") return
+
+      let cancelled = false
+      let timer: ReturnType<typeof setTimeout> | null = null
+
+      import("canvas-confetti").then((confettiModule) => {
+        if (cancelled) return
+        const confetti = confettiModule.default
+
+        timer = setTimeout(() => {
+          if (cancelled) return
+          confetti({
+            particleCount: 15,
+            angle: 60,
+            spread: 40,
+            origin: { x: 0.2, y: 0.5 },
+            gravity: 1.2,
+            scalar: 0.7,
+            colors: ["#FFD700", "#FFC0CB", "#87CEFA"],
+            disableForReducedMotion: true,
+          })
+
+          confetti({
+            particleCount: 15,
+            angle: 120,
+            spread: 40,
+            origin: { x: 0.8, y: 0.5 },
+            gravity: 1.2,
+            scalar: 0.7,
+            colors: ["#FFD700", "#FFC0CB", "#87CEFA"],
+            disableForReducedMotion: true,
+          })
+        }, 300)
+      })
+
+      return () => {
+        cancelled = true
+        if (timer) clearTimeout(timer)
       }
     }, [])
-  
-    return null // This component doesn't render anything
+
+    return null
   }

--- a/apps/web/src/shared/contexts/NavigationContext.tsx
+++ b/apps/web/src/shared/contexts/NavigationContext.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import type React from 'react';
-import { createContext, useContext, useState, useEffect } from 'react';
+import { createContext, useContext, useState } from 'react';
 import { useScrollDirection } from '@/shared/hooks/useScrollDirection';
 
 interface NavigationContextType {
@@ -30,22 +30,25 @@ export const NavigationProvider: React.FC<NavigationProviderProps> = ({
 }) => {
   // 네비게이션 바 표시 상태
   const [isNavVisible, setIsNavVisible] = useState<boolean>(true);
-  
+
   // 스크롤 방향 감지 훅 사용 - 업데이트된 옵션 패턴 사용
   const scrollDirection = useScrollDirection({
     throttleTime: debounceTime,
     topThreshold,
     ignoreSmallChanges
   });
-  
-  useEffect(() => {
-    // 스크롤 방향에 따라 네비게이션 바 표시 여부 결정
+
+  // Sync isNavVisible to scrollDirection during render, with a prev-value comparison,
+  // so the nav doesn't briefly show a stale visibility between renders.
+  const [prevScrollDirection, setPrevScrollDirection] = useState(scrollDirection);
+  if (scrollDirection !== prevScrollDirection) {
+    setPrevScrollDirection(scrollDirection);
     if (scrollDirection === 'down') {
       setIsNavVisible(false);
     } else if (scrollDirection === 'up') {
       setIsNavVisible(true);
     }
-  }, [scrollDirection]);
+  }
   
   return (
     <NavigationContext.Provider value={{ isNavVisible }}>


### PR DESCRIPTION
## Summary

새로운 품질 게이트로 **react-doctor** 도입. 이번 PR은 `apps/web` 한정으로,

- **목표 메트릭**: Bugs / Accessibility / Security의 *error* 카운트만 추적 (errors-only, tracking-only). Maintainability와 Performance는 의견·관습 비중이 커서 메트릭에서 제외.
- **기준선**: 도입 직전 `apps/web` 점수
  - Accessibility: **1 error**, 12 warnings
  - Bugs: **6 errors**, 70 warnings
  - Maintainability: 145 warnings
  - Performance: 35 warnings
  - Security: 7 warnings
  - **합계: 276 issues / 7 errors**
- **이번 PR 후**: **0 errors / 87 warnings**

## What changed

1. `apps/web/doctor.config.json` 신규 — Maintainability·Performance 카테고리 off
2. `apps/web/package.json` — `pnpm doctor` 스크립트 추가 (로컬 확인용, CI 게이트 아님)
3. **WCAG 2.3.3** (`require-reduced-motion`) — `index.css`에 글로벌 `@media (prefers-reduced-motion: reduce)` 추가
4. **prop→state in useEffect** (×4) — `prev`-prop 비교로 렌더 중 동기화로 전환
   - `ActiveUserProfileList.tsx`: 두 useEffect를 하나로 합치고 `ResizeObserver`+`MutationObserver`로 자식 변경 자동 감지 (users 의존성 제거)
   - `PostCompletionContent.tsx`: `isLoading` ↔ `showLoading` 동기화를 렌더 중으로 이동
   - `NavigationContext.tsx`: `scrollDirection` ↔ `isNavVisible` 동기화를 렌더 중으로 이동
5. **Effect cleanup missing** (×2)
   - `ReviewCarousel.tsx`: `api.on('select', h)` → `api.off('select', h)` cleanup 추가
   - `ConfettiEffect.tsx`: 동적 import + setTimeout cancellable 패턴으로 unmount 시 정리

## Test plan

- [ ] `pnpm --filter web doctor` 실행 → 0 errors 확인
- [ ] `pnpm --filter web type-check` 통과
- [ ] `pnpm --filter web lint` 모디파이된 파일 0 errors
- [ ] 로그인 페이지 진입 → 활성 사용자 가로 스크롤 좌/우 화살표 동작 (ActiveUserProfileList)
- [ ] 로그인 페이지 → 리뷰 캐러셀 dot indicator가 슬라이드 변경에 맞춰 동기화 (ReviewCarousel)
- [ ] 글 작성 완료 화면 → 1초 후 축하 모션 + confetti 표시, navigator.vibrate 햅틱 (PostCompletionContent + ConfettiEffect)
- [ ] 글 목록에서 위/아래 스크롤 시 네비게이션 바 표시/숨김 (NavigationContext)
- [ ] OS 설정에서 "동작 줄이기" 활성화 후 위 화면들에서 모션이 즉시 종결되는지 확인 (prefers-reduced-motion)

## Follow-up

- `apps/admin`은 이미 에러 0개이지만 동일 `doctor.config.json` + `doctor` script를 스택 PR로 추가 예정
- 향후 CI 게이트로 승격 여부는 몇 주 운영 후 별도 결정

## Why this scope

react-doctor의 카테고리는 신뢰도가 다릅니다. Bugs/A11y/Security는 React 공식 문서·WCAG·OWASP에 기반한 객관적 footgun을 잡지만, Maintainability/Performance는 상당수가 컨벤션·스타일 의견이라 Goodhart 법칙 리스크가 큽니다. 그래서 이번엔 명확히 사용자 영향이 있는 카테고리만 게이트화하고 점수(score)는 추적하지 않습니다.