### PR TITLE
fix(vite): don't drop console/debugger in test mode

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -89,9 +89,12 @@ export default defineConfig(({ mode }) => {
       modulePreload: { polyfill: false },
     },
     esbuild: {
-      // 119 console.* call sites in src/. Drop them in the build output so they
-      // don't ship to production (Sentry already captures error context).
-      drop: ['console', 'debugger'],
+      // 119 console.* call sites in src/. Drop them in the production build so
+      // they don't ship to users (Sentry already captures error context).
+      // Skip in non-production modes so Vitest can transform source with
+      // console.* intact — otherwise tests that assert on console output
+      // (e.g. executeTrackedWrite slow-write warning) silently never fire.
+      drop: isProduction ? ['console', 'debugger'] : [],
     },
     test: {
       globals: true,


### PR DESCRIPTION
## Problem

`apps/web/vite.config.ts` sets `esbuild.drop: ['console', 'debugger']` **unconditionally**. esbuild removes those call sites at transform time — including the transforms Vitest uses to load source under test. So any test that spies on `console.*` to verify the production code emitted it can never see the call: it was already gone when the spy was installed.

This has been failing CI on `main` and on every PR that runs Vitest:

```
FAIL  src/shared/api/supabaseClient.test.ts
  > executeTrackedWrite > adds slow-write warning breadcrumb and console.warn when operation exceeds threshold
  AssertionError: expected "warn" to be called with arguments: [ StringContaining{…} ]
  Number of calls: 0
```

Verified by direct instrumentation in `supabaseClient.test.ts`:
- `globalThis.console.warn === window.console.warn === consoleSpy` → all the same reference
- `Date.now() - startTime` measured **1101ms** → production code entered the `if (durationMs >= SLOW_WRITE_THRESHOLD_MS)` branch
- `addSentryBreadcrumb` mock observed both the start and the slow-write call → branch did execute
- But `consoleSpy.mock.calls.length` was **0** → the `console.warn(...)` call was stripped from the transformed source

## Fix

Scope `drop` to production only:

```diff
 esbuild: {
-  drop: ['console', 'debugger'],
+  drop: isProduction ? ['console', 'debugger'] : [],
 },
```

`mode === 'production'` (vite build for production) still drops console.* → user bundle size and behavior unchanged. `mode === 'test'` (Vitest) and `mode === 'development'` (dev server) preserve console.* so:
- Tests can spy on `console.warn` / `console.error`
- The dev console behaves as expected during local dev

## Verification

- `pnpm --filter web vitest run` — **808/808** pass after the fix (was 803/808 before)
- The previously failing `executeTrackedWrite > slow-write warning` test now passes (verified at `apps/web/src/shared/api/supabaseClient.test.ts:238`)

## Test plan

- [x] Full Vitest suite passes
- [ ] Reviewer confirms production build output is unchanged