### PR TITLE
feat(admin): react-doctor 메트릭 적용 (web PR에 스택)

### DIFF
--- a/apps/admin/doctor.config.json
+++ b/apps/admin/doctor.config.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.react.doctor/schema/config.json",
+  "categories": {
+    "Maintainability": "off",
+    "Performance": "off"
+  }
+}

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "doctor": "npx --yes react-doctor@latest --no-telemetry"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",


### PR DESCRIPTION
## Stack Context

- **Depends on**: #626 (apps/web — react-doctor 에러 0건 + 메트릭 도입)
- 머지 순서: #626 → main 머지 후 이 PR을 main에 rebase 해서 머지.

## Summary

`apps/admin`에 동일한 doctor.config.json + `npm run doctor` 스크립트 추가.

## Baseline / After

`apps/admin`은 도입 시점에 이미 **errors 0**이었지만, config 없이 스캔하면 Maintainability/Performance 노이즈 105건이 신호를 가립니다.

| | Before (no config) | After (this PR) |
|---|---:|---:|
| Bugs warnings | 16 | 16 |
| Maintainability warnings | 99 | (off) |
| Performance warnings | 6 | (off) |
| **Total issues** | **121** | **16** |
| **Errors** | 0 | **0** ✅ |

## What changed

1. `apps/admin/doctor.config.json` — web과 동일하게 Maintainability·Performance off
2. `apps/admin/package.json` — `npm run doctor` 스크립트 추가

## Test plan

- [ ] `cd apps/admin && npm run doctor` → 0 errors, 16 warnings 확인
- [ ] CI/build에는 영향 없음 (스크립트만 추가)

## Why split as two PRs

`apps/web`은 실제 코드 변경이 있어 리뷰 부담이 다르고, `apps/admin`은 설정만 변경이라 분리해야 리뷰 관점이 명확해집니다.