### PR TITLE
fix(e2e): notify 트리거의 NULL url 로 comments INSERT 가 23502 로 abort되던 문제 해소

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -15,3 +15,12 @@ VALUES (
   now()
 )
 ON CONFLICT (id) DO NOTHING;
+
+-- Seed app_config so the notify_on_* triggers don't enqueue a row with NULL url.
+-- notify_on_comment/reply/like/reaction build `net.http_post(url := get_app_config('edge_function_url') || '/create-notification', ...)`.
+-- With an empty app_config table, that concatenation is NULL, and pg_net's http_request_queue.url is NOT NULL —
+-- the trigger raises 23502 and aborts the parent INSERT (e.g. inserting a comment), which broke comment-flow.spec.ts in CI.
+-- The local edge runtime is excluded from `supabase start` in CI, so delivery just fails silently; the parent INSERT commits.
+INSERT INTO public.app_config (key, value) VALUES
+  ('edge_function_url', 'http://127.0.0.1:54321/functions/v1')
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Problem

PR #637 e2e 가 `comment-flow.spec.ts > write a comment and verify it appears` 에서 실패. 댓글 POST 가 **400 Bad Request, code 23502** 로 거부됨:

\`\`\`
null value in column "url" of relation "http_request_queue" violates not-null constraint
\`\`\`

[CI 실패 링크](https://github.com/BumgeunSong/daily-writing-friends/actions/runs/27144861138/job/80119681093) — 이번 주에 PR #640 rebase 이후 다른 브랜치(rn-prep/phase-1-decouple, private-freewriting…) e2e 도 같은 종류로 빨개짐.

## Root cause

`notify_on_comment` 트리거 (`supabase/migrations/20260505000001_fix_notify_triggers_security_definer.sql:34`):

\`\`\`sql
PERFORM net.http_post(
  url := get_app_config('edge_function_url') || '/create-notification',
  ...
);
\`\`\`

CI 에서는 `supabase start` 직후 `app_config` 테이블이 **비어 있음** → `get_app_config('edge_function_url')` returns NULL → `NULL || '/create-notification'` = NULL → pg_net 의 `http_request_queue.url` 은 NOT NULL → 23502 → 부모 `comments` INSERT 가 abort 됨.

앱 코드는 그 에러를 `Comments.tsx:65` 에서 silent catch 하고 textarea 만 비우므로, 테스트는 "댓글 영역에 새 댓글이 안 보임" 으로 fail.

## Fix

`supabase/seed.sql` 에 `edge_function_url` 한 줄을 추가. 로컬 edge-runtime 은 `supabase start --exclude edge-runtime` 로 어차피 꺼져 있어서 url 은 dummy(127.0.0.1) 면 충분: `net.http_post` 는 비동기 큐만 채우면 부모 INSERT 가 커밋되고 webhook delivery 는 그냥 connection refused 로 끝남.

## Verification

로컬 Supabase 로 end-to-end 확인:

| 단계 | 결과 |
|---|---|
| 빈 app_config 상태에서 service_role 로 comments INSERT | **HTTP 400, code 23502** (CI 와 동일 메시지) |
| 새 seed (`INSERT INTO app_config ('edge_function_url', ...)`) 적용 | HTTP 201 |
| 동일 INSERT 재시도 | **HTTP 201** |

## Test plan

- [x] 로컬 Supabase 에서 23502 재현
- [x] seed 적용 후 동일 INSERT 가 201 로 성공
- [ ] 이 PR e2e 가 green 인지 확인
- [ ] 머지 후 PR #637 rebase → e2e green 확인