### PR TITLE
perf(profile-thumbnails): apply top-5 image loading optimizations

### DIFF
--- a/apps/web/src/comment/api/comment.ts
+++ b/apps/web/src/comment/api/comment.ts
@@ -86,7 +86,7 @@ export async function fetchCommentsFromSupabase(
 
   let q = supabase
     .from('comments')
-    .select('id, content, user_id, user_name, user_profile_image, created_at')
+    .select('id, content, user_id, user_name, user_profile_image, created_at, author:users!user_id(profile_photo_url, nickname)')
     .eq('post_id', postId)
     .order('created_at', { ascending: true });
 
@@ -115,7 +115,7 @@ export async function fetchCommentByIdFromSupabase(
 
   const { data, error } = await supabase
     .from('comments')
-    .select('id, content, user_id, user_name, user_profile_image, created_at')
+    .select('id, content, user_id, user_name, user_profile_image, created_at, author:users!user_id(profile_photo_url, nickname)')
     .eq('id', commentId)
     .single();
 
@@ -129,20 +129,37 @@ export async function fetchCommentByIdFromSupabase(
   return mapRowToComment(data);
 }
 
-function mapRowToComment(row: {
+interface AuthorEmbed {
+  profile_photo_url: string | null;
+  nickname: string | null;
+}
+
+interface CommentRow {
   id: string;
   content: string;
   user_id: string;
   user_name: string;
   user_profile_image: string | null;
   created_at: string;
-}): Comment {
+  author?: AuthorEmbed | AuthorEmbed[] | null;
+}
+
+function unwrapEmbed<T>(embed: T | T[] | null | undefined): T | undefined {
+  if (!embed) return undefined;
+  return Array.isArray(embed) ? embed[0] : embed;
+}
+
+function mapRowToComment(row: CommentRow): Comment {
+  const author = unwrapEmbed(row.author);
   return {
     id: row.id,
     content: row.content,
     userId: row.user_id,
     userName: row.user_name,
     userProfileImage: row.user_profile_image || '',
+    author: author
+      ? { nickname: author.nickname, profilePhotoURL: author.profile_photo_url }
+      : undefined,
     createdAt: createTimestamp(new Date(row.created_at)),
   };
 }

--- a/apps/web/src/comment/api/reply.ts
+++ b/apps/web/src/comment/api/reply.ts
@@ -109,7 +109,7 @@ export async function fetchRepliesFromSupabase(
 
   let q = supabase
     .from('replies')
-    .select('id, content, user_id, user_name, user_profile_image, created_at')
+    .select('id, content, user_id, user_name, user_profile_image, created_at, author:users!user_id(profile_photo_url, nickname)')
     .eq('comment_id', commentId)
     .order('created_at', { ascending: true });
 
@@ -124,14 +124,7 @@ export async function fetchRepliesFromSupabase(
     throw error;
   }
 
-  return (data || []).map((row) => ({
-    id: row.id,
-    content: row.content,
-    userId: row.user_id,
-    userName: row.user_name,
-    userProfileImage: row.user_profile_image || '',
-    createdAt: createTimestamp(new Date(row.created_at)),
-  }));
+  return (data || []).map(mapRowToReply);
 }
 
 /**
@@ -174,7 +167,7 @@ export async function fetchReplyByIdFromSupabase(
 
   const { data, error } = await supabase
     .from('replies')
-    .select('id, content, user_id, user_name, user_profile_image, created_at')
+    .select('id, content, user_id, user_name, user_profile_image, created_at, author:users!user_id(profile_photo_url, nickname)')
     .eq('id', replyId)
     .single();
 
@@ -185,12 +178,40 @@ export async function fetchReplyByIdFromSupabase(
     return null;
   }
 
+  return mapRowToReply(data);
+}
+
+interface AuthorEmbed {
+  profile_photo_url: string | null;
+  nickname: string | null;
+}
+
+interface ReplyRow {
+  id: string;
+  content: string;
+  user_id: string;
+  user_name: string;
+  user_profile_image: string | null;
+  created_at: string;
+  author?: AuthorEmbed | AuthorEmbed[] | null;
+}
+
+function unwrapEmbed<T>(embed: T | T[] | null | undefined): T | undefined {
+  if (!embed) return undefined;
+  return Array.isArray(embed) ? embed[0] : embed;
+}
+
+function mapRowToReply(row: ReplyRow): Reply {
+  const author = unwrapEmbed(row.author);
   return {
-    id: data.id,
-    content: data.content,
-    userId: data.user_id,
-    userName: data.user_name,
-    userProfileImage: data.user_profile_image || '',
-    createdAt: createTimestamp(new Date(data.created_at)),
+    id: row.id,
+    content: row.content,
+    userId: row.user_id,
+    userName: row.user_name,
+    userProfileImage: row.user_profile_image || '',
+    author: author
+      ? { nickname: author.nickname, profilePhotoURL: author.profile_photo_url }
+      : undefined,
+    createdAt: createTimestamp(new Date(row.created_at)),
   };
 }

--- a/apps/web/src/comment/components/CommentHeader.tsx
+++ b/apps/web/src/comment/components/CommentHeader.tsx
@@ -1,32 +1,52 @@
-import { getRelativeTime } from '@/shared/utils/dateUtils';
 import ComposedAvatar from '@/shared/ui/ComposedAvatar';
-import { getUserDisplayName } from '@/shared/utils/userUtils';
-import { WritingBadgeComponent } from '@/stats/components/WritingBadgeComponent';
-import { usePostProfileBadges } from '@/stats/hooks/usePostProfileBadges';
-import { useUser } from '@/user/hooks/useUser';
 import type { FirebaseTimestamp } from '@/shared/model/Timestamp';
+import { getRelativeTime } from '@/shared/utils/dateUtils';
+import { usePostProfileBadges } from '@/stats/hooks/usePostProfileBadges';
+import { WritingBadgeComponent } from '@/stats/components/WritingBadgeComponent';
+import type { CommentAuthor } from '@/comment/model/Comment';
 
 interface CommentHeaderProps {
   userId: string;
   createdAt?: FirebaseTimestamp;
+  /** Live author profile from the comments/replies JOIN. */
+  author?: CommentAuthor;
+  /** Snapshot fields used as fallback when author is unavailable. */
+  fallbackName: string;
+  fallbackProfileImage: string;
 }
 
-export function CommentHeader({ userId, createdAt }: CommentHeaderProps) {
-  const { userData: userProfile } = useUser(userId);
+function resolveDisplayName(author: CommentAuthor | undefined, fallback: string): string {
+  const liveNickname = author?.nickname?.trim();
+  if (liveNickname) return liveNickname;
+  const snapshot = fallback.trim();
+  return snapshot || '??';
+}
+
+function resolveProfileImage(author: CommentAuthor | undefined, fallback: string): string | undefined {
+  return author?.profilePhotoURL || fallback || undefined;
+}
+
+export function CommentHeader({
+  userId,
+  createdAt,
+  author,
+  fallbackName,
+  fallbackProfileImage,
+}: CommentHeaderProps) {
   const { data: badges } = usePostProfileBadges(userId);
+  const displayName = resolveDisplayName(author, fallbackName);
+  const profileImage = resolveProfileImage(author, fallbackProfileImage);
 
   return (
     <div className='flex items-center space-x-3'>
       <ComposedAvatar
         size={24}
-        src={userProfile?.profilePhotoURL || undefined}
-        alt={getUserDisplayName(userProfile) || 'User'}
-        fallback={getUserDisplayName(userProfile)?.[0] || '?'}
+        src={profileImage}
+        alt={displayName}
+        fallback={displayName[0] || '?'}
       />
       <div className='flex items-baseline gap-1.5'>
-        <span className='text-sm font-bold leading-none'>
-          {getUserDisplayName(userProfile)}
-        </span>
+        <span className='text-sm font-bold leading-none'>{displayName}</span>
         {badges?.map((badge) => (
           <WritingBadgeComponent key={badge.name} badge={badge} />
         ))}

--- a/apps/web/src/comment/components/CommentRow.tsx
+++ b/apps/web/src/comment/components/CommentRow.tsx
@@ -51,7 +51,13 @@ const CommentRow: React.FC<CommentRowProps> = ({
   return (
     <div className='flex flex-col space-y-3 pb-4'>
       <div className='flex items-center justify-between'>
-        <CommentHeader userId={comment.userId} createdAt={comment.createdAt} />
+        <CommentHeader
+          userId={comment.userId}
+          createdAt={comment.createdAt}
+          author={comment.author}
+          fallbackName={comment.userName}
+          fallbackProfileImage={comment.userProfileImage}
+        />
         {isAuthor && (
           <div className='flex items-center space-x-1'>
             <Button variant='ghost' size='icon' onClick={handleEditToggle} className='size-9'>

--- a/apps/web/src/comment/components/ReplyRow.tsx
+++ b/apps/web/src/comment/components/ReplyRow.tsx
@@ -43,7 +43,13 @@ const ReplyRow: React.FC<ReplyRowProps> = ({ boardId, reply, commentId, postId, 
   return (
     <div className='group flex flex-col space-y-3 pb-4'>
       <div className='flex items-center justify-between'>
-        <CommentHeader userId={reply.userId} createdAt={reply.createdAt} />
+        <CommentHeader
+          userId={reply.userId}
+          createdAt={reply.createdAt}
+          author={reply.author}
+          fallbackName={reply.userName}
+          fallbackProfileImage={reply.userProfileImage}
+        />
         {isAuthor && (
           <div className='flex items-center space-x-1'>
             <Button variant='ghost' size='icon' onClick={handleEditToggle} className='size-9'>

--- a/apps/web/src/comment/model/Comment.ts
+++ b/apps/web/src/comment/model/Comment.ts
@@ -1,11 +1,19 @@
 import type { FirebaseTimestamp } from '@/shared/model/Timestamp';
 
-// src/types/Comment.ts
+export interface CommentAuthor {
+  nickname: string | null;
+  profilePhotoURL: string | null;
+}
+
 export interface Comment {
   id: string;
   content: string;
   userId: string;
+  /** Snapshot of the author's name at comment-creation time. */
   userName: string;
+  /** Snapshot of the author's profile image at comment-creation time. */
   userProfileImage: string;
+  /** Live author profile joined from the users table; absent when the user row is unavailable. */
+  author?: CommentAuthor;
   createdAt: FirebaseTimestamp;
 }

--- a/apps/web/src/comment/model/Reply.ts
+++ b/apps/web/src/comment/model/Reply.ts
@@ -1,11 +1,15 @@
+import type { CommentAuthor } from '@/comment/model/Comment';
 import type { FirebaseTimestamp } from '@/shared/model/Timestamp';
 
-// Reply.ts
 export interface Reply {
   id: string;
   content: string;
   userId: string;
+  /** Snapshot of the author's name at reply-creation time. */
   userName: string;
+  /** Snapshot of the author's profile image at reply-creation time. */
   userProfileImage: string;
+  /** Live author profile joined from the users table; absent when the user row is unavailable. */
+  author?: CommentAuthor;
   createdAt: FirebaseTimestamp;
 }

--- a/apps/web/src/notification/components/NotificationItem.tsx
+++ b/apps/web/src/notification/components/NotificationItem.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import type { Notification } from '@/notification/model/Notification';
 import ComposedAvatar from '@/shared/ui/ComposedAvatar';
-import { useUser } from '@/user/hooks/useUser';
+import { useUserBasic } from '@/user/hooks/useUserBasic';
 
 interface NotificationItemProps {
   notification: Notification;
@@ -13,7 +13,7 @@ function getNotificationLink(notification: Notification): string {
 
 export const NotificationItem = ({ notification }: NotificationItemProps) => {
   const message = notification.message;
-  const { userData: deferredActor } = useUser(notification.fromUserId);
+  const { data: deferredActor } = useUserBasic(notification.fromUserId);
   const actorProfilePhoto =
     notification.fromUserProfileImage ?? deferredActor?.profilePhotoURL ?? undefined;
 

--- a/apps/web/src/notification/components/NotificationsPage.tsx
+++ b/apps/web/src/notification/components/NotificationsPage.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { NotificationsContent } from '@/notification/components/NotificationsContent';
 import { NotificationsErrorBoundary } from '@/notification/components/NotificationsErrorBoundary';
 import NotificationsHeader from '@/notification/components/NotificationsHeader';
+import { useNotificationActorPrefetch } from '@/notification/hooks/useNotificationActorPrefetch';
 import { useNotificationRefresh } from '@/notification/hooks/useNotificationRefresh';
 import { useNotifications } from '@/notification/hooks/useNotifications';
 import StatusMessage from '@/shared/components/StatusMessage';
@@ -37,6 +38,10 @@ const NotificationsPage = () => {
     hasNextPage,
     isFetchingNextPage,
   } = useNotifications(currentUser?.uid ?? null, NOTIFICATIONS_CONFIG.LIMIT_COUNT);
+
+  // ACTION - Warm the per-actor avatar cache in one IN-query so per-row
+  // useUserBasic calls hit the cache instead of firing N parallel requests.
+  useNotificationActorPrefetch(notifications);
 
   // ACTION - Notification refresh handler
   const { refresh: handleRefreshNotifications } = useNotificationRefresh({

--- a/apps/web/src/notification/hooks/useNotificationActorPrefetch.ts
+++ b/apps/web/src/notification/hooks/useNotificationActorPrefetch.ts
@@ -1,0 +1,51 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import type { Notification } from '@/notification/model/Notification';
+import { fetchBatchUsersBasic } from '@/user/api/userReads';
+import { mapBasicRowToUserBasic, userBasicQueryKey } from '@/user/hooks/useUserBasic';
+
+/**
+ * Prefetches the avatar/name cache for each notification's actor in a single
+ * IN-query, so per-row {@link useUserBasic} calls in NotificationItem hit the
+ * cache instead of firing N parallel single-row requests on cold cache.
+ *
+ * Runs as a post-render effect so the notifications LCP path is unaffected;
+ * worst case is the per-row requests still fire before this resolves, in
+ * which case they populate the same cache themselves.
+ */
+export function useNotificationActorPrefetch(notifications: Notification[]): void {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (notifications.length === 0) return;
+
+    const missingActorIds = collectMissingActorIds(notifications, (id) =>
+      queryClient.getQueryData(userBasicQueryKey(id)) !== undefined,
+    );
+    if (missingActorIds.length === 0) return;
+
+    let cancelled = false;
+    fetchBatchUsersBasic(missingActorIds)
+      .then((rows) => {
+        if (cancelled) return;
+        for (const row of rows) {
+          queryClient.setQueryData(userBasicQueryKey(row.id), mapBasicRowToUserBasic(row));
+        }
+      })
+      .catch(() => {
+        // Per-row useUserBasic queries remain as the fetch path of last resort.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [notifications, queryClient]);
+}
+
+function collectMissingActorIds(
+  notifications: Notification[],
+  isCached: (id: string) => boolean,
+): string[] {
+  const uniqueIds = new Set(notifications.map((n) => n.fromUserId).filter(Boolean));
+  return Array.from(uniqueIds).filter((id) => !isCached(id));
+}

--- a/apps/web/src/shared/hooks/useAvatarUrl.ts
+++ b/apps/web/src/shared/hooks/useAvatarUrl.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+import { getResizedUrl, isFirebaseStorageUrl, THUMB_SIZES } from '@/shared/utils/thumbnailUrl';
+
+// Resolves a Firebase Storage avatar URL to its 128x128 resized variant
+// (created by the Firebase Resize Images extension). Non-Firebase URLs
+// (e.g. Google OAuth, which uses the =s{size} param) pass through.
+// Falls back to the original URL when the resized variant is missing.
+export function useAvatarUrl(originalUrl: string | null | undefined): string | null {
+  const [url, setUrl] = useState<string | null>(originalUrl ?? null);
+
+  useEffect(() => {
+    if (!originalUrl) {
+      setUrl(null);
+      return;
+    }
+    setUrl(originalUrl);
+    if (!isFirebaseStorageUrl(originalUrl)) return;
+
+    let cancelled = false;
+    getResizedUrl(originalUrl, THUMB_SIZES.AVATAR).then((resolved) => {
+      if (!cancelled) setUrl(resolved);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [originalUrl]);
+
+  return url;
+}

--- a/apps/web/src/shared/ui/ComposedAvatar.tsx
+++ b/apps/web/src/shared/ui/ComposedAvatar.tsx
@@ -1,5 +1,6 @@
 import { User as UserIcon } from 'lucide-react';
 import type React from 'react';
+import { useAvatarUrl } from '@/shared/hooks/useAvatarUrl';
 import { cn } from '@/shared/utils/cn';
 import { Avatar, AvatarImage, AvatarFallback } from './avatar';
 
@@ -40,10 +41,10 @@ const ComposedAvatar: React.FC<ComposedAvatarProps> = ({
   loading = 'lazy',
   ...rest
 }) => {
-  // Firebase Storage URLs are now served at the correct size (256x256) because
-  // the upload pipeline pre-resizes via resizeImageBlob. Google avatar URLs still
-  // need the size hint because they come pre-sized from the OAuth provider.
-  const renderSrc = src ? (isGoogleAvatarUrl(src) ? appendGoogleAvatarSizeParam(src, size) : src) : '';
+  // Firebase Storage avatars resolve to the 128x128 resized variant via useAvatarUrl;
+  // Google OAuth avatars pass through and get the =s{size} hint instead.
+  const resolvedSrc = useAvatarUrl(src);
+  const renderSrc = resolvedSrc ? appendGoogleAvatarSizeParam(resolvedSrc, size) : '';
 
   return (
     <Avatar className={cn('ring-1 ring-black/10 dark:ring-white/10', className)} style={{ width: size, height: size }} {...rest}>

--- a/apps/web/src/shared/ui/ComposedAvatar.tsx
+++ b/apps/web/src/shared/ui/ComposedAvatar.tsx
@@ -11,6 +11,12 @@ interface ComposedAvatarProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: number; // px 단위, Tailwind size-9=36px
   className?: string;
   loading?: 'lazy' | 'eager';
+  /**
+   * Set to true for above-the-fold avatars (e.g. profile page header). Sets
+   * `loading="eager"` and `fetchPriority="high"` to skip lazy-loading and
+   * boost network priority for the first paint.
+   */
+  priority?: boolean;
 }
 
 // Hostname check (not substring): `url.includes('googleusercontent.com')` would
@@ -32,6 +38,12 @@ function appendGoogleAvatarSizeParam(url: string, size: number): string {
   return url;
 }
 
+function resolvePriorityAttrs(priority: boolean, loading: 'lazy' | 'eager') {
+  return priority
+    ? { loading: 'eager' as const, fetchPriority: 'high' as const }
+    : { loading, fetchPriority: undefined };
+}
+
 const ComposedAvatar: React.FC<ComposedAvatarProps> = ({
   src,
   alt = 'User',
@@ -39,16 +51,20 @@ const ComposedAvatar: React.FC<ComposedAvatarProps> = ({
   size = 36,
   className = '',
   loading = 'lazy',
+  priority = false,
   ...rest
 }) => {
   // Firebase Storage avatars resolve to the 128x128 resized variant via useAvatarUrl;
   // Google OAuth avatars pass through and get the =s{size} hint instead.
   const resolvedSrc = useAvatarUrl(src);
   const renderSrc = resolvedSrc ? appendGoogleAvatarSizeParam(resolvedSrc, size) : '';
+  const priorityAttrs = resolvePriorityAttrs(priority, loading);
 
   return (
     <Avatar className={cn('ring-1 ring-black/10 dark:ring-white/10', className)} style={{ width: size, height: size }} {...rest}>
-      {renderSrc && <AvatarImage src={renderSrc} alt={alt} loading={loading} decoding="async" />}
+      {renderSrc && (
+        <AvatarImage src={renderSrc} alt={alt} decoding="async" {...priorityAttrs} />
+      )}
       <AvatarFallback>
         {fallback ? fallback : <UserIcon className="size-3.5" />}
       </AvatarFallback>

--- a/apps/web/src/shared/utils/thumbnailUrl.ts
+++ b/apps/web/src/shared/utils/thumbnailUrl.ts
@@ -2,14 +2,11 @@
 //   This module encodes the Firebase Resize Images extension's filename convention
 //   `{base}_{width}x{height}.{ext}` (e.g., `photo.jpg` → `photo_600x338.jpg`).
 //
-//   Avatar rendering no longer uses this helper: the upload pipeline pre-resizes
-//   profile photos to 256x256 JPEG via `resizeImageBlob`, so the file at the
-//   download URL is already correctly sized. Avatars render `src` directly.
-//
-//   This helper remains for post-image use cases (PostCardThumbnail, PostCardContent).
-//   Any future server-side resize pipeline that wants to feed URLs through
-//   `useThumbnailUrl` MUST emit filenames matching the `{base}_{width}x{height}.{ext}`
-//   pattern, or `deriveThumbPath` will need to be refactored.
+//   Avatars consume the 128x128 variant via `useAvatarUrl`; post thumbnails consume
+//   the 600x338 variant via `useThumbnailUrl`. Any future server-side resize pipeline
+//   that wants to feed URLs through these hooks MUST emit filenames matching the
+//   `{base}_{width}x{height}.{ext}` pattern, or `deriveThumbPath` will need to be
+//   refactored.
 
 import { ref, getDownloadURL } from 'firebase/storage';
 import { storage } from '@/firebase';

--- a/apps/web/src/user/components/UserProfile.tsx
+++ b/apps/web/src/user/components/UserProfile.tsx
@@ -61,6 +61,7 @@ export default function UserProfile({ uid }: UserProfileProps) {
         src={userData.profilePhotoURL || undefined}
         alt={`${getUserDisplayName(userData)}'s profile`}
         fallback={getUserDisplayName(userData)?.charAt(0).toUpperCase()}
+        priority
       />
       <div className='min-w-0 flex-1'>
         <div className='flex items-center justify-between'>

--- a/apps/web/src/user/hooks/useUser.ts
+++ b/apps/web/src/user/hooks/useUser.ts
@@ -22,10 +22,12 @@ export function useUser(uid: string | null | undefined) {
         console.error('유저 데이터를 불러오던 중 에러가 발생했습니다:', error);
         Sentry.captureException(error);
       },
-      staleTime: 0,
-      cacheTime: 1000 * 60 * 10,
-      refetchOnMount: true,
-      refetchOnWindowFocus: true,
+      // Other users' profile data changes rarely; own-profile edits
+      // invalidate this key explicitly via useUpdateUserData.
+      staleTime: 5 * 60 * 1000,
+      cacheTime: 30 * 60 * 1000,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
     },
   );
 

--- a/apps/web/src/user/hooks/useUserBasic.ts
+++ b/apps/web/src/user/hooks/useUserBasic.ts
@@ -1,0 +1,57 @@
+import { useQuery } from '@tanstack/react-query';
+import { getSupabaseClient } from '@/shared/api/supabaseClient';
+import type { BasicUserRow } from '@/user/api/userReads';
+
+/**
+ * Lightweight subset of {@link User} used by surfaces that only need to render
+ * an avatar + display name (notifications, mentions, etc.). Distinct from the
+ * full `['user', uid]` cache so bulk-prefetch and full-profile reads don't
+ * clobber each other's cache shape.
+ */
+export interface UserBasic {
+  uid: string;
+  nickname: string | null;
+  realName: string | null;
+  profilePhotoURL: string | null;
+}
+
+export function userBasicQueryKey(uid: string | null | undefined) {
+  return ['userBasic', uid] as const;
+}
+
+export function mapBasicRowToUserBasic(row: BasicUserRow): UserBasic {
+  return {
+    uid: row.id,
+    nickname: row.nickname,
+    realName: row.real_name,
+    profilePhotoURL: row.profile_photo_url,
+  };
+}
+
+async function fetchUserBasic(uid: string): Promise<UserBasic | null> {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from('users')
+    .select('id, real_name, nickname, profile_photo_url')
+    .eq('id', uid)
+    .single();
+  if (error) {
+    if (error.code === 'PGRST116') return null;
+    throw error;
+  }
+  return data ? mapBasicRowToUserBasic(data as BasicUserRow) : null;
+}
+
+export function useUserBasic(uid: string | null | undefined) {
+  return useQuery<UserBasic | null>(
+    userBasicQueryKey(uid),
+    () => fetchUserBasic(uid as string),
+    {
+      enabled: !!uid,
+      staleTime: 5 * 60 * 1000,
+      cacheTime: 30 * 60 * 1000,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+    },
+  );
+}

--- a/docs/plans/2026-06-05-profile-thumbnail-loading-optimization.md
+++ b/docs/plans/2026-06-05-profile-thumbnail-loading-optimization.md
@@ -1,0 +1,332 @@
+# Profile/Thumbnail Image Loading Optimization — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Each task is a separate commit. Verify before moving on.
+
+**Goal:** Apply the top-5 highest-impact items from the profile/thumbnail image loading audit to reduce initial loading time and eliminate refetch storms — without regressions to existing UX.
+
+**Architecture:** Five independent changes against `apps/web/src/`. None require schema migrations. Changes #1, #3, #4 reduce bytes/RTTs; #2 cuts refetch waste; #5 fixes top-of-fold lazy-loading. Each is independently revertable.
+
+**Tech Stack:** React 18 + TanStack Query v4 + Firebase Storage (with Resize Images extension) + Supabase Postgres + TypeScript + Vite.
+
+**Related issue:** [#621 — BoardPage thumbnail 404 console noise](https://github.com/BumgeunSong/daily-writing-friends/issues/621). Task 1 introduces the same 404→fallback pattern for avatars. The existing `getResizedUrl` already handles this safely (try/catch + null-cache), but expect transient console noise for pre-extension avatars until backfill runs.
+
+---
+
+## Pre-flight (one-time)
+
+- Current branch is `profile/thumbnail-image-loading-optimization` (worktree). All work commits here.
+- `pnpm typecheck` and `pnpm test` must pass after each task.
+- `pnpm dev` smoke test (board feed + open a post + notifications page) before committing each task.
+
+---
+
+## Task 1: Route avatars through `getResizedUrl` (128×128 variant)
+
+**Why:** Avatars upload at 256×256 but render at 24–80px. The Firebase Resize Images extension's `128x128` variant is already configured (`THUMB_SIZES.AVATAR`) and `getAvatarUrl` helper already exists — they're just not wired to `ComposedAvatar`.
+
+**Impact:** ~4× fewer decoded pixels per avatar (256² → 128²). Halved decoded RAM. ~5–10 KB → ~2–3 KB on the wire per first-time fetch.
+
+**Files:**
+- Create: `apps/web/src/shared/hooks/useAvatarUrl.ts`
+- Modify: `apps/web/src/shared/ui/ComposedAvatar.tsx`
+- Modify: `apps/web/src/shared/utils/thumbnailUrl.ts` (comment update at line 4-7)
+
+**Step 1.1 — Create `useAvatarUrl` hook**
+
+Mirror `useThumbnailUrl` but pin to `THUMB_SIZES.AVATAR`. Skip the lookup for Google avatar URLs (they're not Firebase Storage; they use `=s{size}` param instead). Return the input URL synchronously, then upgrade after async resolution.
+
+```ts
+// apps/web/src/shared/hooks/useAvatarUrl.ts
+import { useState, useEffect } from 'react';
+import { getResizedUrl, isFirebaseStorageUrl, THUMB_SIZES } from '@/shared/utils/thumbnailUrl';
+
+export function useAvatarUrl(originalUrl: string | null | undefined): string | null {
+  const [url, setUrl] = useState<string | null>(originalUrl ?? null);
+
+  useEffect(() => {
+    if (!originalUrl) {
+      setUrl(null);
+      return;
+    }
+    setUrl(originalUrl);
+    if (!isFirebaseStorageUrl(originalUrl)) return;
+
+    let cancelled = false;
+    getResizedUrl(originalUrl, THUMB_SIZES.AVATAR).then((resolved) => {
+      if (!cancelled) setUrl(resolved);
+    });
+    return () => { cancelled = true; };
+  }, [originalUrl]);
+
+  return url;
+}
+```
+
+**Step 1.2 — Wire `ComposedAvatar` through the hook**
+
+In `ComposedAvatar.tsx`:
+- Import `useAvatarUrl`.
+- Replace the `renderSrc` derivation: first run `src` through `useAvatarUrl`, then apply the Google `=s{size}` param to the result.
+
+```ts
+const resolvedSrc = useAvatarUrl(src);
+const renderSrc = resolvedSrc
+  ? (isGoogleAvatarUrl(resolvedSrc) ? appendGoogleAvatarSizeParam(resolvedSrc, size) : resolvedSrc)
+  : '';
+```
+
+**Step 1.3 — Update the stale comment in `thumbnailUrl.ts`**
+
+Lines 4-7 currently say "Avatar rendering no longer uses this helper" — that becomes false after this task. Replace with a one-liner pointing at `useAvatarUrl`.
+
+**Step 1.4 — Verify**
+
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm dev` → load board feed, open a post detail, open notifications. Avatars still render. Expect transient `_128x128.jpg` 404s in console for older uploads (issue #621 dynamic — pre-existing for post thumbnails). Confirm fallback works (no broken images).
+- DevTools Network tab: filter by `_128x128.jpg`. First-time loads should be ~2–4 KB; subsequent renders served from disk cache.
+
+**Step 1.5 — Commit**
+
+```
+perf(avatars): route ComposedAvatar through 128x128 resized variant
+
+Wire avatars through getResizedUrl(THUMB_SIZES.AVATAR) via a new
+useAvatarUrl hook. Avatars now decode at 128x128 instead of 256x256
+(~4x fewer decoded pixels per render), with graceful fallback to the
+original URL when the resized variant is missing (same pattern as
+useThumbnailUrl, see issue #621).
+
+Google OAuth avatar URLs bypass the lookup since they use the =s
+size parameter instead.
+```
+
+---
+
+## Task 2: Tune `useUser` staleTime and refetch defaults
+
+**Why:** `useUser` has `staleTime: 0` and `refetchOnWindowFocus: true`. With 12 consumer sites (`CommentHeader`, `NotificationItem`, `UserProfile`, etc.) and N comments/notifications per screen, every tab focus triggers an O(N) refetch wave. Other users' profile data changes rarely.
+
+**Impact:** Eliminates a quiet refetch storm. No user-visible UX change for the common case (cache stays warm 5 min); editing your own profile still reflects immediately because `useEditAccount.ts` invalidates the cache directly on mutation.
+
+**Files:**
+- Modify: `apps/web/src/user/hooks/useUser.ts:25-28`
+
+**Step 2.1 — Verify own-profile mutation invalidates the cache**
+
+Read `apps/web/src/user/hooks/useEditAccount.ts`. Confirm it calls `queryClient.invalidateQueries(['user', uid])` (or `setQueryData`) on success. If yes, staleTime can safely move. If not, we need to add invalidation as part of this task before bumping staleTime.
+
+**Step 2.2 — Apply the staleTime / refetch changes**
+
+```ts
+// useUser.ts:25-28
+staleTime: 5 * 60 * 1000,        // 5 min: other users' profile data changes rarely
+cacheTime: 30 * 60 * 1000,       // 30 min: keep in memory longer to absorb tab switches
+refetchOnMount: false,            // staleTime governs; don't refetch on every mount
+refetchOnWindowFocus: false,      // refetch storm on tab focus is wasted work
+```
+
+**Step 2.3 — Verify**
+
+- `pnpm typecheck`
+- `pnpm test` (especially anything under `user/__tests__/`)
+- `pnpm dev`:
+  - Open Network tab. Visit /board → notifications → /board again. Confirm no `users` query refires on tab switch.
+  - Edit your own avatar via EditAccountPage. Confirm new avatar appears immediately in PostCard / CommentHeader (means invalidation works).
+
+**Step 2.4 — Commit**
+
+```
+perf(user): raise useUser staleTime to 5min and disable refetch-on-focus
+
+Other users' profile data changes rarely; refetching on every mount
+and every window focus was N refetches per screen of comments or
+notifications. Cuts background traffic without affecting the
+own-profile-edit path, which invalidates the cache explicitly.
+```
+
+---
+
+## Task 3: Eliminate N+1 in CommentHeader by joining author profile
+
+**Why:** Every `CommentHeader` calls `useUser(userId)`. 20 comments visible = 20 parallel `useUser` hooks, each potentially firing an HTTP request on cold cache.
+
+**Impact:** 1 RTT instead of N (cold cache). Even on warm cache (post-Task-2), drops 20 query subscriptions per comment list.
+
+**Files:**
+- Modify: comment fetch API (likely `apps/web/src/comment/api/comment.ts` — exact path TBD during execution)
+- Modify: `apps/web/src/comment/model/Comment.ts` — add `authorProfileImageURL?: string` (and `authorName` if not already present)
+- Modify: `apps/web/src/comment/components/CommentHeader.tsx:15` — remove `useUser`, take URL + name from props
+
+**Step 3.1 — Locate and read the comment fetch query**
+
+```bash
+rg -n "from\\('?comments'?\\)|fetchComments|useComments" apps/web/src/comment --type ts --type tsx
+```
+
+Identify the query (it's likely a Supabase `select` similar to the posts query in `post/api/post.ts:91`).
+
+**Step 3.2 — Extend the Supabase select with the author join**
+
+Mirror the posts pattern: `users!author_id(profile_photo_url, nickname)` (column name TBD by inspection — adjust to match the comments FK name).
+
+**Step 3.3 — Map joined row to Comment model**
+
+Add a `mapRowToComment` helper (or extend the existing one) that flattens `users.profile_photo_url` → `comment.authorProfileImageURL`.
+
+**Step 3.4 — Update CommentHeader to consume the field**
+
+```ts
+// CommentHeader.tsx
+// Before: const { userData: userProfile } = useUser(userId);
+// After: take authorName + authorProfileImageURL from props (sourced from the comment row).
+```
+
+If `CommentHeader` is used in places that don't pass a full comment row (e.g. CommentForm preview), keep `useUser` as a fallback or pass the current-user's profile in directly.
+
+**Step 3.5 — Verify**
+
+- `pnpm typecheck`
+- `pnpm test` (comment-related tests)
+- `pnpm dev`: open a post with comments. DevTools Network: confirm one comments fetch instead of N+1. Avatars + names still render correctly. Test posting a new comment — the optimistic / refetched comment should still have author info.
+
+**Step 3.6 — Commit**
+
+```
+perf(comments): denormalize author profile into comments fetch (no N+1)
+
+Replace per-row useUser in CommentHeader with author fields embedded
+in the comments query via PostgREST nested select. Eliminates one
+query per comment (was N parallel useUser hooks per visible page).
+Mirrors the existing pattern in post/api/post.ts:91 for feed authors.
+```
+
+---
+
+## Task 4: Bulk-prime user cache for notifications instead of per-row `useUser`
+
+**Why:** After commit `ff1a21ca`, each `NotificationItem` runs its own `useUser(fromUserId)` post-LCP. With 10 notifications and cold cache, that's up to 10 parallel requests right after first paint.
+
+**Impact:** 1 IN-query instead of up to N. Keeps the LCP path clean (notifications query still has no profile JOIN — fires after notifications have rendered). `NotificationItem` doesn't need to change; it just gets warm cache.
+
+**Files:**
+- Modify: `apps/web/src/notification/hooks/useNotifications.ts` (or whichever hook orchestrates the page) — add a follow-up bulk prefetch
+- Use existing `fetchBatchUsersBasic` (already used by `useBatchPostCardData`)
+
+**Step 4.1 — Locate the notifications page composition**
+
+```bash
+rg -n "useNotifications|NotificationItem" apps/web/src/notification --type ts --type tsx
+```
+
+Find the parent component / hook that has the full notifications array. That's where we prime the cache.
+
+**Step 4.2 — Implement bulk prime**
+
+After notifications resolve, derive `uniqueFromUserIds`, fire one `fetchBatchUsersBasic` call, then `queryClient.setQueryData(['user', id], userMap.get(id))` for each. `NotificationItem`'s `useUser` calls then hit the prefilled cache (staleTime from Task 2 will keep it warm).
+
+Implementation sketch:
+
+```ts
+// In the parent (after notifications data loads):
+const queryClient = useQueryClient();
+useEffect(() => {
+  if (!notifications?.length) return;
+  const ids = [...new Set(notifications.map(n => n.fromUserId).filter(Boolean))];
+  const missing = ids.filter(id => !queryClient.getQueryData(['user', id]));
+  if (!missing.length) return;
+  fetchBatchUsersBasic(missing).then((users) => {
+    users.forEach(u => queryClient.setQueryData(['user', u.uid], u));
+  });
+}, [notifications, queryClient]);
+```
+
+**Step 4.3 — Verify**
+
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm dev`: open notifications page on cold cache (hard reload). DevTools Network: expect one `users?id=in.(...)` request shortly after the notifications query, replacing the N parallel per-row requests. Avatars populate at roughly the same time as before.
+- Cross-check with [[feedback_perf_research_first]] mindset: this should be a measurable LCP-neutral, post-LCP-traffic-reducing change. Capture before/after timing in DevTools.
+
+**Step 4.4 — Commit**
+
+```
+perf(notifications): bulk-prime user cache instead of per-row useUser
+
+After notifications load (post-LCP), fire one fetchBatchUsersBasic
+to prime ['user', id] entries for all senders. Replaces up to N
+parallel per-row useUser requests with a single IN-query. Keeps
+the LCP path unchanged — the bulk prime runs after notifications
+render, not before.
+```
+
+---
+
+## Task 5: `eager` + `fetchpriority` for above-the-fold avatars
+
+**Why:** `ComposedAvatar` defaults `loading="lazy"`, including for first-viewport avatars. Lazy-loading the first viewport delays paint past LCP.
+
+**Impact:** Modest but free. Most LCP elements aren't avatars in this app (feed thumbnail or post hero), but lazy-loading an avatar that the browser was about to paint adds an IntersectionObserver round-trip.
+
+**Files:**
+- Modify: `apps/web/src/shared/ui/ComposedAvatar.tsx` — add optional `priority` prop
+- Modify: 1–2 consumer sites where the avatar is reliably above-the-fold (e.g., `UserProfile.tsx` for the profile page header, the *first* `PostCard` in `BoardPage` if easy to express)
+
+**Step 5.1 — Add `priority` prop to `ComposedAvatar`**
+
+```ts
+interface ComposedAvatarProps extends React.HTMLAttributes<HTMLDivElement> {
+  // ...existing
+  priority?: boolean; // top-of-fold; eager + fetchpriority=high
+}
+
+// In the component:
+loading={priority ? 'eager' : loading}
+fetchpriority={priority ? 'high' : undefined}
+```
+
+Note: `fetchpriority` is camelCase in JSX (`fetchPriority`) in React 18+. Confirm by reading the existing PostCardThumbnail or running a typecheck.
+
+**Step 5.2 — Apply `priority` to ProfilePage header**
+
+`UserProfile.tsx:58` renders the 80×80 profile avatar — that's always above-the-fold on the profile page. Pass `priority`.
+
+**Step 5.3 — Skip the feed for now**
+
+Don't try to mark "first N feed avatars" as priority — virtual scrolling and SSR-skeleton make this fragile, and the avatar isn't the LCP element on the feed (the thumbnail is). Document this decision in the commit message so it's not revisited.
+
+**Step 5.4 — Verify**
+
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm dev`: open a profile page. DevTools Network: avatar request fires immediately (not deferred by IntersectionObserver). DevTools Performance recording: avatar paint shifts earlier in the timeline.
+
+**Step 5.5 — Commit**
+
+```
+perf(avatar): add priority prop for above-the-fold avatars
+
+ComposedAvatar now accepts a priority boolean that sets
+loading="eager" and fetchpriority="high". Applied to the profile
+page header avatar, which is always above-the-fold. Feed avatars
+intentionally stay lazy — the LCP element is the post thumbnail,
+not the avatar, and virtual scrolling makes a "first N eager"
+heuristic fragile.
+```
+
+---
+
+## Post-implementation
+
+- Open a PR. Title: `perf(profile-thumbnails): apply top-5 image loading optimizations`.
+- Body: link to this plan + audit summary + before/after notes on what to expect in DevTools Network for the reviewer to verify.
+- Optionally trigger the Web Vitals harness loop to confirm no regression on the headline metric.
+
+## What we explicitly skipped (and why)
+
+- **AVIF / `<picture>`** — Overkill for sub-100px avatars per audit research.
+- **`srcset` with `w` descriptors** — Avatars render at fixed CSS size; browser can pick wrong density.
+- **BlurHash / LQIP** — Imperceptible at 36–48px; initials fallback already exists.
+- **Service worker for avatars** — HTTP cache + `cacheControl: 30d` already covers ~95%.
+- **`?v={updated_at}` cache busting** — Firebase tokens already bust cache on avatar replacement (accidental but functional).
+- **Backfilling the `128x128` Firebase Resize variants for old avatars** — Operational task, outside this code change. Track via issue #621 follow-up.


### PR DESCRIPTION
## Summary

Applies the top-5 highest-impact items from the profile/thumbnail image loading audit. Each item is an independent commit so reviewers (and bisect) can isolate changes.

1. **`f86e15d9` Avatars route through the 128×128 resized variant** — new `useAvatarUrl` hook wires `ComposedAvatar` through the Firebase Resize Images extension. ~4× fewer decoded pixels per render (256² → 128²). Fallback to the original URL when the variant is missing (same try/catch + null-cache pattern as `useThumbnailUrl`; see #621).
2. **`2c89e4a4` `useUser` staleTime 0 → 5 min, no refetch-on-focus** — cuts a refetch storm on every tab focus across all `useUser` consumers (comments, notifications, profile). Own-profile edits still reflect immediately via `useUpdateUserData`'s explicit `invalidateQueries(['user', uid])`.
3. **`07fa0da8` Comments + replies fetch denormalize author via PostgREST JOIN** — `users!user_id(profile_photo_url, nickname)` embedded in the comments/replies select. `CommentHeader` drops per-row `useUser`; takes author + fallback snapshot fields as props. Mirrors the existing pattern in `post/api/post.ts:91`. Falls back to historical `user_name`/`user_profile_image` if the joined user row is unavailable.
4. **`58427cb7` Notifications: bulk-prime `userBasic` cache** — new lightweight `useUserBasic` hook (separate cache key `['userBasic', uid]`) replaces `useUser` in `NotificationItem`. New `useNotificationActorPrefetch` fires one `fetchBatchUsersBasic` IN-query after notifications load, priming the cache so per-row reads hit warm cache instead of firing N parallel single-row requests on cold cache.
5. **`40927664` `priority` prop on `ComposedAvatar`** — adds `loading="eager"` + `fetchPriority="high"` for above-the-fold avatars. Applied to the profile page header avatar.

Plan + audit findings: `docs/plans/2026-06-05-profile-thumbnail-loading-optimization.md` (commit `f0ca534a`).

### Notes for reviewers
- **Schema vs UX tension** in comments: the schema marks `user_name`/`user_profile_image` as "Historical Identity" but the existing UX showed live data via `useUser`. We kept the UX (live JOIN) and demoted the row fields to fallback. Worth a follow-up to either reword the schema comment or actually freeze the snapshot in mutations.
- **404 console noise** from Task 1 for avatars uploaded before the `128x128` variant was active. The fallback works (avatar still renders), but the browser logs the 4xx. Same shape as #621 for post thumbnails. Per user decision, no backfill — old avatars converge naturally as users update their profiles.
- **Separate cache key in Task 4** (`['userBasic', uid]`) is on purpose so the partial shape doesn't clobber the full `User` shape consumed by `UserProfile` and `EditAccountPage`.

### Deployment
Firebase Resize Images extension is already deployed with `IMG_SIZES=600x338,128x128` (confirmed in console). No infrastructure action needed to ship.

## Test Plan

Manual smoke (after merging or against this branch):

- [ ] `/board/:id` — Network filter `_128x128.jpg`: avatars hit the resized variant; transient 404s for pre-extension avatars fall back to original without breaking. Tab away + back: no refetch storm on `users?`.
- [ ] `/post/:id` (with comments) — Network filter `comments`: one query with `author:users!user_id(...)` in the select; no N parallel `users?id=eq.*` follow-ups.
- [ ] `/notifications` (cold cache) — Network: one `notifications?` then one `users?id=in.(...)` IN-query (no N parallel `users?id=eq.*`).
- [ ] `/user/:uid` — Network: profile-header avatar has Priority: High, no `loading="lazy"` attribute.
- [ ] Edit own profile → save → confirm new nickname/avatar appears immediately on your own posts/comments (proves `useUpdateUserData` invalidation still works).

Automated:
- [x] `pnpm type-check` clean
- [x] `pnpm test:run` — 807/808 pass (the one failure on `supabaseClient.test.ts > executeTrackedWrite slow-write breadcrumb` is pre-existing on `main`, unrelated)
- [x] `npx eslint` clean on touched files