### PR TITLE
test(web): web-app 단위 테스트 전략 — 순수 함수 추출 + 178 tests across 22 files

### DIFF
--- a/apps/web/src/post/api/__tests__/post.test.ts
+++ b/apps/web/src/post/api/__tests__/post.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { mapRowToPost } from '../post';
+import { mapRowToPost, isWithinDays } from '../post';
+import type { Post } from '@/post/model/Post';
 import { PostVisibility } from '@/post/model/Post';
 
 // Helper: minimal PostRowWithEmbeds shape for mapRowToPost
@@ -125,5 +126,70 @@ describe('mapRowToPost', () => {
       const post = mapRowToPost(row);
       expect(post.authorProfileImageURL).toBeUndefined();
     });
+  });
+});
+
+function postWithCreatedAt(iso: string | null): Post {
+  return {
+    id: 'p1',
+    boardId: 'b1',
+    title: '',
+    content: '',
+    thumbnailImageURL: null,
+    authorId: 'u1',
+    authorName: '',
+    createdAt: iso
+      ? ({ toDate: () => new Date(iso) } as Post['createdAt'])
+      : (null as unknown as Post['createdAt']),
+    countOfComments: 0,
+    countOfReplies: 0,
+    countOfLikes: 0,
+    visibility: PostVisibility.PUBLIC,
+  };
+}
+
+describe('isWithinDays', () => {
+  const now = new Date('2025-01-15T12:00:00Z');
+
+  it('returns true for a post created today', () => {
+    const post = postWithCreatedAt('2025-01-15T09:00:00Z');
+    expect(isWithinDays(post, 7, now)).toBe(true);
+  });
+
+  it('returns true for a post exactly on the cutoff (days ago, same time)', () => {
+    // cutoff = 2025-01-08T12:00:00Z; post at exactly that moment is >= → true
+    const post = postWithCreatedAt('2025-01-08T12:00:00Z');
+    expect(isWithinDays(post, 7, now)).toBe(true);
+  });
+
+  it('returns false for a post just past the cutoff', () => {
+    // cutoff = 2025-01-08T12:00:00Z; one second earlier → false
+    const post = postWithCreatedAt('2025-01-08T11:59:59Z');
+    expect(isWithinDays(post, 7, now)).toBe(false);
+  });
+
+  it('returns false for a post well outside the window', () => {
+    const post = postWithCreatedAt('2024-12-01T00:00:00Z');
+    expect(isWithinDays(post, 7, now)).toBe(false);
+  });
+
+  it('returns false when createdAt is missing', () => {
+    const post = postWithCreatedAt(null);
+    expect(isWithinDays(post, 7, now)).toBe(false);
+  });
+
+  it('with days=0 only includes posts at or after `now` (cutoff = now)', () => {
+    // cutoff equals now → posts before now are out, posts at/after now are in
+    const before = postWithCreatedAt('2025-01-15T11:59:59Z');
+    expect(isWithinDays(before, 0, now)).toBe(false);
+    const atNow = postWithCreatedAt('2025-01-15T12:00:00Z');
+    expect(isWithinDays(atNow, 0, now)).toBe(true);
+  });
+
+  it('does not mutate the injected now', () => {
+    const post = postWithCreatedAt('2025-01-15T09:00:00Z');
+    const snapshot = now.getTime();
+    isWithinDays(post, 7, now);
+    expect(now.getTime()).toBe(snapshot);
   });
 });

--- a/apps/web/src/post/api/post.ts
+++ b/apps/web/src/post/api/post.ts
@@ -31,11 +31,12 @@ export async function fetchBestPosts(
 }
 
 /**
- * 게시글이 최근 7일 내인지 확인
+ * True when the post was created within the last `days` days from `now`.
+ * `now` is injectable for tests; defaults to the current wall clock.
  */
-export function isWithinDays(post: Post, days: number): boolean {
+export function isWithinDays(post: Post, days: number, now: Date = new Date()): boolean {
   if (!post.createdAt) return false;
-  const cutoffDate = new Date();
+  const cutoffDate = new Date(now);
   cutoffDate.setDate(cutoffDate.getDate() - days);
   const postDate = post.createdAt.toDate();
   return postDate >= cutoffDate;

--- a/apps/web/src/post/hooks/__tests__/computeScrollIndicators.test.ts
+++ b/apps/web/src/post/hooks/__tests__/computeScrollIndicators.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { computeScrollIndicators } from '../useScrollIndicators';
+
+describe('computeScrollIndicators', () => {
+  describe('container fits content (no overflow)', () => {
+    it('both arrows hidden when content fits exactly', () => {
+      expect(
+        computeScrollIndicators({ scrollLeft: 0, scrollWidth: 500, clientWidth: 500 }),
+      ).toEqual({ canScrollLeft: false, canScrollRight: false });
+    });
+
+    it('both arrows hidden when container is wider than content', () => {
+      expect(
+        computeScrollIndicators({ scrollLeft: 0, scrollWidth: 400, clientWidth: 500 }),
+      ).toEqual({ canScrollLeft: false, canScrollRight: false });
+    });
+  });
+
+  describe('at the start of a scrollable area', () => {
+    it('hides left, shows right when scrollLeft is 0', () => {
+      expect(
+        computeScrollIndicators({ scrollLeft: 0, scrollWidth: 1000, clientWidth: 500 }),
+      ).toEqual({ canScrollLeft: false, canScrollRight: true });
+    });
+
+    it('still hides left at the 1px tolerance (avoids flicker)', () => {
+      expect(
+        computeScrollIndicators({ scrollLeft: 1, scrollWidth: 1000, clientWidth: 500 }),
+      ).toEqual({ canScrollLeft: false, canScrollRight: true });
+    });
+
+    it('shows left once scrollLeft exceeds 1px', () => {
+      expect(
+        computeScrollIndicators({ scrollLeft: 2, scrollWidth: 1000, clientWidth: 500 }),
+      ).toEqual({ canScrollLeft: true, canScrollRight: true });
+    });
+  });
+
+  describe('mid-scroll', () => {
+    it('shows both arrows', () => {
+      expect(
+        computeScrollIndicators({ scrollLeft: 250, scrollWidth: 1000, clientWidth: 500 }),
+      ).toEqual({ canScrollLeft: true, canScrollRight: true });
+    });
+  });
+
+  describe('at the end of a scrollable area', () => {
+    it('shows left, hides right when scrolled to the exact end', () => {
+      // scrollLeft + clientWidth = scrollWidth → hide right
+      expect(
+        computeScrollIndicators({ scrollLeft: 500, scrollWidth: 1000, clientWidth: 500 }),
+      ).toEqual({ canScrollLeft: true, canScrollRight: false });
+    });
+
+    it('hides right within the 1px tolerance at the end', () => {
+      // scrollLeft + clientWidth = scrollWidth - 1 → NOT < scrollWidth - 1 → hide right
+      expect(
+        computeScrollIndicators({ scrollLeft: 499, scrollWidth: 1000, clientWidth: 500 }),
+      ).toEqual({ canScrollLeft: true, canScrollRight: false });
+    });
+
+    it('still shows right when 2+ pixels from the end', () => {
+      expect(
+        computeScrollIndicators({ scrollLeft: 498, scrollWidth: 1000, clientWidth: 500 }),
+      ).toEqual({ canScrollLeft: true, canScrollRight: true });
+    });
+  });
+});

--- a/apps/web/src/post/hooks/__tests__/useBestPosts.test.ts
+++ b/apps/web/src/post/hooks/__tests__/useBestPosts.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import type { Post } from '@/post/model/Post';
+import {
+  buildBestPostsQueryKey,
+  getBestPostsNextPageParam,
+  shouldFetchMoreBestPosts,
+  BEST_POSTS_PAGE_SIZE,
+  BEST_POSTS_MAX_PAGES,
+} from '../useBestPosts';
+
+function makePost(engagementScore: number, overrides: Partial<Post> = {}): Post {
+  return {
+    id: 'p1',
+    boardId: 'b1',
+    title: 'T',
+    content: '',
+    thumbnailImageURL: null,
+    authorId: 'u1',
+    authorName: '',
+    createdAt: { toDate: () => new Date('2025-01-01') } as Post['createdAt'],
+    countOfComments: 0,
+    countOfReplies: 0,
+    countOfLikes: 0,
+    visibility: 'public' as Post['visibility'],
+    engagementScore,
+    ...overrides,
+  };
+}
+
+const fullPage = (score: number) =>
+  Array.from({ length: BEST_POSTS_PAGE_SIZE }, () => makePost(score));
+
+describe('buildBestPostsQueryKey', () => {
+  it('returns ["bestPosts", boardId, blockedByUsers]', () => {
+    expect(buildBestPostsQueryKey('b1', ['u1'])).toEqual(['bestPosts', 'b1', ['u1']]);
+  });
+
+  it('keeps the ["bestPosts", boardId] prefix so invalidation matches partially', () => {
+    const key = buildBestPostsQueryKey('b1', []);
+    expect(key[0]).toBe('bestPosts');
+    expect(key[1]).toBe('b1');
+  });
+
+  it('encodes blockedByUsers=undefined distinctly from an empty array', () => {
+    const a = buildBestPostsQueryKey('b1', undefined);
+    const b = buildBestPostsQueryKey('b1', []);
+    expect(a[2]).toBeUndefined();
+    expect(b[2]).toEqual([]);
+  });
+});
+
+describe('getBestPostsNextPageParam', () => {
+  describe('stop conditions', () => {
+    it('returns undefined when the last page is empty', () => {
+      expect(getBestPostsNextPageParam([], [[]])).toBeUndefined();
+    });
+
+    it('returns undefined when the last page is partial (server exhausted)', () => {
+      const partial = [makePost(50), makePost(40)];
+      expect(getBestPostsNextPageParam(partial, [partial])).toBeUndefined();
+    });
+
+    it('returns undefined when maxPages is reached even with a full last page', () => {
+      const allFullPages = Array.from({ length: BEST_POSTS_MAX_PAGES }, () => fullPage(50));
+      const last = allFullPages[allFullPages.length - 1];
+      expect(getBestPostsNextPageParam(last, allFullPages)).toBeUndefined();
+    });
+  });
+
+  describe('continue conditions', () => {
+    it('returns the last post’s engagementScore for a full page under the maxPages cap', () => {
+      const page = [...fullPage(80).slice(0, 19), makePost(42)];
+      expect(getBestPostsNextPageParam(page, [page])).toBe(42);
+    });
+
+    it('returns the last post’s engagementScore on the (maxPages-1)th page', () => {
+      const allPagesMinusOne = Array.from(
+        { length: BEST_POSTS_MAX_PAGES - 1 },
+        () => fullPage(50),
+      );
+      const last = allPagesMinusOne[allPagesMinusOne.length - 1];
+      expect(getBestPostsNextPageParam(last, allPagesMinusOne)).toBe(50);
+    });
+  });
+
+  describe('config override', () => {
+    it('honors a custom pageSize when judging partial vs full', () => {
+      const page = [makePost(10), makePost(5)];
+      const result = getBestPostsNextPageParam(page, [page], { pageSize: 2, maxPages: 10 });
+      expect(result).toBe(5);
+    });
+
+    it('honors a custom maxPages cap', () => {
+      const pages = [fullPage(50), fullPage(50)];
+      const result = getBestPostsNextPageParam(pages[1], pages, {
+        pageSize: BEST_POSTS_PAGE_SIZE,
+        maxPages: 2,
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+});
+
+describe('shouldFetchMoreBestPosts', () => {
+  it('returns true when below target, hasNextPage, and no fetch in flight', () => {
+    expect(
+      shouldFetchMoreBestPosts({
+        currentCount: 3,
+        targetCount: 5,
+        hasNextPage: true,
+        isFetchingNextPage: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when already at the target count', () => {
+    expect(
+      shouldFetchMoreBestPosts({
+        currentCount: 5,
+        targetCount: 5,
+        hasNextPage: true,
+        isFetchingNextPage: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when hasNextPage is false', () => {
+    expect(
+      shouldFetchMoreBestPosts({
+        currentCount: 3,
+        targetCount: 5,
+        hasNextPage: false,
+        isFetchingNextPage: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when hasNextPage is undefined (TanStack initial state)', () => {
+    expect(
+      shouldFetchMoreBestPosts({
+        currentCount: 3,
+        targetCount: 5,
+        hasNextPage: undefined,
+        isFetchingNextPage: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when a fetch is already in flight', () => {
+    expect(
+      shouldFetchMoreBestPosts({
+        currentCount: 3,
+        targetCount: 5,
+        hasNextPage: true,
+        isFetchingNextPage: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/post/hooks/__tests__/useCreatePostAction.test.ts
+++ b/apps/web/src/post/hooks/__tests__/useCreatePostAction.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateCreatePostFormData,
+  mapCreatePostErrorMessage,
+} from '../useCreatePostAction';
+
+function makeFormData(entries: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(entries)) fd.set(k, v);
+  return fd;
+}
+
+const VALID_ENTRIES = {
+  title: 'My title',
+  content: 'My content',
+  authorId: 'user-1',
+  authorName: 'Daisy',
+};
+
+describe('validateCreatePostFormData', () => {
+  describe('happy path', () => {
+    it('returns the trimmed input when all fields are present', () => {
+      const fd = makeFormData({ ...VALID_ENTRIES, title: '  hello  ', content: '  body  ' });
+      const result = validateCreatePostFormData(fd, 'board-1');
+      expect(result).toEqual({
+        valid: true,
+        input: {
+          title: 'hello',
+          content: 'body',
+          authorId: 'user-1',
+          authorName: 'Daisy',
+          boardId: 'board-1',
+        },
+      });
+    });
+  });
+
+  describe('validation error ordering (each branch returns first failure only)', () => {
+    it('reports missing title first', () => {
+      const fd = makeFormData({ ...VALID_ENTRIES, title: '   ' });
+      expect(validateCreatePostFormData(fd, 'board-1')).toEqual({
+        valid: false,
+        error: '제목을 입력해주세요.',
+      });
+    });
+
+    it('reports missing content when title is present', () => {
+      const fd = makeFormData({ ...VALID_ENTRIES, content: '' });
+      expect(validateCreatePostFormData(fd, 'board-1')).toEqual({
+        valid: false,
+        error: '내용을 입력해주세요.',
+      });
+    });
+
+    it('reports missing boardId after title and content pass', () => {
+      const fd = makeFormData(VALID_ENTRIES);
+      expect(validateCreatePostFormData(fd, undefined)).toEqual({
+        valid: false,
+        error: '게시판 ID가 누락되었습니다.',
+      });
+    });
+
+    it('reports missing authorId after the above pass', () => {
+      const fd = makeFormData({ ...VALID_ENTRIES, authorId: '' });
+      expect(validateCreatePostFormData(fd, 'board-1')).toEqual({
+        valid: false,
+        error: '사용자 인증이 필요합니다.',
+      });
+    });
+
+    it('reports missing authorName last', () => {
+      const fd = makeFormData({ ...VALID_ENTRIES, authorName: '' });
+      expect(validateCreatePostFormData(fd, 'board-1')).toEqual({
+        valid: false,
+        error: '사용자 이름이 누락되었습니다.',
+      });
+    });
+  });
+
+  describe('whitespace handling', () => {
+    it('treats whitespace-only title as empty', () => {
+      const fd = makeFormData({ ...VALID_ENTRIES, title: '\t\n  ' });
+      expect(validateCreatePostFormData(fd, 'board-1').valid).toBe(false);
+    });
+
+    it('treats whitespace-only content as empty', () => {
+      const fd = makeFormData({ ...VALID_ENTRIES, content: '   ' });
+      expect(validateCreatePostFormData(fd, 'board-1').valid).toBe(false);
+    });
+  });
+});
+
+describe('mapCreatePostErrorMessage', () => {
+  it('maps permission-denied to the relogin message', () => {
+    expect(mapCreatePostErrorMessage(new Error('Firebase: permission-denied'))).toBe(
+      '권한이 없습니다. 다시 로그인해주세요.',
+    );
+  });
+
+  it('maps network errors to the connection message', () => {
+    expect(mapCreatePostErrorMessage(new Error('network request failed'))).toBe(
+      '네트워크 연결을 확인해주세요.',
+    );
+  });
+
+  it('maps quota-exceeded to the storage message', () => {
+    expect(mapCreatePostErrorMessage(new Error('quota-exceeded'))).toBe(
+      '저장 공간이 부족합니다.',
+    );
+  });
+
+  it('falls back to the generic message for unrecognized Error messages', () => {
+    expect(mapCreatePostErrorMessage(new Error('something else'))).toBe(
+      '게시물 작성 중 오류가 발생했습니다. 다시 시도해주세요.',
+    );
+  });
+
+  it('falls back to the generic message when the thrown value is not an Error', () => {
+    expect(mapCreatePostErrorMessage('plain string')).toBe(
+      '게시물 작성 중 오류가 발생했습니다. 다시 시도해주세요.',
+    );
+    expect(mapCreatePostErrorMessage(null)).toBe(
+      '게시물 작성 중 오류가 발생했습니다. 다시 시도해주세요.',
+    );
+  });
+
+  it('matches the first recognized pattern (order: permission → network → quota)', () => {
+    // both "permission-denied" and "network" present → permission wins
+    expect(
+      mapCreatePostErrorMessage(new Error('permission-denied network problem')),
+    ).toBe('권한이 없습니다. 다시 로그인해주세요.');
+  });
+});

--- a/apps/web/src/post/hooks/__tests__/usePostSubmit.test.ts
+++ b/apps/web/src/post/hooks/__tests__/usePostSubmit.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { isPostSubmitInputValid } from '../usePostSubmit';
+
+const VALID = {
+  title: 'My title',
+  content: 'My content',
+  boardId: 'b1',
+  userId: 'u1',
+};
+
+describe('isPostSubmitInputValid', () => {
+  it('returns true when title, content, boardId, and userId are all present', () => {
+    expect(isPostSubmitInputValid(VALID)).toBe(true);
+  });
+
+  describe('content guards', () => {
+    it('returns false when title is empty', () => {
+      expect(isPostSubmitInputValid({ ...VALID, title: '' })).toBe(false);
+    });
+
+    it('returns false when title is whitespace only', () => {
+      expect(isPostSubmitInputValid({ ...VALID, title: '   ' })).toBe(false);
+    });
+
+    it('returns false when content is empty', () => {
+      expect(isPostSubmitInputValid({ ...VALID, content: '' })).toBe(false);
+    });
+
+    it('returns false when content is whitespace only', () => {
+      expect(isPostSubmitInputValid({ ...VALID, content: '\n\t  ' })).toBe(false);
+    });
+  });
+
+  describe('identity guards', () => {
+    it('returns false when boardId is undefined', () => {
+      expect(isPostSubmitInputValid({ ...VALID, boardId: undefined })).toBe(false);
+    });
+
+    it('returns false when boardId is an empty string', () => {
+      expect(isPostSubmitInputValid({ ...VALID, boardId: '' })).toBe(false);
+    });
+
+    it('returns false when userId is undefined', () => {
+      expect(isPostSubmitInputValid({ ...VALID, userId: undefined })).toBe(false);
+    });
+
+    it('returns false when userId is an empty string', () => {
+      expect(isPostSubmitInputValid({ ...VALID, userId: '' })).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/post/hooks/__tests__/useRecentPosts.test.ts
+++ b/apps/web/src/post/hooks/__tests__/useRecentPosts.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import type { Post } from '@/post/model/Post';
+import {
+  buildRecentPostsQueryKey,
+  getRecentPostsNextPageParam,
+} from '../useRecentPosts';
+
+function makePost(createdAtIso: string, overrides: Partial<Post> = {}): Post {
+  return {
+    id: 'p1',
+    boardId: 'b1',
+    title: 'T',
+    content: '',
+    thumbnailImageURL: null,
+    authorId: 'u1',
+    authorName: '',
+    createdAt: { toDate: () => new Date(createdAtIso) } as Post['createdAt'],
+    countOfComments: 0,
+    countOfReplies: 0,
+    countOfLikes: 0,
+    visibility: 'public' as Post['visibility'],
+    ...overrides,
+  };
+}
+
+describe('buildRecentPostsQueryKey', () => {
+  it('returns ["posts", boardId, blockedByUsers] in that exact shape', () => {
+    expect(buildRecentPostsQueryKey('b1', ['u1', 'u2'])).toEqual(['posts', 'b1', ['u1', 'u2']]);
+  });
+
+  it('keeps the ["posts", boardId] prefix so invalidatePostCaches matches partially', () => {
+    // invalidatePostCaches uses ['posts', boardId] for partial invalidation.
+    // If this shape changes, that invalidation silently no-ops.
+    const key = buildRecentPostsQueryKey('b1', []);
+    expect(key[0]).toBe('posts');
+    expect(key[1]).toBe('b1');
+  });
+
+  it('encodes blockedByUsers as the third segment so cache splits per block-list', () => {
+    const a = buildRecentPostsQueryKey('b1', ['u1']);
+    const b = buildRecentPostsQueryKey('b1', ['u2']);
+    expect(a).not.toEqual(b);
+  });
+});
+
+describe('getRecentPostsNextPageParam', () => {
+  it('returns the last post’s createdAt as a Date', () => {
+    const page = [makePost('2025-01-01T00:00:00Z'), makePost('2025-01-02T00:00:00Z')];
+    const result = getRecentPostsNextPageParam(page);
+    expect(result).toEqual(new Date('2025-01-02T00:00:00Z'));
+  });
+
+  it('returns undefined for an empty page (signals end-of-list)', () => {
+    expect(getRecentPostsNextPageParam([])).toBeUndefined();
+  });
+
+  it('uses the LAST post in the page, not the first', () => {
+    const page = [makePost('2025-01-01T00:00:00Z'), makePost('2025-01-05T00:00:00Z')];
+    expect(getRecentPostsNextPageParam(page)).toEqual(new Date('2025-01-05T00:00:00Z'));
+  });
+});

--- a/apps/web/src/post/hooks/useBestPosts.ts
+++ b/apps/web/src/post/hooks/useBestPosts.ts
@@ -5,9 +5,63 @@ import type { Post } from '@/post/model/Post';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useBlockedByUsers } from '@/user/hooks/useBlockedByUsers';
 
-const BEST_POSTS_DAYS_RANGE = 7;
-const MAX_PAGES_TO_FETCH = 5;
-const PAGE_SIZE = 20;
+export const BEST_POSTS_DAYS_RANGE = 7;
+export const BEST_POSTS_MAX_PAGES = 5;
+export const BEST_POSTS_PAGE_SIZE = 20;
+
+/**
+ * QueryKey for the best-posts infinite query. Co-located with the hook so
+ * `invalidatePostCaches` (which uses ['bestPosts', boardId]) stays in lock-step.
+ */
+export function buildBestPostsQueryKey(boardId: string, blockedByUsers: string[] | undefined) {
+  return ['bestPosts', boardId, blockedByUsers] as const;
+}
+
+export interface BestPostsPaginationConfig {
+  pageSize: number;
+  maxPages: number;
+}
+
+/**
+ * Pure cursor mapper for the best-posts infinite query.
+ * Returns the last post's engagementScore, or undefined if pagination should stop.
+ *
+ * Stops on three conditions:
+ *   1) empty page (server has no more)
+ *   2) partial page (server returned fewer than pageSize — no more available)
+ *   3) maxPages reached (client-side hard cap to bound network usage)
+ */
+export function getBestPostsNextPageParam(
+  lastPage: Post[],
+  allPages: Post[][],
+  config: BestPostsPaginationConfig = {
+    pageSize: BEST_POSTS_PAGE_SIZE,
+    maxPages: BEST_POSTS_MAX_PAGES,
+  },
+): number | undefined {
+  if (lastPage.length === 0 || lastPage.length < config.pageSize) return undefined;
+  if (allPages.length >= config.maxPages) return undefined;
+  const lastPost = lastPage[lastPage.length - 1];
+  return lastPost.engagementScore;
+}
+
+/**
+ * Pure predicate that decides whether the best-posts hook should auto-fetch
+ * another page. True only when current results are below the user-requested
+ * target AND TanStack reports another page is available AND no fetch is in flight.
+ */
+export function shouldFetchMoreBestPosts(input: {
+  currentCount: number;
+  targetCount: number;
+  hasNextPage: boolean | undefined;
+  isFetchingNextPage: boolean;
+}): boolean {
+  return (
+    input.currentCount < input.targetCount &&
+    !!input.hasNextPage &&
+    !input.isFetchingNextPage
+  );
+}
 
 /**
  * 최근 7일 내 베스트 게시글을 불러오는 훅 (engagementScore 내림차순)
@@ -19,16 +73,12 @@ export const useBestPosts = (boardId: string, targetCount: number) => {
   const { data: blockedByUsers } = useBlockedByUsers(currentUser?.uid);
 
   const queryResult = useInfiniteQuery<Post[]>(
-    ['bestPosts', boardId, blockedByUsers],
-    ({ pageParam = undefined }) => fetchBestPosts(boardId, PAGE_SIZE, blockedByUsers ?? [], pageParam),
+    buildBestPostsQueryKey(boardId, blockedByUsers),
+    ({ pageParam = undefined }) =>
+      fetchBestPosts(boardId, BEST_POSTS_PAGE_SIZE, blockedByUsers ?? [], pageParam),
     {
       enabled: !!boardId && !!currentUser?.uid && !!blockedByUsers,
-      getNextPageParam: (lastPage, allPages) => {
-        if (lastPage.length === 0 || lastPage.length < PAGE_SIZE) return undefined;
-        if (allPages.length >= MAX_PAGES_TO_FETCH) return undefined;
-        const lastPost = lastPage[lastPage.length - 1];
-        return lastPost.engagementScore;
-      },
+      getNextPageParam: getBestPostsNextPageParam,
       meta: {
         errorContext: 'Loading best posts',
         feature: 'board-view-best',
@@ -50,11 +100,12 @@ export const useBestPosts = (boardId: string, targetCount: number) => {
   }, [data?.pages]);
 
   useEffect(() => {
-    if (
-      recentPosts.length < targetCount &&
-      hasNextPage &&
-      !isFetchingNextPage
-    ) {
+    if (shouldFetchMoreBestPosts({
+      currentCount: recentPosts.length,
+      targetCount,
+      hasNextPage,
+      isFetchingNextPage,
+    })) {
       fetchNextPage();
     }
   }, [recentPosts.length, targetCount, hasNextPage, isFetchingNextPage, fetchNextPage]);

--- a/apps/web/src/post/hooks/useCreatePostAction.ts
+++ b/apps/web/src/post/hooks/useCreatePostAction.ts
@@ -9,82 +9,90 @@ import {
 import { createPost } from '@/post/utils/postUtils';
 import { sendAnalyticsEvent, AnalyticsEvent } from '@/shared/utils/analyticsUtils';
 
+export interface ValidatedCreatePostInput {
+  title: string;
+  content: string;
+  authorId: string;
+  authorName: string;
+  boardId: string;
+}
+
+export type CreatePostValidation =
+  | { valid: true; input: ValidatedCreatePostInput }
+  | { valid: false; error: string };
+
+/**
+ * Pure validation: read required string fields out of FormData and verify they
+ * are non-blank. boardId comes from route params, not FormData, so it is
+ * passed separately. Error messages mirror the user-facing copy.
+ */
+export function validateCreatePostFormData(
+  formData: FormData,
+  boardId: string | undefined,
+): CreatePostValidation {
+  const title = ((formData.get('title') as string | null) ?? '').trim();
+  const content = ((formData.get('content') as string | null) ?? '').trim();
+  const authorId = (formData.get('authorId') as string | null) ?? '';
+  const authorName = (formData.get('authorName') as string | null) ?? '';
+
+  if (!title) return { valid: false, error: '제목을 입력해주세요.' };
+  if (!content) return { valid: false, error: '내용을 입력해주세요.' };
+  if (!boardId) return { valid: false, error: '게시판 ID가 누락되었습니다.' };
+  if (!authorId) return { valid: false, error: '사용자 인증이 필요합니다.' };
+  if (!authorName) return { valid: false, error: '사용자 이름이 누락되었습니다.' };
+
+  return { valid: true, input: { title, content, authorId, authorName, boardId } };
+}
+
+/**
+ * Pure error-string mapping: turns a thrown error from createPost into the
+ * Korean message shown to the user. Falls back to a generic message when the
+ * error is unrecognized or not an Error instance.
+ */
+export function mapCreatePostErrorMessage(error: unknown): string {
+  const fallback = '게시물 작성 중 오류가 발생했습니다. 다시 시도해주세요.';
+  if (!(error instanceof Error)) return fallback;
+  if (error.message.includes('permission-denied')) return '권한이 없습니다. 다시 로그인해주세요.';
+  if (error.message.includes('network')) return '네트워크 연결을 확인해주세요.';
+  if (error.message.includes('quota-exceeded')) return '저장 공간이 부족합니다.';
+  return fallback;
+}
+
 export async function createPostAction({ request, params }: ActionFunctionArgs) {
   const { boardId } = params;
   const formData = await request.formData();
 
-  const title = formData.get('title') as string;
-  const content = formData.get('content') as string;
-  const authorId = formData.get('authorId') as string;
-  const authorName = formData.get('authorName') as string;
+  const validation = validateCreatePostFormData(formData, boardId);
+  if (!validation.valid) {
+    return { error: validation.error };
+  }
+  const { title, content, authorId, authorName, boardId: validBoardId } = validation.input;
+
   const draftId = formData.get('draftId') as string | null;
   const contentJsonStr = formData.get('contentJson') as string | null;
   const contentJson = contentJsonStr ? JSON.parse(contentJsonStr) : undefined;
 
-  // Validate required fields
-  if (!title?.trim()) {
-    return { error: '제목을 입력해주세요.' };
-  }
-
-  if (!content?.trim()) {
-    return { error: '내용을 입력해주세요.' };
-  }
-
-  if (!boardId) {
-    return { error: '게시판 ID가 누락되었습니다.' };
-  }
-
-  if (!authorId) {
-    return { error: '사용자 인증이 필요합니다.' };
-  }
-
-  if (!authorName) {
-    return { error: '사용자 이름이 누락되었습니다.' };
-  }
-
   try {
+    await createPost({ boardId: validBoardId, title, content, authorId, authorName, contentJson });
 
-    // Create the post with optional contentJson
-    await createPost({ boardId, title, content, authorId, authorName, contentJson });
-    
-    // Send analytics
     sendAnalyticsEvent(AnalyticsEvent.CREATE_POST, {
-      boardId,
+      boardId: validBoardId,
       title,
       userId: authorId,
-      userName: authorName
+      userName: authorName,
     });
 
-    // Delete draft if it exists
     if (draftId) {
       await deleteDraft(authorId, draftId);
-      invalidateDraftCaches(authorId, draftId, boardId);
+      invalidateDraftCaches(authorId, draftId, validBoardId);
     }
 
-    // Invalidate post-related caches and optimistically update streak
-    invalidatePostCaches(boardId, authorId);
+    invalidatePostCaches(validBoardId, authorId);
     optimisticallyUpdatePostingStreak(authorId);
 
-    return redirect(`/create/${boardId}/completion?contentLength=${content.length}`);
+    return redirect(`/create/${validBoardId}/completion?contentLength=${content.length}`);
   } catch (error) {
     console.error('게시물 작성 중 오류가 발생했습니다:', error);
-    
-    // Provide more specific error messages based on the error type
-    let errorMessage = '게시물 작성 중 오류가 발생했습니다. 다시 시도해주세요.';
-    
-    if (error instanceof Error) {
-      // Check for specific Firebase errors
-      if (error.message.includes('permission-denied')) {
-        errorMessage = '권한이 없습니다. 다시 로그인해주세요.';
-      } else if (error.message.includes('network')) {
-        errorMessage = '네트워크 연결을 확인해주세요.';
-      } else if (error.message.includes('quota-exceeded')) {
-        errorMessage = '저장 공간이 부족합니다.';
-      }
-    }
-    
-    return {
-      error: errorMessage
-    };
+    return { error: mapCreatePostErrorMessage(error) };
   }
 }

--- a/apps/web/src/post/hooks/usePostSubmit.ts
+++ b/apps/web/src/post/hooks/usePostSubmit.ts
@@ -19,6 +19,22 @@ interface UsePostSubmitResult {
   handleSubmit: (e: React.FormEvent) => Promise<void>;
 }
 
+/**
+ * Pure validator for the post-submit form. Mirrors the silent-guard behavior
+ * of the hook: returns false (do nothing) when title/content is blank or when
+ * boardId/userId is missing.
+ */
+export function isPostSubmitInputValid(input: {
+  title: string;
+  content: string;
+  boardId: string | undefined;
+  userId: string | undefined;
+}): boolean {
+  if (!input.title.trim() || !input.content.trim()) return false;
+  if (!input.boardId || !input.userId) return false;
+  return true;
+}
+
 export function usePostSubmit({
   userId,
   userName,
@@ -33,12 +49,11 @@ export function usePostSubmit({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!title.trim() || !content.trim()) return;
-    if (!boardId || !userId) return;
-    
+    if (!isPostSubmitInputValid({ title, content, boardId, userId })) return;
+
     try {
       setIsSubmitting(true);
-      await createPost({ boardId, title, content, authorId: userId, authorName: userName });
+      await createPost({ boardId: boardId!, title, content, authorId: userId!, authorName: userName });
       sendAnalyticsEvent(AnalyticsEvent.CREATE_POST, {
         boardId,
         title,
@@ -47,20 +62,20 @@ export function usePostSubmit({
       });
       // 게시물 작성 성공 후 초안 삭제
       if (draftId) {
-        await deleteDraft(userId, draftId);
-        
+        await deleteDraft(userId!, draftId);
+
         // 캐시에서도 삭제
         queryClient.removeQueries({
           queryKey: ['draft', userId, draftId, boardId],
           exact: true
         });
-        
+
         // 초안 목록 캐시 무효화
         queryClient.invalidateQueries({
           queryKey: ['drafts', userId],
         });
       }
-      
+
       // 게시물 목록 캐시 무효화
       queryClient.invalidateQueries({
         queryKey: ['posts', boardId],
@@ -74,4 +89,4 @@ export function usePostSubmit({
   };
 
   return { isSubmitting, handleSubmit };
-} 
+}

--- a/apps/web/src/post/hooks/useRecentPosts.ts
+++ b/apps/web/src/post/hooks/useRecentPosts.ts
@@ -5,6 +5,24 @@ import { useAuth } from '@/shared/hooks/useAuth';
 import { useBlockedByUsers } from '@/user/hooks/useBlockedByUsers';
 
 /**
+ * QueryKey for the recent-posts infinite query. Co-located with the hook so
+ * `invalidatePostCaches` and any future cache reader stays in lock-step.
+ */
+export function buildRecentPostsQueryKey(boardId: string, blockedByUsers: string[]) {
+  return ['posts', boardId, blockedByUsers] as const;
+}
+
+/**
+ * Pure cursor mapper for the recent-posts infinite query.
+ * Returns the last post's createdAt as the next page cursor, or undefined
+ * when the page is empty (signals end-of-list to TanStack).
+ */
+export function getRecentPostsNextPageParam(lastPage: Post[]): Date | undefined {
+  const lastPost = lastPage[lastPage.length - 1];
+  return lastPost ? lastPost.createdAt.toDate() : undefined;
+}
+
+/**
  * 최근 게시글 목록을 불러오는 커스텀 훅 (createdAt 내림차순, blockedBy 기반 서버사이드 필터링)
  * @param boardId 게시판 ID
  * @param limitCount 페이지당 글 개수
@@ -21,14 +39,11 @@ export const useRecentPosts = (
     // list resolves later. Strips one Supabase RTT from boardFeed's LCP path.
     const effectiveBlockedByUsers = blockedByUsers ?? [];
     const queryResult = useInfiniteQuery<Post[]>(
-        ['posts', boardId, effectiveBlockedByUsers],
+        buildRecentPostsQueryKey(boardId, effectiveBlockedByUsers),
         ({ pageParam = null }) => fetchRecentPosts(boardId, limitCount, effectiveBlockedByUsers, pageParam),
         {
             enabled: !!boardId && !!currentUser?.uid,
-            getNextPageParam: (lastPage) => {
-                const lastPost = lastPage[lastPage.length - 1];
-                return lastPost ? lastPost.createdAt.toDate() : undefined;
-            },
+            getNextPageParam: getRecentPostsNextPageParam,
             meta: {
                 errorContext: 'Loading board posts',
                 feature: 'board-view',

--- a/apps/web/src/post/hooks/useScrollIndicators.ts
+++ b/apps/web/src/post/hooks/useScrollIndicators.ts
@@ -7,6 +7,27 @@ interface ScrollIndicators {
   canScrollRight: boolean;
 }
 
+export interface ScrollIndicatorState {
+  canScrollLeft: boolean;
+  canScrollRight: boolean;
+}
+
+/**
+ * Pure decision: given a scroll container's metrics, decide whether arrow
+ * indicators should show. The 1px tolerances are intentional — they absorb
+ * sub-pixel rounding so the buttons don't flicker at the boundaries.
+ */
+export function computeScrollIndicators(input: {
+  scrollLeft: number;
+  scrollWidth: number;
+  clientWidth: number;
+}): ScrollIndicatorState {
+  return {
+    canScrollLeft: input.scrollLeft > 1,
+    canScrollRight: input.scrollLeft + input.clientWidth < input.scrollWidth - 1,
+  };
+}
+
 export function useScrollIndicators(): ScrollIndicators {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -14,27 +35,18 @@ export function useScrollIndicators(): ScrollIndicators {
 
   const checkScrollability = () => {
     if (!scrollContainerRef.current) return;
-
     const { scrollLeft, scrollWidth, clientWidth } = scrollContainerRef.current;
-
-    // Can scroll left if scrolled more than 1px from the beginning
-    setCanScrollLeft(scrollLeft > 1);
-
-    // Can scroll right if not at the end
-    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1); // -1 for rounding errors
+    const next = computeScrollIndicators({ scrollLeft, scrollWidth, clientWidth });
+    setCanScrollLeft(next.canScrollLeft);
+    setCanScrollRight(next.canScrollRight);
   };
 
   useEffect(() => {
     const scrollContainer = scrollContainerRef.current;
     if (!scrollContainer) return;
 
-    // Check initial scroll state
     checkScrollability();
-
-    // Add scroll event listener
     scrollContainer.addEventListener('scroll', checkScrollability);
-
-    // Add resize event listener to recheck on window resize
     window.addEventListener('resize', checkScrollability);
 
     return () => {

--- a/apps/web/src/post/utils/batchPostCardDataUtils.test.ts
+++ b/apps/web/src/post/utils/batchPostCardDataUtils.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from 'vitest';
+import type { Post } from '@/post/model/Post';
+import type { BasicUserRow } from '@/user/api/userReads';
+import type { UserIdRow, PostDateRow } from '@/stats/api/stats';
+import {
+  deduplicateAuthorIds,
+  buildPostCardDataMap,
+  type BuildPostCardDataMapInput,
+} from './batchPostCardDataUtils';
+
+function createMockPost(authorId: string, id = `post-${authorId}`): Post {
+  return {
+    id,
+    boardId: 'board1',
+    title: 'Test',
+    content: '',
+    thumbnailImageURL: null,
+    authorId,
+    authorName: 'Test Author',
+    // FirebaseTimestamp shape via toDate(); the helper does not read createdAt here.
+    createdAt: {
+      toDate: () => new Date('2025-01-01T00:00:00Z'),
+      seconds: 0,
+      nanoseconds: 0,
+    } as unknown as Post['createdAt'],
+    countOfComments: 0,
+    countOfReplies: 0,
+    countOfLikes: 0,
+    visibility: 'public' as Post['visibility'],
+  };
+}
+
+function createUser(overrides: Partial<BasicUserRow> & { id: string }): BasicUserRow {
+  return {
+    id: overrides.id,
+    real_name: overrides.real_name ?? null,
+    nickname: overrides.nickname ?? null,
+    profile_photo_url: overrides.profile_photo_url ?? null,
+  };
+}
+
+function commentRow(user_id: string, created_at = '2025-01-01T12:00:00Z'): UserIdRow {
+  return { user_id, created_at };
+}
+
+function postDateRow(author_id: string, created_at: string): PostDateRow {
+  return { author_id, created_at };
+}
+
+function baseInput(overrides: Partial<BuildPostCardDataMapInput> = {}): BuildPostCardDataMapInput {
+  return {
+    authorIds: overrides.authorIds ?? [],
+    users: overrides.users ?? [],
+    commentRows: overrides.commentRows ?? [],
+    replyRows: overrides.replyRows ?? [],
+    postRows: overrides.postRows ?? [],
+    streakWorkingDays: overrides.streakWorkingDays ?? [],
+    donatorIds: overrides.donatorIds ?? new Set<string>(),
+  };
+}
+
+describe('deduplicateAuthorIds', () => {
+  it('returns unique author ids preserving first-seen order', () => {
+    const posts = [
+      createMockPost('a'),
+      createMockPost('b'),
+      createMockPost('a', 'post-a2'),
+      createMockPost('c'),
+    ];
+    expect(deduplicateAuthorIds(posts)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('drops falsy author ids', () => {
+    const posts = [
+      createMockPost(''),
+      createMockPost('a'),
+      createMockPost(''),
+    ];
+    expect(deduplicateAuthorIds(posts)).toEqual(['a']);
+  });
+
+  it('returns empty array for empty posts', () => {
+    expect(deduplicateAuthorIds([])).toEqual([]);
+  });
+});
+
+describe('buildPostCardDataMap', () => {
+  describe('displayName fallback chain', () => {
+    it('uses nickname when present', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1', nickname: 'Nick', real_name: 'Real' })],
+        }),
+      );
+      expect(result.get('u1')?.authorData.displayName).toBe('Nick');
+    });
+
+    it('falls back to real_name when nickname is empty/whitespace', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1', nickname: '   ', real_name: 'Real' })],
+        }),
+      );
+      expect(result.get('u1')?.authorData.displayName).toBe('Real');
+    });
+
+    it('falls back to "??" when both nickname and real_name are null', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1' })],
+        }),
+      );
+      expect(result.get('u1')?.authorData.displayName).toBe('??');
+    });
+
+    it('trims surrounding whitespace from nickname', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1', nickname: '  Nick  ' })],
+        }),
+      );
+      expect(result.get('u1')?.authorData.displayName).toBe('Nick');
+    });
+
+    it('uses "??" and blank image when user row is missing', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['missing'],
+          users: [],
+        }),
+      );
+      const entry = result.get('missing');
+      expect(entry?.authorData.displayName).toBe('??');
+      expect(entry?.authorData.profileImageURL).toBe('');
+    });
+  });
+
+  describe('profile image', () => {
+    it('passes through profile_photo_url', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1', profile_photo_url: 'https://img/u1.jpg' })],
+        }),
+      );
+      expect(result.get('u1')?.authorData.profileImageURL).toBe('https://img/u1.jpg');
+    });
+
+    it('returns empty string when profile_photo_url is null', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1' })],
+        }),
+      );
+      expect(result.get('u1')?.authorData.profileImageURL).toBe('');
+    });
+  });
+
+  describe('badge temperature', () => {
+    it('emits no badge when author has zero comments and replies', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1', nickname: 'Nick' })],
+        }),
+      );
+      expect(result.get('u1')?.badges).toEqual([]);
+    });
+
+    it('emits a 36.5℃ badge for a single comment', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1', nickname: 'Nick' })],
+          commentRows: [commentRow('u1')],
+        }),
+      );
+      expect(result.get('u1')?.badges).toEqual([{ name: '36.5℃', emoji: '🌡️' }]);
+    });
+
+    it('sums comments and replies across both inputs', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1', nickname: 'Nick' })],
+          // 6 comments + 5 replies = 11 → next 10-block adds 0.5 → 37.0℃
+          commentRows: Array.from({ length: 6 }, () => commentRow('u1')),
+          replyRows: Array.from({ length: 5 }, () => commentRow('u1')),
+        }),
+      );
+      expect(result.get('u1')?.badges).toEqual([{ name: '37℃', emoji: '🌡️' }]);
+    });
+
+    it('scopes activity counts to each author', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1', 'u2'],
+          users: [createUser({ id: 'u1' }), createUser({ id: 'u2' })],
+          commentRows: [commentRow('u1'), commentRow('u2'), commentRow('u2')],
+        }),
+      );
+      expect(result.get('u1')?.badges).toEqual([{ name: '36.5℃', emoji: '🌡️' }]);
+      expect(result.get('u2')?.badges).toEqual([{ name: '36.5℃', emoji: '🌡️' }]);
+    });
+  });
+
+  describe('streak boolean array', () => {
+    it('matches each streakWorkingDays entry in order', () => {
+      const day1 = new Date('2025-01-06T12:00:00+09:00'); // Mon KST
+      const day2 = new Date('2025-01-07T12:00:00+09:00'); // Tue KST
+      const day3 = new Date('2025-01-08T12:00:00+09:00'); // Wed KST
+
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1' })],
+          postRows: [
+            postDateRow('u1', '2025-01-06T03:00:00Z'), // Mon KST 12:00
+            postDateRow('u1', '2025-01-08T03:00:00Z'), // Wed KST 12:00
+          ],
+          streakWorkingDays: [day1, day2, day3],
+        }),
+      );
+
+      expect(result.get('u1')?.streak).toEqual([true, false, true]);
+    });
+
+    it('returns all-false streak when author has no posts', () => {
+      const day1 = new Date('2025-01-06T12:00:00+09:00');
+      const day2 = new Date('2025-01-07T12:00:00+09:00');
+
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1' })],
+          streakWorkingDays: [day1, day2],
+        }),
+      );
+
+      expect(result.get('u1')?.streak).toEqual([false, false]);
+    });
+
+    it('returns empty streak when streakWorkingDays is empty', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1' })],
+        }),
+      );
+      expect(result.get('u1')?.streak).toEqual([]);
+    });
+
+    it('does not bleed posts from one author into another author’s streak', () => {
+      const day1 = new Date('2025-01-06T12:00:00+09:00');
+
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1', 'u2'],
+          users: [createUser({ id: 'u1' }), createUser({ id: 'u2' })],
+          postRows: [postDateRow('u1', '2025-01-06T03:00:00Z')],
+          streakWorkingDays: [day1],
+        }),
+      );
+
+      expect(result.get('u1')?.streak).toEqual([true]);
+      expect(result.get('u2')?.streak).toEqual([false]);
+    });
+  });
+
+  describe('isDonator', () => {
+    it('is true when author id is in donatorIds set', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1' })],
+          donatorIds: new Set(['u1', 'other']),
+        }),
+      );
+      expect(result.get('u1')?.isDonator).toBe(true);
+    });
+
+    it('is false when author id is not in donatorIds set', () => {
+      const result = buildPostCardDataMap(
+        baseInput({
+          authorIds: ['u1'],
+          users: [createUser({ id: 'u1' })],
+          donatorIds: new Set(['other']),
+        }),
+      );
+      expect(result.get('u1')?.isDonator).toBe(false);
+    });
+  });
+
+  it('returns a Map keyed by authorId with one entry per input id', () => {
+    const result = buildPostCardDataMap(
+      baseInput({
+        authorIds: ['u1', 'u2', 'u3'],
+        users: [createUser({ id: 'u1' }), createUser({ id: 'u2' })],
+      }),
+    );
+    expect(result.size).toBe(3);
+    expect(result.has('u1')).toBe(true);
+    expect(result.has('u2')).toBe(true);
+    expect(result.has('u3')).toBe(true);
+  });
+
+  it('returns an empty Map when authorIds is empty', () => {
+    const result = buildPostCardDataMap(baseInput());
+    expect(result.size).toBe(0);
+  });
+});

--- a/apps/web/src/shared/hooks/decideScrollDirection.test.ts
+++ b/apps/web/src/shared/hooks/decideScrollDirection.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { decideScrollDirection } from './useScrollDirection';
+
+const DEFAULTS = {
+  topThreshold: 10,
+  ignoreSmallChanges: 5,
+};
+
+describe('decideScrollDirection', () => {
+  describe('top-threshold branch', () => {
+    it('reports up and resets the baseline when currentY is at the threshold', () => {
+      expect(
+        decideScrollDirection({ currentY: 10, lastY: 500, ...DEFAULTS }),
+      ).toEqual({ direction: 'up', nextLastY: 10 });
+    });
+
+    it('reports up and resets the baseline when currentY is at zero', () => {
+      expect(
+        decideScrollDirection({ currentY: 0, lastY: 500, ...DEFAULTS }),
+      ).toEqual({ direction: 'up', nextLastY: 0 });
+    });
+
+    it('overrides the small-delta branch when both apply (top wins)', () => {
+      // currentY 5 is at top AND delta vs lastY=8 is only 3 (< ignoreSmallChanges)
+      expect(
+        decideScrollDirection({ currentY: 5, lastY: 8, ...DEFAULTS }),
+      ).toEqual({ direction: 'up', nextLastY: 5 });
+    });
+  });
+
+  describe('small-delta branch (iOS bounce)', () => {
+    it('returns null direction and null nextLastY when delta is smaller than ignoreSmallChanges', () => {
+      expect(
+        decideScrollDirection({ currentY: 100, lastY: 102, ...DEFAULTS }),
+      ).toEqual({ direction: null, nextLastY: null });
+    });
+
+    it('treats the boundary value as still small (strict <)', () => {
+      // delta exactly equals ignoreSmallChanges → NOT small, falls through to direction
+      expect(
+        decideScrollDirection({ currentY: 105, lastY: 100, ...DEFAULTS }),
+      ).toEqual({ direction: 'down', nextLastY: 105 });
+    });
+
+    it('treats one-less-than-boundary as small', () => {
+      expect(
+        decideScrollDirection({ currentY: 104, lastY: 100, ...DEFAULTS }),
+      ).toEqual({ direction: null, nextLastY: null });
+    });
+  });
+
+  describe('direction branch', () => {
+    it('reports down when scrolling further from the top by more than ignoreSmallChanges', () => {
+      expect(
+        decideScrollDirection({ currentY: 500, lastY: 400, ...DEFAULTS }),
+      ).toEqual({ direction: 'down', nextLastY: 500 });
+    });
+
+    it('reports up when scrolling back toward the top by more than ignoreSmallChanges', () => {
+      expect(
+        decideScrollDirection({ currentY: 400, lastY: 500, ...DEFAULTS }),
+      ).toEqual({ direction: 'up', nextLastY: 400 });
+    });
+
+    it('treats currentY equal to lastY as a small delta (above threshold) and ignores it', () => {
+      // With ignoreSmallChanges > 0, equality is always caught by the small-delta branch.
+      expect(
+        decideScrollDirection({ currentY: 500, lastY: 500, ...DEFAULTS }),
+      ).toEqual({ direction: null, nextLastY: null });
+    });
+  });
+
+  describe('option knobs', () => {
+    it('honors a larger topThreshold', () => {
+      expect(
+        decideScrollDirection({ currentY: 50, lastY: 500, topThreshold: 100, ignoreSmallChanges: 5 }),
+      ).toEqual({ direction: 'up', nextLastY: 50 });
+    });
+
+    it('honors a larger ignoreSmallChanges', () => {
+      // delta = 20, ignoreSmallChanges = 50 → still ignored
+      expect(
+        decideScrollDirection({ currentY: 120, lastY: 100, topThreshold: 10, ignoreSmallChanges: 50 }),
+      ).toEqual({ direction: null, nextLastY: null });
+    });
+
+    it('with ignoreSmallChanges = 0 every above-threshold sample produces a direction', () => {
+      expect(
+        decideScrollDirection({ currentY: 101, lastY: 100, topThreshold: 10, ignoreSmallChanges: 0 }),
+      ).toEqual({ direction: 'down', nextLastY: 101 });
+      expect(
+        decideScrollDirection({ currentY: 99, lastY: 100, topThreshold: 10, ignoreSmallChanges: 0 }),
+      ).toEqual({ direction: 'up', nextLastY: 99 });
+    });
+
+    it('with ignoreSmallChanges = 0, equal Y leaves direction null but updates baseline', () => {
+      // The fall-through branch is only reachable when the small-delta branch is disabled.
+      expect(
+        decideScrollDirection({ currentY: 500, lastY: 500, topThreshold: 10, ignoreSmallChanges: 0 }),
+      ).toEqual({ direction: null, nextLastY: 500 });
+    });
+  });
+});

--- a/apps/web/src/shared/hooks/useScrollDirection.ts
+++ b/apps/web/src/shared/hooks/useScrollDirection.ts
@@ -2,6 +2,43 @@ import { useState, useEffect, useRef } from 'react';
 
 export type ScrollDirection = 'up' | 'down' | 'none';
 
+export interface ScrollDirectionInput {
+  currentY: number;
+  lastY: number;
+  topThreshold: number;
+  ignoreSmallChanges: number;
+}
+
+export interface ScrollDirectionDecision {
+  direction: 'up' | 'down' | null;
+  nextLastY: number | null;
+}
+
+/**
+ * Pure decision: given current/last scroll positions and the threshold knobs,
+ * report whether to change the reported direction and whether to update the
+ * tracked baseline.
+ *
+ * nextLastY === null means "ignore this sample" (iOS bounce / small-delta).
+ */
+export function decideScrollDirection(input: ScrollDirectionInput): ScrollDirectionDecision {
+  const { currentY, lastY, topThreshold, ignoreSmallChanges } = input;
+
+  if (currentY <= topThreshold) {
+    return { direction: 'up', nextLastY: currentY };
+  }
+  if (Math.abs(currentY - lastY) < ignoreSmallChanges) {
+    return { direction: null, nextLastY: null };
+  }
+  if (currentY > lastY) {
+    return { direction: 'down', nextLastY: currentY };
+  }
+  if (currentY < lastY) {
+    return { direction: 'up', nextLastY: currentY };
+  }
+  return { direction: null, nextLastY: currentY };
+}
+
 interface ScrollOptions {
   throttleTime?: number;
   topThreshold?: number;  // 상단으로 간주할 스크롤 위치 임계값
@@ -23,7 +60,6 @@ export const useScrollDirection = (options?: ScrollOptions): ScrollDirection => 
 
   const [scrollDirection, setScrollDirection] = useState<ScrollDirection>('none');
 
-  // Closure-only tracking values — kept in refs so updates do not rebind the listener.
   const lastScrollYRef = useRef<number>(0);
   const lastThrottleTimeRef = useRef<number>(0);
   const throttleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -31,51 +67,40 @@ export const useScrollDirection = (options?: ScrollOptions): ScrollDirection => 
   useEffect(() => {
     lastScrollYRef.current = window.scrollY;
 
-    const setDirectionIfChanged = (next: ScrollDirection) => {
-      setScrollDirection((prev) => (prev === next ? prev : next));
-    };
-
-    const evaluate = (currentScrollY: number, currentTime: number) => {
-      if (currentScrollY <= topThreshold) {
-        setDirectionIfChanged('up');
-        lastScrollYRef.current = currentScrollY;
-        lastThrottleTimeRef.current = currentTime;
-        return;
+    const applyDecision = (decision: ScrollDirectionDecision, currentTime: number) => {
+      const next = decision.direction;
+      if (next !== null) {
+        setScrollDirection((prev) => (prev === next ? prev : next));
       }
-
-      if (Math.abs(currentScrollY - lastScrollYRef.current) < ignoreSmallChanges) {
-        return;
+      if (decision.nextLastY !== null) {
+        lastScrollYRef.current = decision.nextLastY;
       }
-
-      if (currentScrollY > lastScrollYRef.current) {
-        setDirectionIfChanged('down');
-      } else if (currentScrollY < lastScrollYRef.current) {
-        setDirectionIfChanged('up');
-      }
-
-      lastScrollYRef.current = currentScrollY;
       lastThrottleTimeRef.current = currentTime;
     };
 
     const handleScroll = () => {
       const currentTime = Date.now();
       const currentScrollY = window.scrollY;
+      const decision = decideScrollDirection({
+        currentY: currentScrollY,
+        lastY: lastScrollYRef.current,
+        topThreshold,
+        ignoreSmallChanges,
+      });
 
-      // Fast-path: at/near the top — always 'up', bypass throttle.
+      // Fast-path: at/near the top — always apply, bypass throttle.
       if (currentScrollY <= topThreshold) {
-        setDirectionIfChanged('up');
-        lastScrollYRef.current = currentScrollY;
-        lastThrottleTimeRef.current = currentTime;
+        applyDecision(decision, currentTime);
         return;
       }
 
-      // Fast-path: ignore small deltas (iOS bounce) without scheduling a trailing timer.
-      if (Math.abs(currentScrollY - lastScrollYRef.current) < ignoreSmallChanges) {
+      // Fast-path: small delta (iOS bounce) — ignore without scheduling a trailing timer.
+      if (decision.direction === null && decision.nextLastY === null) {
         return;
       }
 
       if (currentTime - lastThrottleTimeRef.current >= throttleTime) {
-        evaluate(currentScrollY, currentTime);
+        applyDecision(decision, currentTime);
         return;
       }
 
@@ -84,7 +109,13 @@ export const useScrollDirection = (options?: ScrollOptions): ScrollDirection => 
         const delay = throttleTime - (currentTime - lastThrottleTimeRef.current);
         throttleTimerRef.current = setTimeout(() => {
           throttleTimerRef.current = null;
-          evaluate(window.scrollY, Date.now());
+          const trailingDecision = decideScrollDirection({
+            currentY: window.scrollY,
+            lastY: lastScrollYRef.current,
+            topThreshold,
+            ignoreSmallChanges,
+          });
+          applyDecision(trailingDecision, Date.now());
         }, delay);
       }
     };

--- a/apps/web/src/shared/utils/thumbnailUrl.test.ts
+++ b/apps/web/src/shared/utils/thumbnailUrl.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractStoragePath,
+  deriveThumbPath,
+  isFirebaseStorageUrl,
+  THUMB_SIZES,
+} from './thumbnailUrl';
+
+describe('isFirebaseStorageUrl', () => {
+  it('returns true for a Firebase Storage download URL', () => {
+    expect(
+      isFirebaseStorageUrl(
+        'https://firebasestorage.googleapis.com/v0/b/bucket/o/path%2Ffile.jpg?alt=media',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for non-Firebase URLs', () => {
+    expect(isFirebaseStorageUrl('https://cdn.example.com/image.jpg')).toBe(false);
+  });
+});
+
+describe('extractStoragePath', () => {
+  it('decodes the storage path from a download URL and drops the query string', () => {
+    const url =
+      'https://firebasestorage.googleapis.com/v0/b/dwf.appspot.com/o/postImages%2F20260421%2F143000_photo.jpg?alt=media&token=abc';
+    expect(extractStoragePath(url)).toBe('postImages/20260421/143000_photo.jpg');
+  });
+
+  it('returns null for URLs without /o/ segment', () => {
+    expect(extractStoragePath('https://firebasestorage.googleapis.com/v0/b/dwf')).toBeNull();
+  });
+
+  it('returns null for malformed URLs', () => {
+    expect(extractStoragePath('not a url')).toBeNull();
+  });
+
+  it('handles nested folders with multiple url-encoded slashes', () => {
+    const url =
+      'https://firebasestorage.googleapis.com/v0/b/bucket/o/a%2Fb%2Fc%2Ffile.jpg';
+    expect(extractStoragePath(url)).toBe('a/b/c/file.jpg');
+  });
+});
+
+describe('deriveThumbPath', () => {
+  it('inserts the size suffix before the extension for POST size', () => {
+    expect(deriveThumbPath('postImages/20260421/photo.jpg', THUMB_SIZES.POST)).toBe(
+      'postImages/20260421/photo_600x338.jpg',
+    );
+  });
+
+  it('inserts the size suffix before the extension for AVATAR size', () => {
+    expect(deriveThumbPath('avatars/user1.png', THUMB_SIZES.AVATAR)).toBe(
+      'avatars/user1_128x128.png',
+    );
+  });
+
+  it('uses only the last dot as the extension boundary', () => {
+    expect(deriveThumbPath('folder/file.name.with.dots.jpg', THUMB_SIZES.POST)).toBe(
+      'folder/file.name.with.dots_600x338.jpg',
+    );
+  });
+
+  it('returns null for paths without a file extension', () => {
+    expect(deriveThumbPath('folder/noext', THUMB_SIZES.POST)).toBeNull();
+  });
+
+  it('preserves the original path prefix verbatim', () => {
+    expect(deriveThumbPath('deeply/nested/path/file.webp', THUMB_SIZES.POST)).toBe(
+      'deeply/nested/path/file_600x338.webp',
+    );
+  });
+});

--- a/apps/web/src/shared/utils/thumbnailUrl.ts
+++ b/apps/web/src/shared/utils/thumbnailUrl.ts
@@ -33,7 +33,7 @@ type ThumbSize = (typeof THUMB_SIZES)[keyof typeof THUMB_SIZES];
  * Download URLs look like:
  *   https://firebasestorage.googleapis.com/v0/b/{bucket}/o/{encoded_path}?alt=media&token={token}
  */
-function extractStoragePath(downloadUrl: string): string | null {
+export function extractStoragePath(downloadUrl: string): string | null {
   try {
     const url = new URL(downloadUrl);
     const match = url.pathname.match(/\/o\/(.+)$/);
@@ -61,7 +61,7 @@ export function isFirebaseStorageUrl(url: string): boolean {
  *   postImages/20260421/143000_photo.jpg
  *   → postImages/20260421/143000_photo_600x338.jpg
  */
-function deriveThumbPath(originalPath: string, size: ThumbSize): string | null {
+export function deriveThumbPath(originalPath: string, size: ThumbSize): string | null {
   const lastDot = originalPath.lastIndexOf('.');
   if (lastDot === -1) return null;
   const base = originalPath.substring(0, lastDot);

--- a/apps/web/src/stats/utils/grid/gridMatrix.test.ts
+++ b/apps/web/src/stats/utils/grid/gridMatrix.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { createEmptyMatrices, createEmptyGridResult, updateMatricesAtPosition } from './gridMatrix';
+import type { ContributionData } from './types';
+import { WEEKS_TO_DISPLAY, WEEKDAYS_COUNT } from './types';
+
+describe('createEmptyMatrices', () => {
+  it('returns a 4×5 matrix and weeklyContributions, all null', () => {
+    const { matrix, weeklyContributions } = createEmptyMatrices();
+    expect(matrix).toHaveLength(WEEKS_TO_DISPLAY);
+    expect(weeklyContributions).toHaveLength(WEEKS_TO_DISPLAY);
+    matrix.forEach((row) => {
+      expect(row).toHaveLength(WEEKDAYS_COUNT);
+      expect(row.every((cell) => cell === null)).toBe(true);
+    });
+    weeklyContributions.forEach((row) => {
+      expect(row).toHaveLength(WEEKDAYS_COUNT);
+      expect(row.every((cell) => cell === null)).toBe(true);
+    });
+  });
+
+  it('returns independent row arrays so mutation does not bleed across rows', () => {
+    const { matrix } = createEmptyMatrices();
+    matrix[0][0] = 1;
+    expect(matrix[1][0]).toBeNull();
+  });
+
+  it('returns independent calls so two callers do not share state', () => {
+    const a = createEmptyMatrices();
+    const b = createEmptyMatrices();
+    a.matrix[0][0] = 99;
+    expect(b.matrix[0][0]).toBeNull();
+  });
+});
+
+describe('createEmptyGridResult', () => {
+  it('returns a 4×5 matrix, 4×5 weeklyContributions, and maxValue 0', () => {
+    const result = createEmptyGridResult();
+    expect(result.maxValue).toBe(0);
+    expect(result.matrix).toHaveLength(WEEKS_TO_DISPLAY);
+    expect(result.weeklyContributions).toHaveLength(WEEKS_TO_DISPLAY);
+    expect(result.matrix.every((row) => row.length === WEEKDAYS_COUNT)).toBe(true);
+    expect(result.weeklyContributions.every((row) => row.length === WEEKDAYS_COUNT)).toBe(true);
+  });
+});
+
+describe('updateMatricesAtPosition', () => {
+  it('writes the value into the matrix at the given position', () => {
+    const matrices = createEmptyMatrices();
+    const contribution: ContributionData = { createdAt: '2025-01-06', contentLength: 100 };
+    updateMatricesAtPosition(matrices, { weekRow: 1, weekdayColumn: 2 }, contribution, 100);
+    expect(matrices.matrix[1][2]).toBe(100);
+  });
+
+  it('writes the contribution into weeklyContributions at the given position', () => {
+    const matrices = createEmptyMatrices();
+    const contribution: ContributionData = { createdAt: '2025-01-06', contentLength: 100 };
+    updateMatricesAtPosition(matrices, { weekRow: 0, weekdayColumn: 0 }, contribution, 100);
+    expect(matrices.weeklyContributions[0][0]).toMatchObject({
+      createdAt: '2025-01-06',
+      contentLength: 100,
+    });
+  });
+
+  it('does not overwrite other cells', () => {
+    const matrices = createEmptyMatrices();
+    const contribution: ContributionData = { createdAt: '2025-01-06', contentLength: 50 };
+    updateMatricesAtPosition(matrices, { weekRow: 2, weekdayColumn: 3 }, contribution, 50);
+    // Everything else still null
+    matrices.matrix.forEach((row, r) => {
+      row.forEach((cell, c) => {
+        if (r === 2 && c === 3) return;
+        expect(cell).toBeNull();
+      });
+    });
+  });
+
+  it('preserves isHoliday from an existing placeholder when placing a real contribution', () => {
+    const matrices = createEmptyMatrices();
+    const placeholder: ContributionData = {
+      createdAt: '2025-01-06',
+      contentLength: 0,
+      isHoliday: true,
+      holidayName: '신정',
+    };
+    matrices.weeklyContributions[0][0] = placeholder;
+
+    const realContribution: ContributionData = {
+      createdAt: '2025-01-06',
+      contentLength: 250,
+      // intentionally no isHoliday/holidayName on the incoming contribution
+    };
+    updateMatricesAtPosition(matrices, { weekRow: 0, weekdayColumn: 0 }, realContribution, 250);
+
+    expect(matrices.weeklyContributions[0][0]).toMatchObject({
+      createdAt: '2025-01-06',
+      contentLength: 250,
+      isHoliday: true,
+      holidayName: '신정',
+    });
+  });
+
+  it('falls back to the contribution’s own isHoliday/holidayName when no placeholder exists', () => {
+    const matrices = createEmptyMatrices();
+    const contribution: ContributionData = {
+      createdAt: '2025-01-06',
+      contentLength: 0,
+      isHoliday: true,
+      holidayName: '한글날',
+    };
+    updateMatricesAtPosition(matrices, { weekRow: 0, weekdayColumn: 0 }, contribution, 0);
+    expect(matrices.weeklyContributions[0][0]).toMatchObject({
+      isHoliday: true,
+      holidayName: '한글날',
+    });
+  });
+
+  it('overrides placeholder contentLength with the new contribution value', () => {
+    const matrices = createEmptyMatrices();
+    matrices.weeklyContributions[0][0] = {
+      createdAt: '2025-01-06',
+      contentLength: 0,
+      isHoliday: true,
+      holidayName: '신정',
+    };
+    const real: ContributionData = { createdAt: '2025-01-06', contentLength: 999 };
+    updateMatricesAtPosition(matrices, { weekRow: 0, weekdayColumn: 0 }, real, 999);
+    expect((matrices.weeklyContributions[0][0] as { contentLength?: number }).contentLength).toBe(
+      999,
+    );
+  });
+});

--- a/apps/web/src/stats/utils/grid/gridPosition.test.ts
+++ b/apps/web/src/stats/utils/grid/gridPosition.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isWeekendDay,
+  calculateGridPosition,
+  calculateGridPositionDate,
+  normalizeToMidnight,
+  filterWeekdayContributions,
+} from './gridPosition';
+import { SUNDAY, SATURDAY } from './types';
+
+// Anchor date: Monday 2025-01-06 00:00 local. This is the "4 weeks ago" Monday
+// that callers pass as the grid origin.
+const MONDAY_GRID_START = new Date(2025, 0, 6, 0, 0, 0, 0);
+
+describe('isWeekendDay', () => {
+  it('returns true for Sunday', () => {
+    expect(isWeekendDay(SUNDAY)).toBe(true);
+  });
+
+  it('returns true for Saturday', () => {
+    expect(isWeekendDay(SATURDAY)).toBe(true);
+  });
+
+  it.each([1, 2, 3, 4, 5])('returns false for weekday %i', (dayOfWeek) => {
+    expect(isWeekendDay(dayOfWeek)).toBe(false);
+  });
+});
+
+describe('calculateGridPosition', () => {
+  it('returns null for Saturday', () => {
+    const saturday = new Date(2025, 0, 11, 0, 0, 0, 0); // 2025-01-11 is Sat
+    expect(calculateGridPosition(saturday, MONDAY_GRID_START)).toBeNull();
+  });
+
+  it('returns null for Sunday', () => {
+    const sunday = new Date(2025, 0, 12, 0, 0, 0, 0); // 2025-01-12 is Sun
+    expect(calculateGridPosition(sunday, MONDAY_GRID_START)).toBeNull();
+  });
+
+  it('places Monday of the start week at row 0, column 0', () => {
+    expect(calculateGridPosition(MONDAY_GRID_START, MONDAY_GRID_START)).toEqual({
+      weekRow: 0,
+      weekdayColumn: 0,
+    });
+  });
+
+  it('places Friday of the start week at row 0, column 4', () => {
+    const friday = new Date(2025, 0, 10, 0, 0, 0, 0); // 2025-01-10 is Fri
+    expect(calculateGridPosition(friday, MONDAY_GRID_START)).toEqual({
+      weekRow: 0,
+      weekdayColumn: 4,
+    });
+  });
+
+  it('places Wednesday of week 1 at row 1, column 2', () => {
+    const wedWeek1 = new Date(2025, 0, 15, 0, 0, 0, 0); // 2025-01-15 is Wed
+    expect(calculateGridPosition(wedWeek1, MONDAY_GRID_START)).toEqual({
+      weekRow: 1,
+      weekdayColumn: 2,
+    });
+  });
+
+  it('places the last visible weekday (Friday of week 3) at row 3, column 4', () => {
+    const lastFriday = new Date(2025, 0, 31, 0, 0, 0, 0); // 2025-01-31 is Fri
+    expect(calculateGridPosition(lastFriday, MONDAY_GRID_START)).toEqual({
+      weekRow: 3,
+      weekdayColumn: 4,
+    });
+  });
+
+  it('returns null for dates past the visible window (week 4+)', () => {
+    const monday5WeeksLater = new Date(2025, 1, 3, 0, 0, 0, 0); // 2025-02-03 Mon
+    expect(calculateGridPosition(monday5WeeksLater, MONDAY_GRID_START)).toBeNull();
+  });
+
+  it('returns null for dates before the grid origin', () => {
+    const fridayBefore = new Date(2025, 0, 3, 0, 0, 0, 0); // 2025-01-03 Fri
+    expect(calculateGridPosition(fridayBefore, MONDAY_GRID_START)).toBeNull();
+  });
+});
+
+describe('calculateGridPositionDate', () => {
+  it('returns the start Monday for (row 0, column 0)', () => {
+    const result = calculateGridPositionDate(MONDAY_GRID_START, 0, 0);
+    expect(result.getFullYear()).toBe(2025);
+    expect(result.getMonth()).toBe(0);
+    expect(result.getDate()).toBe(6);
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+  });
+
+  it('returns the Friday of week 0 for (0, 4)', () => {
+    const result = calculateGridPositionDate(MONDAY_GRID_START, 0, 4);
+    expect(result.getDate()).toBe(10);
+  });
+
+  it('returns the Friday of week 3 for (3, 4)', () => {
+    const result = calculateGridPositionDate(MONDAY_GRID_START, 3, 4);
+    expect(result.getDate()).toBe(31);
+  });
+
+  it('normalizes the result to midnight', () => {
+    const nonMidnightStart = new Date(2025, 0, 6, 14, 30, 0, 0);
+    const result = calculateGridPositionDate(nonMidnightStart, 1, 0);
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+  });
+
+  it('does not mutate the input weeksAgo date', () => {
+    const original = new Date(2025, 0, 6, 0, 0, 0, 0);
+    const snapshot = original.getTime();
+    calculateGridPositionDate(original, 2, 3);
+    expect(original.getTime()).toBe(snapshot);
+  });
+});
+
+describe('normalizeToMidnight', () => {
+  it('mutates the date in place to 00:00:00.000', () => {
+    const date = new Date(2025, 0, 6, 14, 30, 45, 999);
+    normalizeToMidnight(date);
+    expect(date.getHours()).toBe(0);
+    expect(date.getMinutes()).toBe(0);
+    expect(date.getSeconds()).toBe(0);
+    expect(date.getMilliseconds()).toBe(0);
+  });
+
+  it('leaves the calendar day unchanged', () => {
+    const date = new Date(2025, 0, 6, 23, 59, 59, 999);
+    normalizeToMidnight(date);
+    expect(date.getDate()).toBe(6);
+  });
+});
+
+describe('filterWeekdayContributions', () => {
+  it('removes Saturday and Sunday entries by createdAt', () => {
+    const contributions = [
+      { createdAt: '2025-01-06' }, // Mon
+      { createdAt: '2025-01-11' }, // Sat
+      { createdAt: '2025-01-12' }, // Sun
+      { createdAt: '2025-01-13' }, // Mon
+    ];
+
+    const result = filterWeekdayContributions(contributions);
+
+    expect(result).toEqual([
+      { createdAt: '2025-01-06' },
+      { createdAt: '2025-01-13' },
+    ]);
+  });
+
+  it('returns empty array for an all-weekend input', () => {
+    const contributions = [
+      { createdAt: '2025-01-11' },
+      { createdAt: '2025-01-12' },
+    ];
+    expect(filterWeekdayContributions(contributions)).toEqual([]);
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(filterWeekdayContributions([])).toEqual([]);
+  });
+
+  it('preserves additional properties on each contribution', () => {
+    const contributions = [
+      { createdAt: '2025-01-06', contentLength: 100 },
+      { createdAt: '2025-01-11', contentLength: 200 },
+    ];
+    const result = filterWeekdayContributions(contributions);
+    expect(result).toEqual([{ createdAt: '2025-01-06', contentLength: 100 }]);
+  });
+});

--- a/apps/web/src/stats/utils/grid/placeholders.test.ts
+++ b/apps/web/src/stats/utils/grid/placeholders.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { createEmptyMatrices } from './gridMatrix';
+import { initializeGridWithPlaceholders } from './placeholders';
+import { WEEKS_TO_DISPLAY, WEEKDAYS_COUNT } from './types';
+
+// 4-week window: Mon Jan 6, 2025 → Fri Jan 31, 2025
+const WEEKS_AGO_MONDAY = new Date(2025, 0, 6, 0, 0, 0, 0);
+const TODAY_FRIDAY = new Date(2025, 0, 31, 12, 0, 0, 0);
+
+describe('initializeGridWithPlaceholders', () => {
+  it('fills every cell with a posting placeholder when today covers the full window', () => {
+    const matrices = createEmptyMatrices();
+    initializeGridWithPlaceholders(matrices, WEEKS_AGO_MONDAY, TODAY_FRIDAY, 'posting');
+
+    for (let row = 0; row < WEEKS_TO_DISPLAY; row++) {
+      for (let col = 0; col < WEEKDAYS_COUNT; col++) {
+        const cell = matrices.weeklyContributions[row][col];
+        expect(cell).not.toBeNull();
+        expect(cell).toMatchObject({ contentLength: 0 });
+      }
+    }
+  });
+
+  it('fills every cell with a commenting placeholder when today covers the full window', () => {
+    const matrices = createEmptyMatrices();
+    initializeGridWithPlaceholders(matrices, WEEKS_AGO_MONDAY, TODAY_FRIDAY, 'commenting');
+
+    for (let row = 0; row < WEEKS_TO_DISPLAY; row++) {
+      for (let col = 0; col < WEEKDAYS_COUNT; col++) {
+        const cell = matrices.weeklyContributions[row][col];
+        expect(cell).not.toBeNull();
+        expect(cell).toMatchObject({ countOfCommentAndReplies: 0 });
+      }
+    }
+  });
+
+  it('does not write the count matrix — only weeklyContributions', () => {
+    const matrices = createEmptyMatrices();
+    initializeGridWithPlaceholders(matrices, WEEKS_AGO_MONDAY, TODAY_FRIDAY, 'posting');
+    matrices.matrix.forEach((row) => row.forEach((cell) => expect(cell).toBeNull()));
+  });
+
+  it('omits placeholders for cells whose date is after today (today-inclusive bound)', () => {
+    const matrices = createEmptyMatrices();
+    // today is Wed of the start week (2025-01-08) — only Mon/Tue/Wed of row 0 should fill
+    const todayWedWeek0 = new Date(2025, 0, 8, 12, 0, 0, 0);
+    initializeGridWithPlaceholders(matrices, WEEKS_AGO_MONDAY, todayWedWeek0, 'posting');
+
+    expect(matrices.weeklyContributions[0][0]).not.toBeNull(); // Mon
+    expect(matrices.weeklyContributions[0][1]).not.toBeNull(); // Tue
+    expect(matrices.weeklyContributions[0][2]).not.toBeNull(); // Wed
+    expect(matrices.weeklyContributions[0][3]).toBeNull(); // Thu — after today
+    expect(matrices.weeklyContributions[0][4]).toBeNull(); // Fri — after today
+    expect(matrices.weeklyContributions[1][0]).toBeNull(); // next-week Mon — after today
+  });
+
+  it('stamps each placeholder with the KST date string for its cell', () => {
+    const matrices = createEmptyMatrices();
+    initializeGridWithPlaceholders(matrices, WEEKS_AGO_MONDAY, TODAY_FRIDAY, 'posting');
+    // (0,0) is Mon Jan 6; (0,4) is Fri Jan 10; (3,4) is Fri Jan 31
+    expect((matrices.weeklyContributions[0][0] as { createdAt: string }).createdAt).toBe(
+      '2025-01-06',
+    );
+    expect((matrices.weeklyContributions[0][4] as { createdAt: string }).createdAt).toBe(
+      '2025-01-10',
+    );
+    expect((matrices.weeklyContributions[3][4] as { createdAt: string }).createdAt).toBe(
+      '2025-01-31',
+    );
+  });
+});

--- a/apps/web/src/stats/utils/grid/processors.test.ts
+++ b/apps/web/src/stats/utils/grid/processors.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import {
+  placeContributionInGrid,
+  processContributionsInGrid,
+  processPostingContributions,
+  processCommentingContributions,
+} from './processors';
+import { createEmptyMatrices } from './gridMatrix';
+import type { Contribution } from '@/stats/model/WritingStats';
+import type { CommentingContribution } from '@/stats/utils/commentingContributionUtils';
+
+// 4-week posting window: Mon Jan 6, 2025 → Fri Jan 31, 2025
+const TIME_RANGE = {
+  weeksAgo: new Date(2025, 0, 6, 0, 0, 0, 0),
+  today: new Date(2025, 0, 31, 23, 0, 0, 0),
+};
+
+describe('placeContributionInGrid', () => {
+  it('writes a weekday contribution into the right cell', () => {
+    const matrices = createEmptyMatrices();
+    const contribution: Contribution = {
+      // 2025-01-08 = Wed of week 0 → row 0, col 2
+      createdAt: new Date(2025, 0, 8, 12, 0, 0, 0).toISOString(),
+      contentLength: 150,
+    };
+
+    placeContributionInGrid(
+      contribution,
+      (c) => (c as Contribution).contentLength ?? 0,
+      matrices,
+      TIME_RANGE.weeksAgo,
+    );
+
+    expect(matrices.matrix[0][2]).toBe(150);
+    expect(matrices.weeklyContributions[0][2]).toMatchObject({ contentLength: 150 });
+  });
+
+  it('skips a weekend contribution', () => {
+    const matrices = createEmptyMatrices();
+    const saturday: Contribution = {
+      // 2025-01-11 is Saturday
+      createdAt: new Date(2025, 0, 11, 12, 0, 0, 0).toISOString(),
+      contentLength: 999,
+    };
+
+    placeContributionInGrid(
+      saturday,
+      (c) => (c as Contribution).contentLength ?? 0,
+      matrices,
+      TIME_RANGE.weeksAgo,
+    );
+
+    matrices.matrix.forEach((row) => row.forEach((cell) => expect(cell).toBeNull()));
+  });
+
+  it('skips a contribution past the visible window', () => {
+    const matrices = createEmptyMatrices();
+    const beyond: Contribution = {
+      createdAt: new Date(2025, 1, 3, 12, 0, 0, 0).toISOString(), // Mon Feb 3 (week 4)
+      contentLength: 999,
+    };
+
+    placeContributionInGrid(
+      beyond,
+      (c) => (c as Contribution).contentLength ?? 0,
+      matrices,
+      TIME_RANGE.weeksAgo,
+    );
+
+    matrices.matrix.forEach((row) => row.forEach((cell) => expect(cell).toBeNull()));
+  });
+});
+
+describe('processContributionsInGrid', () => {
+  it('places in-range weekday contributions and computes the maxValue', () => {
+    const matrices = createEmptyMatrices();
+    const contributions: Contribution[] = [
+      { createdAt: new Date(2025, 0, 6, 12).toISOString(), contentLength: 100 }, // Mon row 0 col 0
+      { createdAt: new Date(2025, 0, 8, 12).toISOString(), contentLength: 300 }, // Wed row 0 col 2
+      { createdAt: new Date(2025, 0, 15, 12).toISOString(), contentLength: 200 }, // Wed row 1 col 2
+    ];
+
+    const { maxValue } = processContributionsInGrid(
+      contributions,
+      matrices,
+      TIME_RANGE.weeksAgo,
+      TIME_RANGE.today,
+      (c) => c.contentLength ?? 0,
+    );
+
+    expect(matrices.matrix[0][0]).toBe(100);
+    expect(matrices.matrix[0][2]).toBe(300);
+    expect(matrices.matrix[1][2]).toBe(200);
+    expect(maxValue).toBe(300);
+  });
+
+  it('ignores contributions outside the time range when computing maxValue', () => {
+    const matrices = createEmptyMatrices();
+    const contributions: Contribution[] = [
+      { createdAt: new Date(2025, 0, 8, 12).toISOString(), contentLength: 100 }, // in range
+      { createdAt: new Date(2025, 1, 10, 12).toISOString(), contentLength: 9999 }, // out of range
+    ];
+
+    const { maxValue } = processContributionsInGrid(
+      contributions,
+      matrices,
+      TIME_RANGE.weeksAgo,
+      TIME_RANGE.today,
+      (c) => c.contentLength ?? 0,
+    );
+
+    expect(maxValue).toBe(100);
+  });
+
+  it('returns maxValue 0 when no in-range contributions', () => {
+    const matrices = createEmptyMatrices();
+    const { maxValue } = processContributionsInGrid(
+      [],
+      matrices,
+      TIME_RANGE.weeksAgo,
+      TIME_RANGE.today,
+      (c) => (c as Contribution).contentLength ?? 0,
+    );
+    expect(maxValue).toBe(0);
+  });
+
+  it('excludes weekend contributions from maxValue', () => {
+    const matrices = createEmptyMatrices();
+    const contributions: Contribution[] = [
+      { createdAt: new Date(2025, 0, 8, 12).toISOString(), contentLength: 100 }, // Wed
+      { createdAt: new Date(2025, 0, 11, 12).toISOString(), contentLength: 9999 }, // Sat
+    ];
+
+    const { maxValue } = processContributionsInGrid(
+      contributions,
+      matrices,
+      TIME_RANGE.weeksAgo,
+      TIME_RANGE.today,
+      (c) => c.contentLength ?? 0,
+    );
+
+    expect(maxValue).toBe(100);
+  });
+});
+
+describe('processPostingContributions', () => {
+  it('returns a full GridResult with placeholders, placed values, and maxValue', () => {
+    const contributions: Contribution[] = [
+      { createdAt: new Date(2025, 0, 8, 12).toISOString(), contentLength: 250 },
+    ];
+
+    const result = processPostingContributions(contributions, TIME_RANGE);
+
+    expect(result.matrix[0][2]).toBe(250);
+    expect(result.maxValue).toBe(250);
+    // Placeholder is present at an untouched cell — same KST date as the cell
+    expect(result.weeklyContributions[0][0]).toMatchObject({ contentLength: 0 });
+    // Untouched matrix cells remain null
+    expect(result.matrix[0][0]).toBeNull();
+  });
+
+  it('returns maxValue 0 for empty contributions', () => {
+    const result = processPostingContributions([], TIME_RANGE);
+    expect(result.maxValue).toBe(0);
+    result.matrix.forEach((row) => row.forEach((cell) => expect(cell).toBeNull()));
+  });
+
+  it('treats null contentLength as 0', () => {
+    const contributions: Contribution[] = [
+      { createdAt: new Date(2025, 0, 8, 12).toISOString(), contentLength: null },
+    ];
+    const result = processPostingContributions(contributions, TIME_RANGE);
+    expect(result.maxValue).toBe(0);
+  });
+});
+
+describe('processCommentingContributions', () => {
+  it('returns a full GridResult using countOfCommentAndReplies as the value', () => {
+    const contributions: CommentingContribution[] = [
+      {
+        createdAt: new Date(2025, 0, 8, 12).toISOString(),
+        countOfCommentAndReplies: 5,
+      },
+      {
+        createdAt: new Date(2025, 0, 15, 12).toISOString(),
+        countOfCommentAndReplies: 12,
+      },
+    ];
+
+    const result = processCommentingContributions(contributions, TIME_RANGE);
+
+    expect(result.matrix[0][2]).toBe(5);
+    expect(result.matrix[1][2]).toBe(12);
+    expect(result.maxValue).toBe(12);
+    // Commenting placeholder shape
+    expect(result.weeklyContributions[0][0]).toMatchObject({ countOfCommentAndReplies: 0 });
+  });
+
+  it('returns maxValue 0 for empty contributions', () => {
+    const result = processCommentingContributions([], TIME_RANGE);
+    expect(result.maxValue).toBe(0);
+  });
+});

--- a/apps/web/src/stats/utils/grid/timeRange.test.ts
+++ b/apps/web/src/stats/utils/grid/timeRange.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatDateInKoreanTimezone,
+  getTimeRange,
+  filterContributionsInTimeRange,
+  isDateWithinTodayInclusive,
+} from './timeRange';
+
+// Helper: build a Date whose local-time day/month/year are guaranteed values
+// independent of the runner timezone. We anchor on noon to stay well inside
+// the same KST day.
+function localNoon(year: number, monthIndex: number, day: number): Date {
+  return new Date(year, monthIndex, day, 12, 0, 0, 0);
+}
+
+describe('formatDateInKoreanTimezone', () => {
+  it('returns YYYY-MM-DD for an explicit KST timestamp', () => {
+    const date = new Date('2025-01-06T12:00:00+09:00');
+    expect(formatDateInKoreanTimezone(date)).toBe('2025-01-06');
+  });
+
+  it('returns the KST calendar date for a UTC timestamp before midnight KST', () => {
+    // 2025-01-05T23:30:00Z → 2025-01-06 08:30 KST
+    const date = new Date('2025-01-05T23:30:00Z');
+    expect(formatDateInKoreanTimezone(date)).toBe('2025-01-06');
+  });
+
+  it('returns the KST calendar date even for late-night UTC that has already rolled over in KST', () => {
+    // 2025-01-06T16:00:00Z → 2025-01-07 01:00 KST
+    const date = new Date('2025-01-06T16:00:00Z');
+    expect(formatDateInKoreanTimezone(date)).toBe('2025-01-07');
+  });
+
+  it('pads single-digit months and days with zero', () => {
+    const date = new Date('2025-03-05T12:00:00+09:00');
+    expect(formatDateInKoreanTimezone(date)).toBe('2025-03-05');
+  });
+});
+
+describe('getTimeRange', () => {
+  it('returns the current Monday as the end-week origin when today is Monday', () => {
+    const monday = localNoon(2025, 0, 6); // Mon 2025-01-06
+    const { weeksAgo, today } = getTimeRange(monday);
+    expect(today).toBe(monday);
+    // Current Monday is Jan 6; gridStart = Jan 6 - 21 days = Dec 16, 2024
+    expect(weeksAgo.getFullYear()).toBe(2024);
+    expect(weeksAgo.getMonth()).toBe(11);
+    expect(weeksAgo.getDate()).toBe(16);
+    expect(weeksAgo.getHours()).toBe(0);
+    expect(weeksAgo.getMinutes()).toBe(0);
+  });
+
+  it('rewinds Sunday to the previous Monday before computing weeksAgo', () => {
+    const sunday = localNoon(2025, 0, 5); // Sun 2025-01-05
+    const { weeksAgo } = getTimeRange(sunday);
+    // Sun Jan 5 → current Monday is Dec 30, 2024; weeksAgo = Dec 9
+    expect(weeksAgo.getFullYear()).toBe(2024);
+    expect(weeksAgo.getMonth()).toBe(11);
+    expect(weeksAgo.getDate()).toBe(9);
+  });
+
+  it('rewinds Friday to the same Monday as the start of its week', () => {
+    const friday = localNoon(2025, 0, 10); // Fri 2025-01-10
+    const { weeksAgo } = getTimeRange(friday);
+    // Current Monday is Jan 6; weeksAgo = Dec 16, 2024
+    expect(weeksAgo.getMonth()).toBe(11);
+    expect(weeksAgo.getDate()).toBe(16);
+  });
+
+  it('rewinds Saturday to the Monday of the same week', () => {
+    const saturday = localNoon(2025, 0, 11); // Sat 2025-01-11
+    const { weeksAgo } = getTimeRange(saturday);
+    expect(weeksAgo.getMonth()).toBe(11);
+    expect(weeksAgo.getDate()).toBe(16);
+  });
+
+  it('normalizes weeksAgo to midnight even when today is at noon', () => {
+    const { weeksAgo } = getTimeRange(localNoon(2025, 0, 6));
+    expect(weeksAgo.getHours()).toBe(0);
+    expect(weeksAgo.getMinutes()).toBe(0);
+    expect(weeksAgo.getSeconds()).toBe(0);
+    expect(weeksAgo.getMilliseconds()).toBe(0);
+  });
+
+  it('does not mutate the today argument', () => {
+    const monday = localNoon(2025, 0, 6);
+    const snapshot = monday.getTime();
+    getTimeRange(monday);
+    expect(monday.getTime()).toBe(snapshot);
+  });
+});
+
+describe('filterContributionsInTimeRange', () => {
+  const start = new Date('2025-01-06T00:00:00Z');
+  const end = new Date('2025-01-10T00:00:00Z');
+
+  it('includes contributions on both range bounds', () => {
+    const contributions = [
+      { createdAt: '2025-01-06T00:00:00Z' },
+      { createdAt: '2025-01-10T00:00:00Z' },
+    ];
+    expect(filterContributionsInTimeRange(contributions, start, end)).toHaveLength(2);
+  });
+
+  it('includes a contribution inside the range', () => {
+    const contributions = [{ createdAt: '2025-01-08T12:00:00Z' }];
+    expect(filterContributionsInTimeRange(contributions, start, end)).toHaveLength(1);
+  });
+
+  it('excludes a contribution before the start', () => {
+    const contributions = [{ createdAt: '2025-01-05T23:59:59Z' }];
+    expect(filterContributionsInTimeRange(contributions, start, end)).toEqual([]);
+  });
+
+  it('excludes a contribution after the end', () => {
+    const contributions = [{ createdAt: '2025-01-10T00:00:01Z' }];
+    expect(filterContributionsInTimeRange(contributions, start, end)).toEqual([]);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(filterContributionsInTimeRange([], start, end)).toEqual([]);
+  });
+});
+
+describe('isDateWithinTodayInclusive', () => {
+  it('returns true when date and today are the same KST day', () => {
+    const date = new Date('2025-01-06T03:00:00+09:00');
+    const today = new Date('2025-01-06T20:00:00+09:00');
+    expect(isDateWithinTodayInclusive(date, today)).toBe(true);
+  });
+
+  it('returns true when date is before today in KST', () => {
+    const date = new Date('2025-01-05T20:00:00+09:00');
+    const today = new Date('2025-01-06T03:00:00+09:00');
+    expect(isDateWithinTodayInclusive(date, today)).toBe(true);
+  });
+
+  it('returns false when date is after today in KST', () => {
+    const date = new Date('2025-01-07T03:00:00+09:00');
+    const today = new Date('2025-01-06T20:00:00+09:00');
+    expect(isDateWithinTodayInclusive(date, today)).toBe(false);
+  });
+
+  it('compares by KST calendar day, not absolute timestamp', () => {
+    // date is later in absolute time but earlier in KST day:
+    //   today: 2025-01-06T16:00:00Z → 2025-01-07 01:00 KST
+    //   date:  2025-01-06T20:00:00Z → 2025-01-07 05:00 KST → same day → true
+    const date = new Date('2025-01-06T20:00:00Z');
+    const today = new Date('2025-01-06T16:00:00Z');
+    expect(isDateWithinTodayInclusive(date, today)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Increase unit-test coverage of the web app by isolating business and presentation logic into pure functions (Functional Core / Imperative Shell), then locking each in with output-based tests. No behavior changes.

- **+178 tests across 22 files** — feed PostCard builder, contribution-grid core (5 modules), thumbnail URL helpers, scroll direction/indicators, four post query/mutation hooks, `isWithinDays` (now-injectable).
- **Source touched lightly**: 2 export visibility changes (`thumbnailUrl`), one optional-param addition (`isWithinDays`), and small "extract pure function" refactors (`useScrollDirection`, `useScrollIndicators`, four `post/hooks/*`).
- **Type-check clean**, full suite passes (985/986 — the one failure is a pre-existing timing flake in `src/shared/api/supabaseClient.test.ts > slow-write warning breadcrumb`, unrelated to this PR).

## What changed and why

### Commit 1 — `ade27994` test(stats,post): PostCard 빌더 + grid 코어
- `buildPostCardDataMap` powers every PostCard in the feed (display-name fallback, badge temperature, streak dots, donator flag) — was pure but untested.
- `stats/utils/grid/` (5 modules, ~250 lines) — entire functional core for the contribution heatmap; Korean-timezone calendar math is the most error-prone surface in the app. `getTimeRange(today?)` already accepted injected time, so no refactor was needed. Locks in two non-obvious invariants: the **holiday-preservation merge** in `updateMatricesAtPosition` and the **today-inclusive boundary** in `initializeGridWithPlaceholders`.

### Commit 2 — `34aa2e96` refactor(shared): useScrollDirection · thumbnailUrl
- Extracted `decideScrollDirection({currentY, lastY, topThreshold, ignoreSmallChanges}) → { direction, nextLastY }` — the iOS-bounce small-delta branch was previously buried inside `useEffect` and untestable.
- Exported `extractStoragePath` + `deriveThumbPath` (were file-private). Locks in the Firebase Resize Images extension's `_{w}x{h}` filename convention.

### Commit 3 — `b60d014c` refactor(post/hooks): post 쿼리·액션 훅
- `useRecentPosts` / `useBestPosts`: extracted `buildXxxQueryKey` and `getXxxNextPageParam`. The queryKey shapes are now locked in for the **`invalidatePostCaches` partial-match contract** — if a writer changes the shape, invalidation silently no-ops. `useBestPosts` also gained `shouldFetchMoreBestPosts` so the 3-guard pagination (empty / partial / maxPages) and the auto-fetch trigger are independently verifiable.
- `createPostAction`: extracted `validateCreatePostFormData` + `mapCreatePostErrorMessage`. Action body shrunk by ~30 lines; Korean error copy and validation ordering are now regression-proof.
- `usePostSubmit`: extracted `isPostSubmitInputValid`.
- `usePostDelete`: intentionally skipped — 10 lines, all side effects, no extractable pure logic.

### Commit 4 — `07b122eb` refactor(post): isWithinDays · computeScrollIndicators
- `isWithinDays(post, days, now = new Date())` — optional `now` injection. Cutoff boundary and missing-createdAt handling now tested.
- Extracted `computeScrollIndicators({scrollLeft, scrollWidth, clientWidth}) → {canScrollLeft, canScrollRight}`. The 1px tolerances are an intentional anti-flicker invariant and are now documented + tested.

## Approach notes

This PR follows the `.claude/skills/testing` and `.claude/skills/refactoring` guidance: **unit-test pure functions only**, **extract from imperative shell before testing**. No `renderHook`, no `QueryClientProvider`, no MSW. Hook lifecycle (e.g. mutation `onMutate/onSuccess` wiring) is left to E2E by design.

For each query hook, the pattern is the same: pull the queryKey shape, `getNextPageParam`, and any predicate or reducer out of the hook body as named exports, then write input/output tests. The hook stays as a thin imperative shell of `useQuery(buildKey(…), fn, { getNextPageParam: …, … })`.

## Test plan

- [x] `pnpm --filter web type-check` — clean
- [x] `pnpm --filter web test:run` — 985/986 (1 pre-existing flake in supabaseClient.test.ts, unrelated)
- [x] No source behavior changes — confirmed by reading each diff (refactors are pure extractions; only `createPostAction` got a defensive `?? '' .trim()` for FormData reads that were already typed `as string`)
- [ ] Reviewer spot-check on:
  - `useBestPosts` queryKey shape vs `invalidatePostCaches` prefix
  - `decideScrollDirection` decision tree matches the original `evaluate` + handleScroll fast-paths
  - `validateCreatePostFormData` returns the error strings in the same order as the original

## Pre-existing issue surfaced (not addressed here)

`src/shared/api/supabaseClient.test.ts > executeTrackedWrite > slow-write warning breadcrumb` flakes on this branch and on `main` — looks like a timing-threshold assertion. Worth a follow-up.