### PR TITLE
fix: 프리라이팅 타이머가 입력 중 일시정지되는 문제 해결

### DIFF
--- a/apps/web/src/post/components/EditorTiptap.tsx
+++ b/apps/web/src/post/components/EditorTiptap.tsx
@@ -13,6 +13,7 @@ interface EditorTiptapProps {
   initialHtml?: string;
   initialJson?: ProseMirrorDoc;
   onChange: (output: { html: string; json: ProseMirrorDoc }) => void;
+  onTyping?: () => void;
   placeholder?: string;
   onUploadingChange?: (isUploading: boolean) => void;
 }
@@ -26,12 +27,13 @@ export interface EditorTiptapHandle {
  * A rich text editor with image upload support and responsive toolbar
  */
 export const EditorTiptap = forwardRef<EditorTiptapHandle, EditorTiptapProps>(
-  ({ initialHtml, initialJson, onChange, placeholder = '내용을 입력하세요...', onUploadingChange }, ref) => {
+  ({ initialHtml, initialJson, onChange, onTyping, placeholder = '내용을 입력하세요...', onUploadingChange }, ref) => {
     // Initialize editor with custom configuration
     const editor = useTiptapEditor({
       initialHtml,
       initialJson,
       onChange,
+      onTyping,
       placeholder,
     });
 

--- a/apps/web/src/post/components/PostEditor.tsx
+++ b/apps/web/src/post/components/PostEditor.tsx
@@ -4,6 +4,7 @@ import { EditorTiptap } from './EditorTiptap';
 interface PostEditorProps {
   value: string;
   onChange: (value: string) => void;
+  onTyping?: () => void;
   placeholder?: string;
   onUploadingChange?: (isUploading: boolean) => void;
   onContentJsonChange?: (json: ProseMirrorDoc) => void;
@@ -12,6 +13,7 @@ interface PostEditorProps {
 export function PostEditor({
   value,
   onChange,
+  onTyping,
   placeholder,
   onUploadingChange,
   onContentJsonChange,
@@ -23,6 +25,7 @@ export function PostEditor({
         onChange(html);
         onContentJsonChange?.(json);
       }}
+      onTyping={onTyping}
       placeholder={placeholder}
       onUploadingChange={onUploadingChange}
     />

--- a/apps/web/src/post/components/PostFreewritingPage.tsx
+++ b/apps/web/src/post/components/PostFreewritingPage.tsx
@@ -1,8 +1,9 @@
 import { Loader2 } from "lucide-react"
-import { useState, useRef, useEffect, useCallback } from "react"
+import { useState, useCallback } from "react"
 import { useParams, useNavigate, useLocation } from "react-router-dom"
 import { toast } from "sonner"
 import { PostVisibility } from '@/post/model/Post'
+import { useTypingPresence } from '@/post/hooks/useTypingPresence'
 import { prependTopicToContent } from '@/post/utils/freewritingContentUtils'
 import { createPost } from '@/post/utils/postUtils'
 import { useAuth } from '@/shared/hooks/useAuth'
@@ -38,10 +39,12 @@ export default function PostFreewritingPage() {
   const postTitle = userNickname ? `${userNickname}님의 프리라이팅` : "프리라이팅"
   const [content, setContent] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [timerStatus, setTimerStatus] = useState<WritingStatus>(WritingStatus.Paused)
   const [hasReachedTargetTime, setHasReachedTargetTime] = useState(false)
 
-  const typingPauseTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const { isTyping, ping: handleTyping } = useTypingPresence({
+    idleDelay: TYPING_PAUSE_DELAY_IN_MILLISECONDS,
+  })
+  const timerStatus = isTyping ? WritingStatus.Writing : WritingStatus.Paused
 
   const handleTargetTimeReached = useCallback(() => {
     setHasReachedTargetTime(true)
@@ -50,24 +53,7 @@ export default function PostFreewritingPage() {
 
   const handleContentChange = (updatedContent: string) => {
     setContent(updatedContent)
-    setTimerStatus(WritingStatus.Writing)
-
-    if (typingPauseTimeoutRef.current) {
-      clearTimeout(typingPauseTimeoutRef.current)
-    }
-
-    typingPauseTimeoutRef.current = setTimeout(() => {
-      setTimerStatus(WritingStatus.Paused)
-    }, TYPING_PAUSE_DELAY_IN_MILLISECONDS)
   }
-
-  useEffect(() => {
-    return () => {
-      if (typingPauseTimeoutRef.current) {
-        clearTimeout(typingPauseTimeoutRef.current)
-      }
-    }
-  }, [])
 
   const handleSubmit = async (e?: React.FormEvent) => {
     e?.preventDefault()
@@ -156,6 +142,7 @@ export default function PostFreewritingPage() {
           <PostEditor
             value={content}
             onChange={handleContentChange}
+            onTyping={handleTyping}
           />
         </form>
       </div>

--- a/apps/web/src/post/hooks/__tests__/useTypingPresence.test.ts
+++ b/apps/web/src/post/hooks/__tests__/useTypingPresence.test.ts
@@ -1,0 +1,81 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useTypingPresence } from '../useTypingPresence';
+
+describe('useTypingPresence', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stays typing through continuous pings shorter than idleDelay', () => {
+    const { result } = renderHook(() => useTypingPresence({ idleDelay: 2000 }));
+
+    for (let i = 0; i < 30; i++) {
+      act(() => {
+        result.current.ping();
+        vi.advanceTimersByTime(100);
+      });
+    }
+
+    expect(result.current.isTyping).toBe(true);
+  });
+
+  it('goes idle after idleDelay passes with no ping', () => {
+    const { result } = renderHook(() => useTypingPresence({ idleDelay: 2000 }));
+
+    act(() => {
+      result.current.ping();
+    });
+    expect(result.current.isTyping).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.isTyping).toBe(false);
+  });
+
+  it('resets the idle countdown on each ping', () => {
+    const { result } = renderHook(() => useTypingPresence({ idleDelay: 2000 }));
+
+    act(() => {
+      result.current.ping();
+    });
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(result.current.isTyping).toBe(true);
+
+    act(() => {
+      result.current.ping();
+    });
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(result.current.isTyping).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.isTyping).toBe(false);
+  });
+
+  it('clears the pending timeout on unmount', () => {
+    const { result, unmount } = renderHook(() =>
+      useTypingPresence({ idleDelay: 2000 }),
+    );
+
+    act(() => {
+      result.current.ping();
+    });
+
+    unmount();
+
+    expect(() => {
+      vi.advanceTimersByTime(5000);
+    }).not.toThrow();
+  });
+});

--- a/apps/web/src/post/hooks/useTiptapEditor.ts
+++ b/apps/web/src/post/hooks/useTiptapEditor.ts
@@ -18,6 +18,12 @@ interface UseTiptapEditorProps {
   initialHtml?: string;
   initialJson?: ProseMirrorDoc;
   onChange: (output: { html: string; json: ProseMirrorDoc }) => void;
+  /**
+   * Fired synchronously on every editor update (per keystroke), bypassing
+   * onChange's debounce. Use this for typing-presence signals that must not
+   * wait for the user to pause.
+   */
+  onTyping?: () => void;
   placeholder?: string;
   debounceDelay?: number;
 }
@@ -30,10 +36,15 @@ export function useTiptapEditor({
   initialHtml,
   initialJson,
   onChange,
+  onTyping,
   placeholder = DEFAULT_PLACEHOLDER,
   debounceDelay = DEFAULT_DEBOUNCE_DELAY,
 }: UseTiptapEditorProps) {
   const debounceTimerRef = useRef<NodeJS.Timeout>();
+  const onTypingRef = useRef(onTyping);
+  useEffect(() => {
+    onTypingRef.current = onTyping;
+  }, [onTyping]);
 
   // Configure TipTap extensions
   const extensions = [
@@ -98,6 +109,9 @@ export function useTiptapEditor({
       },
     },
     onUpdate: ({ editor }) => {
+      // Immediate typing signal — must fire per keystroke so the freewriting
+      // pause timer cannot expire mid-typing while onChange is still debounced.
+      onTypingRef.current?.();
       // Debounce onChange calls for performance
       clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = setTimeout(() => {

--- a/apps/web/src/post/hooks/useTypingPresence.ts
+++ b/apps/web/src/post/hooks/useTypingPresence.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseTypingPresenceOptions {
+  idleDelay: number;
+}
+
+interface UseTypingPresenceReturn {
+  isTyping: boolean;
+  ping: () => void;
+}
+
+/**
+ * Tracks whether the user is actively typing by treating each `ping()` as a
+ * keepalive. Goes idle once `idleDelay` milliseconds pass without a ping.
+ *
+ * Why: editor onChange callbacks are usually debounced for performance, which
+ * means continuous typing can starve a presence timer that listens only to the
+ * debounced signal. Callers should `ping()` from a non-debounced source (e.g.
+ * Tiptap's onUpdate) so presence stays accurate while typing is continuous.
+ */
+export function useTypingPresence({
+  idleDelay,
+}: UseTypingPresenceOptions): UseTypingPresenceReturn {
+  const [isTyping, setIsTyping] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout>();
+
+  const ping = useCallback(() => {
+    setIsTyping(true);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => {
+      setIsTyping(false);
+    }, idleDelay);
+  }, [idleDelay]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return { isTyping, ping };
+}


### PR DESCRIPTION
## Summary

- 프리라이팅 페이지에서 사용자가 빠르게 연속 입력하는 동안 타이머가 간헐적으로 '일시정지'로 잘못 전환되는 문제 수정
- 원인: `useTiptapEditor.onUpdate` 가 `onChange` 를 300ms 디바운스해서 부모로 보내는데, 이 부모 콜백이 2초 일시정지 타임아웃을 리셋하는 유일한 경로였음. 연속 입력으로 300ms 이상 휴지 구간이 없으면 onChange 가 발화되지 않아 이전에 세팅된 2000ms 타임아웃이 입력 중에 만료되어 '일시정지'로 플립됨
- 해결: 디바운스를 우회하는 즉시 `onTyping` 신호를 에디터 → 페이지로 전달하고, 동일 책임을 가진 `useTypingPresence({ idleDelay })` 훅으로 분리. 페이지는 `isTyping` 으로 `WritingStatus` 를 단순 파생만 함

## Changes

- `useTiptapEditor.ts`: optional `onTyping` 콜백 추가 (ref 안정화, 매 키스트로크마다 동기 호출)
- `EditorTiptap.tsx`, `PostEditor.tsx`: prop pass-through
- `PostFreewritingPage.tsx`: 수동 `useRef` + `useEffect` 타임아웃 로직 제거, `useTypingPresence` 로 대체
- 신규 `useTypingPresence` 훅 + 4개 단위 테스트 (연속 ping 시나리오로 오늘의 회귀 잠금 포함)

## Test plan

- [x] `pnpm --filter web test src/post/hooks/__tests__/useTypingPresence.test.ts` (4/4 pass)
- [x] 기존 `useCountupTimer`, `useInterval` 테스트 회귀 없음 (9/9 pass)
- [x] 로컬 dev 서버 + agent-browser 로 실측 검증:
  - 3초간 연속 입력 (30 keystroke × 100ms) → 배지 `쓰는 중` 유지, `일시정지` 표시 0회
  - 입력 중단 → ~2초 후 `일시정지` 로 전환
  - 일시정지 상태에서 재입력 → 즉시 `쓰는 중` 으로 복귀