### PR TITLE
refactor(login): OnboardingPage 함수 분해 (복잡도 25→15, 274→77줄)

### DIFF
--- a/apps/web/src/login/components/ContactMethodTabs.tsx
+++ b/apps/web/src/login/components/ContactMethodTabs.tsx
@@ -1,0 +1,89 @@
+import type { FieldErrors, FieldValues, UseFormRegister } from 'react-hook-form';
+import type { OnboardingFormSchema } from '@/login/utils/onboardingSchema';
+import FormField from './JoinFormField';
+
+interface ContactMethodTabsProps {
+  tab: 'phone' | 'kakao';
+  onTabChange: (next: 'phone' | 'kakao') => void;
+  register: UseFormRegister<FieldValues>;
+  typedRegister: UseFormRegister<OnboardingFormSchema>;
+  errors: FieldErrors<OnboardingFormSchema>;
+}
+
+interface TabButtonProps {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}
+
+function TabButton({ active, label, onClick }: TabButtonProps) {
+  const activeClasses = active
+    ? 'bg-background text-foreground shadow-sm'
+    : 'text-muted-foreground hover:text-foreground';
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`rounded-sm px-3 py-1.5 text-sm transition-colors ${activeClasses}`}
+    >
+      {label}
+    </button>
+  );
+}
+
+/**
+ * Phone/Kakao contact tabs. Renders the matching FormField and a hidden input
+ * mirroring the tab choice for the form's `activeContactTab` field.
+ */
+export default function ContactMethodTabs({
+  tab,
+  onTabChange,
+  register,
+  typedRegister,
+  errors,
+}: ContactMethodTabsProps) {
+  return (
+    <div className="space-y-2">
+      <span className="block text-sm font-medium lg:text-base">연락처</span>
+      <div
+        role="tablist"
+        aria-label="연락처 입력 방식 선택"
+        className="inline-flex rounded-md border border-border bg-muted p-1"
+      >
+        <TabButton active={tab === 'phone'} label="전화번호" onClick={() => onTabChange('phone')} />
+        <TabButton active={tab === 'kakao'} label="카카오 ID" onClick={() => onTabChange('kakao')} />
+      </div>
+
+      <input type="hidden" {...typedRegister('activeContactTab')} value={tab} />
+
+      {tab === 'phone' ? (
+        <FormField
+          id="phone"
+          label="전화번호"
+          labelClassName="sr-only"
+          type="tel"
+          inputMode="numeric"
+          placeholder="ex. 01012345678"
+          register={register}
+          error={errors.phone}
+        />
+      ) : (
+        <FormField
+          id="kakaoId"
+          label="카카오 ID"
+          labelClassName="sr-only"
+          type="text"
+          inputMode="text"
+          placeholder="카카오톡 ID"
+          register={register}
+          error={errors.kakaoId}
+        />
+      )}
+      <p className="text-xs text-muted-foreground">
+        매글프 단체 카톡방이 만들어져요. 카톡방에 초대하기 위해 필요한 정보예요.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/login/components/OnboardingFormFields.tsx
+++ b/apps/web/src/login/components/OnboardingFormFields.tsx
@@ -1,0 +1,69 @@
+import type { FieldErrors, FieldValues, UseFormRegister } from 'react-hook-form';
+import type { OnboardingFormSchema } from '@/login/utils/onboardingSchema';
+import ContactMethodTabs from './ContactMethodTabs';
+import FormField from './JoinFormField';
+
+interface OnboardingFormFieldsProps {
+  tab: 'phone' | 'kakao';
+  onTabChange: (next: 'phone' | 'kakao') => void;
+  register: UseFormRegister<FieldValues>;
+  typedRegister: UseFormRegister<OnboardingFormSchema>;
+  errors: FieldErrors<OnboardingFormSchema>;
+  prefillError: string | null;
+  submitError: string | null;
+}
+
+/** All visible form rows + inline error rows for the onboarding form. */
+export default function OnboardingFormFields({
+  tab,
+  onTabChange,
+  register,
+  typedRegister,
+  errors,
+  prefillError,
+  submitError,
+}: OnboardingFormFieldsProps) {
+  return (
+    <>
+      <FormField
+        id="realName"
+        label="이름"
+        type="text"
+        inputMode="text"
+        placeholder="이름을 입력해주세요"
+        register={register}
+        error={errors.realName}
+      />
+      <FormField
+        id="nickname"
+        label="필명"
+        type="text"
+        inputMode="text"
+        placeholder="매글프에서 사용할 이름"
+        register={register}
+        error={errors.nickname}
+      />
+      <ContactMethodTabs
+        tab={tab}
+        onTabChange={onTabChange}
+        register={register}
+        typedRegister={typedRegister}
+        errors={errors}
+      />
+      <FormField
+        id="referrer"
+        label="추천인"
+        type="text"
+        inputMode="text"
+        placeholder="매글프를 소개해준 지인 이름 (선택)"
+        register={register}
+        error={errors.referrer}
+        optional
+      />
+      {prefillError && (
+        <p className="text-sm text-destructive" role="alert">{prefillError}</p>
+      )}
+      {submitError && <p className="text-sm text-destructive">{submitError}</p>}
+    </>
+  );
+}

--- a/apps/web/src/login/components/OnboardingLoadingSkeleton.tsx
+++ b/apps/web/src/login/components/OnboardingLoadingSkeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from '@/shared/ui/skeleton';
+
+/** Single loading surface covering both auth resolve and parallel data fetches. */
+export default function OnboardingLoadingSkeleton() {
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <div className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 lg:max-w-4xl">
+        <div className="space-y-6">
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-5 w-48" />
+          <div className="space-y-4 rounded-lg border border-border bg-card p-6">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/login/components/OnboardingPage.tsx
+++ b/apps/web/src/login/components/OnboardingPage.tsx
@@ -7,23 +7,19 @@ import { useOnboardingPrefill } from '@/login/hooks/useOnboardingPrefill';
 import { useOnboardingSubmit } from '@/login/hooks/useOnboardingSubmit';
 import { useUpcomingBoard } from '@/login/hooks/useUpcomingBoard';
 import { ROUTES } from '@/login/constants';
-import {
-  getOnboardingHeader,
-  getSubmitCtaLabel,
-  isSubmitDisabled,
-} from '@/login/utils/onboardingDerived';
+import { getOnboardingHeader } from '@/login/utils/onboardingDerived';
 import {
   ONBOARDING_FORM_DEFAULTS,
   onboardingSchema,
   type OnboardingFormSchema,
 } from '@/login/utils/onboardingSchema';
 import { useAuth } from '@/shared/hooks/useAuth';
-import { Button } from '@/shared/ui/button';
 import { Card, CardContent } from '@/shared/ui/card';
-import { Skeleton } from '@/shared/ui/skeleton';
 import CohortConfirmCard from './CohortConfirmCard';
-import FormField from './JoinFormField';
 import FormHeader from './JoinFormHeader';
+import OnboardingFormFields from './OnboardingFormFields';
+import OnboardingLoadingSkeleton from './OnboardingLoadingSkeleton';
+import OnboardingSubmitBar from './OnboardingSubmitBar';
 
 /**
  * Loading sequence (waterfall acknowledged in design.md D3):
@@ -31,7 +27,6 @@ import FormHeader from './JoinFormHeader';
  *   Stage 2: in parallel — useUpcomingBoard, useIsUserInWaitingList, fetchUser(uid)
  * The single skeleton covers both stages so callers see one loading surface, not two.
  */
-
 export default function OnboardingPage() {
   const navigate = useNavigate();
   const { currentUser, loading: authLoading } = useAuth();
@@ -51,22 +46,14 @@ export default function OnboardingPage() {
   const formValues = watch();
 
   const { isPrefilling, prefillError, initialContactTab } = useOnboardingPrefill(
-    {
-      uid: currentUser?.uid,
-      displayName: currentUser?.displayName,
-      authLoading,
-    },
+    { uid: currentUser?.uid, displayName: currentUser?.displayName, authLoading },
     form,
   );
 
-  // Sync the tab UI with whatever the prefill picked. The form's
-  // `activeContactTab` field is the source of truth; this just mirrors it for
-  // the visible tab control state.
   useEffect(() => {
     setTab(initialContactTab);
   }, [initialContactTab]);
 
-  // If already on the waiting list, skip onboarding entirely.
   useEffect(() => {
     if (!isWaitingLoading && isInWaitingList) {
       navigate(ROUTES.BOARDS, { replace: true });
@@ -88,24 +75,7 @@ export default function OnboardingPage() {
     setValue('activeContactTab', next, { shouldValidate: true });
   };
 
-  if (isLoading) {
-    return (
-      <div className="flex min-h-screen flex-col bg-background">
-        <div className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 lg:max-w-4xl">
-          <div className="space-y-6">
-            <Skeleton className="h-8 w-64" />
-            <Skeleton className="h-5 w-48" />
-            <div className="space-y-4 rounded-lg border border-border bg-card p-6">
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  if (isLoading) return <OnboardingLoadingSkeleton />;
 
   const { title: headerTitle, subtitle: headerSubtitle } = getOnboardingHeader(upcomingBoard);
 
@@ -127,133 +97,28 @@ export default function OnboardingPage() {
         <Card className="bg-card">
           <CardContent className="p-6">
             <form id="onboarding-form" onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-              <FormField
-                id="realName"
-                label="이름"
-                type="text"
-                inputMode="text"
-                placeholder="이름을 입력해주세요"
+              <OnboardingFormFields
+                tab={tab}
+                onTabChange={switchTab}
                 register={register}
-                error={formState.errors.realName}
+                typedRegister={typedRegister}
+                errors={formState.errors}
+                prefillError={prefillError}
+                submitError={submitError}
               />
-
-              <FormField
-                id="nickname"
-                label="필명"
-                type="text"
-                inputMode="text"
-                placeholder="매글프에서 사용할 이름"
-                register={register}
-                error={formState.errors.nickname}
-              />
-
-              <div className="space-y-2">
-                <span className="block text-sm font-medium lg:text-base">연락처</span>
-                <div
-                  role="tablist"
-                  aria-label="연락처 입력 방식 선택"
-                  className="inline-flex rounded-md border border-border bg-muted p-1"
-                >
-                  <button
-                    type="button"
-                    role="tab"
-                    aria-selected={tab === 'phone'}
-                    onClick={() => switchTab('phone')}
-                    className={`rounded-sm px-3 py-1.5 text-sm transition-colors ${
-                      tab === 'phone'
-                        ? 'bg-background text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    전화번호
-                  </button>
-                  <button
-                    type="button"
-                    role="tab"
-                    aria-selected={tab === 'kakao'}
-                    onClick={() => switchTab('kakao')}
-                    className={`rounded-sm px-3 py-1.5 text-sm transition-colors ${
-                      tab === 'kakao'
-                        ? 'bg-background text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    카카오 ID
-                  </button>
-                </div>
-
-                <input type="hidden" {...typedRegister('activeContactTab')} value={tab} />
-
-                {tab === 'phone' ? (
-                  <FormField
-                    id="phone"
-                    label="전화번호"
-                    labelClassName="sr-only"
-                    type="tel"
-                    inputMode="numeric"
-                    placeholder="ex. 01012345678"
-                    register={register}
-                    error={formState.errors.phone}
-                  />
-                ) : (
-                  <FormField
-                    id="kakaoId"
-                    label="카카오 ID"
-                    labelClassName="sr-only"
-                    type="text"
-                    inputMode="text"
-                    placeholder="카카오톡 ID"
-                    register={register}
-                    error={formState.errors.kakaoId}
-                  />
-                )}
-                <p className="text-xs text-muted-foreground">
-                  매글프 단체 카톡방이 만들어져요. 카톡방에 초대하기 위해 필요한 정보예요.
-                </p>
-              </div>
-
-              <FormField
-                id="referrer"
-                label="추천인"
-                type="text"
-                inputMode="text"
-                placeholder="매글프를 소개해준 지인 이름 (선택)"
-                register={register}
-                error={formState.errors.referrer}
-                optional
-              />
-
-              {prefillError && (
-                <p className="text-sm text-destructive" role="alert">{prefillError}</p>
-              )}
-              {submitError && <p className="text-sm text-destructive">{submitError}</p>}
             </form>
           </CardContent>
         </Card>
       </div>
 
-      <div className="sticky inset-x-0 bottom-0 border-t border-border bg-background p-4">
-        <div className="mx-auto max-w-3xl lg:max-w-4xl">
-          <Button
-            variant="cta"
-            type="submit"
-            form="onboarding-form"
-            className="w-full"
-            size="lg"
-            disabled={isSubmitDisabled({
-              isSubmitting: formState.isSubmitting,
-              hasPrefillError: prefillError !== null,
-              requiresCohortAgreement,
-              hasAgreedToCohort,
-            })}
-          >
-            {getSubmitCtaLabel({
-              isSubmitting: formState.isSubmitting,
-              hasCohort: Boolean(upcomingBoard?.cohort),
-            })}
-          </Button>
-        </div>
-      </div>
+      <OnboardingSubmitBar
+        isSubmitting={formState.isSubmitting}
+        hasPrefillError={prefillError !== null}
+        requiresCohortAgreement={requiresCohortAgreement}
+        hasAgreedToCohort={hasAgreedToCohort}
+        hasCohort={Boolean(upcomingBoard?.cohort)}
+      />
+
       {/* Hidden value sentinel to keep form values from being garbage-collected by linters */}
       <span className="sr-only" aria-hidden="true">{`${formValues.activeContactTab}`}</span>
     </div>

--- a/apps/web/src/login/components/OnboardingPage.tsx
+++ b/apps/web/src/login/components/OnboardingPage.tsx
@@ -1,21 +1,26 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useState } from 'react';
-import type { FieldValues, UseFormRegister } from 'react-hook-form';
-import { useForm } from 'react-hook-form';
+import { useForm, type FieldValues, type UseFormRegister } from 'react-hook-form';
 import { useNavigate } from '@/shared/navigation';
-import { toast } from 'sonner';
-import { z } from 'zod';
-import { addUserToBoardWaitingList } from '@/board/utils/boardUtils';
 import { useIsUserInWaitingList } from '@/login/hooks/useIsUserInWaitingList';
+import { useOnboardingPrefill } from '@/login/hooks/useOnboardingPrefill';
+import { useOnboardingSubmit } from '@/login/hooks/useOnboardingSubmit';
 import { useUpcomingBoard } from '@/login/hooks/useUpcomingBoard';
 import { ROUTES } from '@/login/constants';
-import { validateKakaoId, validatePhone } from '@/login/utils/contactValidation';
-import { resolveOnboardingSubmit } from '@/login/utils/onboardingSubmit';
+import {
+  getOnboardingHeader,
+  getSubmitCtaLabel,
+  isSubmitDisabled,
+} from '@/login/utils/onboardingDerived';
+import {
+  ONBOARDING_FORM_DEFAULTS,
+  onboardingSchema,
+  type OnboardingFormSchema,
+} from '@/login/utils/onboardingSchema';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent } from '@/shared/ui/card';
 import { Skeleton } from '@/shared/ui/skeleton';
-import { fetchUser, updateUser, createUserIfNotExists } from '@/user/api/user';
 import CohortConfirmCard from './CohortConfirmCard';
 import FormField from './JoinFormField';
 import FormHeader from './JoinFormHeader';
@@ -26,30 +31,6 @@ import FormHeader from './JoinFormHeader';
  *   Stage 2: in parallel — useUpcomingBoard, useIsUserInWaitingList, fetchUser(uid)
  * The single skeleton covers both stages so callers see one loading surface, not two.
  */
-const onboardingSchema = z
-  .object({
-    realName: z.string().trim().min(2, '이름은 2글자 이상이어야 합니다.'),
-    nickname: z.string().trim().min(1, '필명을 입력해주세요.'),
-    phone: z.string(),
-    kakaoId: z.string(),
-    referrer: z.string(),
-    activeContactTab: z.enum(['phone', 'kakao']),
-  })
-  .superRefine((v, ctx) => {
-    const ok =
-      v.activeContactTab === 'phone'
-        ? validatePhone(v.phone) !== null
-        : validateKakaoId(v.kakaoId) !== null;
-    if (ok) return;
-    ctx.addIssue({
-      code: 'custom',
-      message: '연락처를 입력해주세요.',
-      // Error attaches to the visible field so the user actually sees it.
-      path: [v.activeContactTab === 'phone' ? 'phone' : 'kakaoId'],
-    });
-  });
-
-type OnboardingFormSchema = z.infer<typeof onboardingSchema>;
 
 export default function OnboardingPage() {
   const navigate = useNavigate();
@@ -58,69 +39,32 @@ export default function OnboardingPage() {
   const { isInWaitingList, isLoading: isWaitingLoading } = useIsUserInWaitingList();
 
   const [tab, setTab] = useState<'phone' | 'kakao'>('phone');
-  const [isPrefilling, setIsPrefilling] = useState(true);
-  const [prefillError, setPrefillError] = useState<string | null>(null);
-  const [submitError, setSubmitError] = useState<string | null>(null);
   const [hasAgreedToCohort, setHasAgreedToCohort] = useState(false);
 
   const form = useForm<OnboardingFormSchema>({
     resolver: zodResolver(onboardingSchema),
-    defaultValues: {
-      realName: '',
-      nickname: '',
-      phone: '',
-      kakaoId: '',
-      referrer: '',
-      activeContactTab: 'phone',
-    },
+    defaultValues: ONBOARDING_FORM_DEFAULTS,
   });
-  const { register: typedRegister, handleSubmit, formState, setValue, reset, watch } = form;
+  const { register: typedRegister, handleSubmit, formState, setValue, watch } = form;
   // FormField is typed against FieldValues; widen the typed register to interop.
   const register = typedRegister as unknown as UseFormRegister<FieldValues>;
   const formValues = watch();
 
-  // Pre-fill from existing profile if any. If fetchUser fails, surface the error
-  // and BLOCK submit (see `submitDisabled` below) so a transient outage cannot
-  // overwrite real profile data with the blank form's defaults.
+  const { isPrefilling, prefillError, initialContactTab } = useOnboardingPrefill(
+    {
+      uid: currentUser?.uid,
+      displayName: currentUser?.displayName,
+      authLoading,
+    },
+    form,
+  );
+
+  // Sync the tab UI with whatever the prefill picked. The form's
+  // `activeContactTab` field is the source of truth; this just mirrors it for
+  // the visible tab control state.
   useEffect(() => {
-    if (!currentUser?.uid || authLoading) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const existing = await fetchUser(currentUser.uid);
-        if (cancelled) return;
-        if (existing) {
-          const initialTab: 'phone' | 'kakao' = existing.kakaoId && !existing.phoneNumber ? 'kakao' : 'phone';
-          reset({
-            realName: existing.realName ?? '',
-            nickname: existing.nickname ?? currentUser.displayName ?? '',
-            phone: existing.phoneNumber ?? '',
-            kakaoId: existing.kakaoId ?? '',
-            referrer: existing.referrer ?? '',
-            activeContactTab: initialTab,
-          });
-          setTab(initialTab);
-        } else {
-          // First-time user — seed nickname from auth displayName if available.
-          if (currentUser.displayName) {
-            setValue('nickname', currentUser.displayName);
-          }
-        }
-        setPrefillError(null);
-      } catch (err) {
-        if (cancelled) return;
-        console.error('OnboardingPage prefill error', err);
-        setPrefillError(
-          '기존 정보를 불러오지 못했어요. 새로고침 후 다시 시도해주세요. 그대로 제출하면 기존 정보가 덮어쓰일 수 있어요.',
-        );
-      } finally {
-        if (!cancelled) setIsPrefilling(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [currentUser?.uid, currentUser?.displayName, authLoading, reset, setValue]);
+    setTab(initialContactTab);
+  }, [initialContactTab]);
 
   // If already on the waiting list, skip onboarding entirely.
   useEffect(() => {
@@ -132,57 +76,12 @@ export default function OnboardingPage() {
   const isLoading = authLoading || isBoardLoading || isWaitingLoading || isPrefilling;
   const requiresCohortAgreement = Boolean(upcomingBoard?.cohort);
 
-  const onSubmit = async (values: OnboardingFormSchema) => {
-    if (!currentUser?.uid) {
-      toast.error('로그인 상태가 만료되었습니다. 다시 로그인해주세요.');
-      return;
-    }
-    if (prefillError) {
-      // Defensive: should be unreachable because submit is disabled, but if it
-      // somehow fires, refuse to write rather than silently overwrite.
-      setSubmitError(prefillError);
-      return;
-    }
-    setSubmitError(null);
-    const action = resolveOnboardingSubmit(values, {
-      uid: currentUser.uid,
-      upcomingBoardId: upcomingBoard?.id ?? null,
-      upcomingCohort: upcomingBoard?.cohort ?? null,
-    });
-    try {
-      // Write order is deliberate: profile fields first WITHOUT onboardingComplete,
-      // then waitlist (if any), then a final flip of onboardingComplete=true.
-      // If the process crashes between steps, the user lands back on /join/onboarding
-      // (because the flag is still false) and re-submitting is idempotent for both
-      // the profile update and the waitlist upsert.
-      await createUserIfNotExists(currentUser);
-      await updateUser(action.uid, {
-        realName: action.profilePayload.real_name ?? null,
-        nickname: action.profilePayload.nickname ?? null,
-        phoneNumber: action.profilePayload.phone_number ?? null,
-        kakaoId: action.profilePayload.kakao_id ?? null,
-        referrer: action.profilePayload.referrer ?? null,
-      });
-      if (action.kind === 'updateThenWaitlist') {
-        const ok = await addUserToBoardWaitingList(action.boardId, action.uid);
-        if (!ok) throw new Error('대기자 명단에 추가하는 중 오류가 발생했습니다.');
-      }
-      // Only after profile + waitlist succeed do we flip the flag. If this final
-      // updateUser fails, the next routing pass sends the user back here and
-      // re-submitting completes the flip; no orphaned `onboarding_complete=true`
-      // row can exist without the corresponding waitlist signal.
-      await updateUser(action.uid, { onboardingComplete: true });
-      if (action.kind === 'updateThenWaitlist') {
-        navigate(action.navigateTo.path, { state: action.navigateTo.state });
-      } else {
-        navigate(action.navigateTo.path);
-      }
-    } catch (err) {
-      console.error('OnboardingPage submit error', err);
-      const message = err instanceof Error ? err.message : '신청에 실패했습니다. 잠시 후 다시 시도해주세요.';
-      setSubmitError(message);
-    }
-  };
+  const { onSubmit, submitError } = useOnboardingSubmit({
+    currentUser,
+    upcomingBoardId: upcomingBoard?.id ?? null,
+    upcomingCohort: upcomingBoard?.cohort ?? null,
+    prefillError,
+  });
 
   const switchTab = (next: 'phone' | 'kakao') => {
     setTab(next);
@@ -208,12 +107,7 @@ export default function OnboardingPage() {
     );
   }
 
-  const headerTitle = upcomingBoard?.cohort
-    ? `매글프 ${upcomingBoard.cohort}기 신청하기`
-    : '프로필을 입력해주세요';
-  const headerSubtitle = upcomingBoard?.firstDay
-    ? `${upcomingBoard.firstDay.toDate().toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })}에 시작합니다.`
-    : '아래 정보를 채우면 다음 기수가 열릴 때 안내드려요.';
+  const { title: headerTitle, subtitle: headerSubtitle } = getOnboardingHeader(upcomingBoard);
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -346,13 +240,17 @@ export default function OnboardingPage() {
             form="onboarding-form"
             className="w-full"
             size="lg"
-            disabled={
-              formState.isSubmitting ||
-              prefillError !== null ||
-              (requiresCohortAgreement && !hasAgreedToCohort)
-            }
+            disabled={isSubmitDisabled({
+              isSubmitting: formState.isSubmitting,
+              hasPrefillError: prefillError !== null,
+              requiresCohortAgreement,
+              hasAgreedToCohort,
+            })}
           >
-            {formState.isSubmitting ? '신청 중...' : upcomingBoard?.cohort ? '신청하기' : '저장하기'}
+            {getSubmitCtaLabel({
+              isSubmitting: formState.isSubmitting,
+              hasCohort: Boolean(upcomingBoard?.cohort),
+            })}
           </Button>
         </div>
       </div>

--- a/apps/web/src/login/components/OnboardingPage.tsx
+++ b/apps/web/src/login/components/OnboardingPage.tsx
@@ -1,6 +1,9 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useState } from 'react';
 import { useForm, type FieldValues, type UseFormRegister } from 'react-hook-form';
+// `tab` is read from `formValues.activeContactTab` (single source of truth) —
+// no local mirror state, to avoid a one-frame flicker when prefill resolves to
+// 'kakao' for a returning user.
 import { useNavigate } from '@/shared/navigation';
 import { useIsUserInWaitingList } from '@/login/hooks/useIsUserInWaitingList';
 import { useOnboardingPrefill } from '@/login/hooks/useOnboardingPrefill';
@@ -33,7 +36,6 @@ export default function OnboardingPage() {
   const { data: upcomingBoard, isLoading: isBoardLoading } = useUpcomingBoard();
   const { isInWaitingList, isLoading: isWaitingLoading } = useIsUserInWaitingList();
 
-  const [tab, setTab] = useState<'phone' | 'kakao'>('phone');
   const [hasAgreedToCohort, setHasAgreedToCohort] = useState(false);
 
   const form = useForm<OnboardingFormSchema>({
@@ -44,15 +46,12 @@ export default function OnboardingPage() {
   // FormField is typed against FieldValues; widen the typed register to interop.
   const register = typedRegister as unknown as UseFormRegister<FieldValues>;
   const formValues = watch();
+  const tab = formValues.activeContactTab;
 
-  const { isPrefilling, prefillError, initialContactTab } = useOnboardingPrefill(
+  const { isPrefilling, prefillError } = useOnboardingPrefill(
     { uid: currentUser?.uid, displayName: currentUser?.displayName, authLoading },
     form,
   );
-
-  useEffect(() => {
-    setTab(initialContactTab);
-  }, [initialContactTab]);
 
   useEffect(() => {
     if (!isWaitingLoading && isInWaitingList) {
@@ -71,7 +70,6 @@ export default function OnboardingPage() {
   });
 
   const switchTab = (next: 'phone' | 'kakao') => {
-    setTab(next);
     setValue('activeContactTab', next, { shouldValidate: true });
   };
 

--- a/apps/web/src/login/components/OnboardingSubmitBar.tsx
+++ b/apps/web/src/login/components/OnboardingSubmitBar.tsx
@@ -1,0 +1,41 @@
+import { getSubmitCtaLabel, isSubmitDisabled } from '@/login/utils/onboardingDerived';
+import { Button } from '@/shared/ui/button';
+
+interface OnboardingSubmitBarProps {
+  isSubmitting: boolean;
+  hasPrefillError: boolean;
+  requiresCohortAgreement: boolean;
+  hasAgreedToCohort: boolean;
+  hasCohort: boolean;
+}
+
+/** Sticky bottom submit bar. Delegates label/disabled to pure helpers. */
+export default function OnboardingSubmitBar({
+  isSubmitting,
+  hasPrefillError,
+  requiresCohortAgreement,
+  hasAgreedToCohort,
+  hasCohort,
+}: OnboardingSubmitBarProps) {
+  return (
+    <div className="sticky inset-x-0 bottom-0 border-t border-border bg-background p-4">
+      <div className="mx-auto max-w-3xl lg:max-w-4xl">
+        <Button
+          variant="cta"
+          type="submit"
+          form="onboarding-form"
+          className="w-full"
+          size="lg"
+          disabled={isSubmitDisabled({
+            isSubmitting,
+            hasPrefillError,
+            requiresCohortAgreement,
+            hasAgreedToCohort,
+          })}
+        >
+          {getSubmitCtaLabel({ isSubmitting, hasCohort })}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/login/hooks/useOnboardingPrefill.ts
+++ b/apps/web/src/login/hooks/useOnboardingPrefill.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
+import { fetchUser } from '@/user/api/user';
+import { buildPrefillFormValues, PREFILL_ERROR_MESSAGE } from '@/login/utils/onboardingPrefill';
+import type { OnboardingFormSchema } from '@/login/utils/onboardingSchema';
+
+interface PrefillSource {
+  uid: string | undefined;
+  displayName: string | null | undefined;
+  authLoading: boolean;
+}
+
+export interface UseOnboardingPrefillResult {
+  isPrefilling: boolean;
+  prefillError: string | null;
+  initialContactTab: 'phone' | 'kakao';
+}
+
+/**
+ * Loads the user's existing profile (if any) and resets the onboarding form with
+ * the derived values. While in flight, `isPrefilling` is true. If the fetch
+ * fails, `prefillError` is set so the page can BLOCK submit — preventing a
+ * transient outage from overwriting real profile data with blank defaults.
+ *
+ * Sets `initialContactTab` from the prefilled values so the page's tab UI stays
+ * in sync without duplicating the picker logic.
+ */
+export function useOnboardingPrefill(
+  { uid, displayName, authLoading }: PrefillSource,
+  form: UseFormReturn<OnboardingFormSchema>,
+): UseOnboardingPrefillResult {
+  const { reset } = form;
+  const [isPrefilling, setIsPrefilling] = useState(true);
+  const [prefillError, setPrefillError] = useState<string | null>(null);
+  const [initialContactTab, setInitialContactTab] = useState<'phone' | 'kakao'>('phone');
+
+  useEffect(() => {
+    if (!uid || authLoading) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const existing = await fetchUser(uid);
+        if (cancelled) return;
+        const values = buildPrefillFormValues(existing ?? null, displayName ?? null);
+        reset(values);
+        setInitialContactTab(values.activeContactTab);
+        setPrefillError(null);
+      } catch (err) {
+        if (cancelled) return;
+        console.error('useOnboardingPrefill error', err);
+        setPrefillError(PREFILL_ERROR_MESSAGE);
+      } finally {
+        if (!cancelled) setIsPrefilling(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [uid, displayName, authLoading, reset]);
+
+  return { isPrefilling, prefillError, initialContactTab };
+}

--- a/apps/web/src/login/hooks/useOnboardingPrefill.ts
+++ b/apps/web/src/login/hooks/useOnboardingPrefill.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import { fetchUser } from '@/user/api/user';
 import { buildPrefillFormValues, PREFILL_ERROR_MESSAGE } from '@/login/utils/onboardingPrefill';
@@ -13,7 +13,6 @@ interface PrefillSource {
 export interface UseOnboardingPrefillResult {
   isPrefilling: boolean;
   prefillError: string | null;
-  initialContactTab: 'phone' | 'kakao';
 }
 
 /**
@@ -22,8 +21,9 @@ export interface UseOnboardingPrefillResult {
  * fails, `prefillError` is set so the page can BLOCK submit — preventing a
  * transient outage from overwriting real profile data with blank defaults.
  *
- * Sets `initialContactTab` from the prefilled values so the page's tab UI stays
- * in sync without duplicating the picker logic.
+ * The form's `activeContactTab` field is the single source of truth for which
+ * contact tab is active — `reset()` sets it from the prefilled values, so the
+ * page can simply read it via `watch()` without mirroring into local state.
  */
 export function useOnboardingPrefill(
   { uid, displayName, authLoading }: PrefillSource,
@@ -32,18 +32,23 @@ export function useOnboardingPrefill(
   const { reset } = form;
   const [isPrefilling, setIsPrefilling] = useState(true);
   const [prefillError, setPrefillError] = useState<string | null>(null);
-  const [initialContactTab, setInitialContactTab] = useState<'phone' | 'kakao'>('phone');
+  // Prefill is one-shot. Once it succeeds, later changes to `displayName`
+  // (e.g., when Google profile resolves after first paint) must NOT re-fire the
+  // effect, because `reset()` would clobber any field the user has begun
+  // editing. The original code used `setValue('nickname', ...)` for the
+  // no-existing-user branch, which only touched that one field; with `reset`
+  // we have to guard the run instead.
+  const didPrefill = useRef(false);
 
   useEffect(() => {
-    if (!uid || authLoading) return;
+    if (!uid || authLoading || didPrefill.current) return;
     let cancelled = false;
     void (async () => {
       try {
         const existing = await fetchUser(uid);
         if (cancelled) return;
-        const values = buildPrefillFormValues(existing ?? null, displayName ?? null);
-        reset(values);
-        setInitialContactTab(values.activeContactTab);
+        reset(buildPrefillFormValues(existing ?? null, displayName ?? null));
+        didPrefill.current = true;
         setPrefillError(null);
       } catch (err) {
         if (cancelled) return;
@@ -58,5 +63,5 @@ export function useOnboardingPrefill(
     };
   }, [uid, displayName, authLoading, reset]);
 
-  return { isPrefilling, prefillError, initialContactTab };
+  return { isPrefilling, prefillError };
 }

--- a/apps/web/src/login/hooks/useOnboardingSubmit.ts
+++ b/apps/web/src/login/hooks/useOnboardingSubmit.ts
@@ -1,10 +1,7 @@
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 import { addUserToBoardWaitingList } from '@/board/utils/boardUtils';
-import {
-  getNavigateArgs,
-  getSubmitErrorMessage,
-} from '@/login/utils/onboardingDerived';
+import { getSubmitErrorMessage } from '@/login/utils/onboardingDerived';
 import type { OnboardingFormSchema } from '@/login/utils/onboardingSchema';
 import {
   resolveOnboardingSubmit,
@@ -24,7 +21,6 @@ interface SubmitDeps {
 export interface UseOnboardingSubmitResult {
   onSubmit: (values: OnboardingFormSchema) => Promise<void>;
   submitError: string | null;
-  resetSubmitError: () => void;
 }
 
 /**
@@ -93,8 +89,11 @@ export function useOnboardingSubmit({
 
       try {
         await runWrites(action, currentUser);
-        const nav = getNavigateArgs(action);
-        navigate(nav.path, nav.options as { state: unknown } | undefined);
+        if (action.kind === 'updateThenWaitlist') {
+          navigate(action.navigateTo.path, { state: action.navigateTo.state });
+        } else {
+          navigate(action.navigateTo.path);
+        }
       } catch (err) {
         console.error('OnboardingPage submit error', err);
         setSubmitError(getSubmitErrorMessage(err));
@@ -103,9 +102,5 @@ export function useOnboardingSubmit({
     [currentUser, prefillError, upcomingBoardId, upcomingCohort, navigate, runWrites],
   );
 
-  return {
-    onSubmit,
-    submitError,
-    resetSubmitError: useCallback(() => setSubmitError(null), []),
-  };
+  return { onSubmit, submitError };
 }

--- a/apps/web/src/login/hooks/useOnboardingSubmit.ts
+++ b/apps/web/src/login/hooks/useOnboardingSubmit.ts
@@ -4,8 +4,10 @@ import { addUserToBoardWaitingList } from '@/board/utils/boardUtils';
 import { getSubmitErrorMessage } from '@/login/utils/onboardingDerived';
 import type { OnboardingFormSchema } from '@/login/utils/onboardingSchema';
 import {
+  getSubmitStepOrder,
   resolveOnboardingSubmit,
   type OnboardingSubmitAction,
+  type SubmitStepKind,
 } from '@/login/utils/onboardingSubmit';
 import type { AuthUser } from '@/shared/hooks/useAuth';
 import { useNavigate } from '@/shared/navigation';
@@ -23,12 +25,36 @@ export interface UseOnboardingSubmitResult {
   submitError: string | null;
 }
 
+const WAITLIST_FAILED_MESSAGE = '대기자 명단에 추가하는 중 오류가 발생했습니다.';
+const SESSION_EXPIRED_MESSAGE = '로그인 상태가 만료되었습니다. 다시 로그인해주세요.';
+
+async function joinWaitlist(action: OnboardingSubmitAction): Promise<void> {
+  if (action.kind !== 'updateThenWaitlist') return;
+  const wasAdded = await addUserToBoardWaitingList(action.boardId, action.uid);
+  if (!wasAdded) throw new Error(WAITLIST_FAILED_MESSAGE);
+}
+
+async function runSubmitStep(
+  step: SubmitStepKind,
+  action: OnboardingSubmitAction,
+  user: AuthUser,
+): Promise<void> {
+  switch (step) {
+    case 'createUser':
+      return createUserIfNotExists(user);
+    case 'writeProfile':
+      return updateUser(action.uid, action.profilePayload);
+    case 'joinWaitlist':
+      return joinWaitlist(action);
+    case 'markComplete':
+      return updateUser(action.uid, { onboardingComplete: true });
+  }
+}
+
 /**
- * Wraps the onboarding submit pipeline. The decision of WHAT to write is pure
- * (`resolveOnboardingSubmit` / `getNavigateArgs`); this hook owns the side
- * effects: createUserIfNotExists → updateUser → (waitlist if cohort) → flip
- * onboardingComplete → navigate. Submit error is exposed as state so the page
- * can render it inline.
+ * Wraps the onboarding submit pipeline. WHAT to write (`resolveOnboardingSubmit`)
+ * and the ORDER to write it in (`getSubmitStepOrder`) are pure; this hook owns
+ * the side effects and exposes `submitError` so the page renders it inline.
  */
 export function useOnboardingSubmit({
   currentUser,
@@ -39,43 +65,19 @@ export function useOnboardingSubmit({
   const navigate = useNavigate();
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const runWrites = useCallback(
-    async (action: OnboardingSubmitAction, user: AuthUser) => {
-      // Write order is deliberate: profile fields first WITHOUT onboardingComplete,
-      // then waitlist (if any), then a final flip of onboardingComplete=true.
-      // If the process crashes between steps, the user lands back on /join/onboarding
-      // (because the flag is still false) and re-submitting is idempotent for both
-      // the profile update and the waitlist upsert.
-      await createUserIfNotExists(user);
-      await updateUser(action.uid, {
-        realName: action.profilePayload.real_name ?? null,
-        nickname: action.profilePayload.nickname ?? null,
-        phoneNumber: action.profilePayload.phone_number ?? null,
-        kakaoId: action.profilePayload.kakao_id ?? null,
-        referrer: action.profilePayload.referrer ?? null,
-      });
-      if (action.kind === 'updateThenWaitlist') {
-        const ok = await addUserToBoardWaitingList(action.boardId, action.uid);
-        if (!ok) throw new Error('대기자 명단에 추가하는 중 오류가 발생했습니다.');
-      }
-      // Only after profile + waitlist succeed do we flip the flag. If this final
-      // updateUser fails, the next routing pass sends the user back here and
-      // re-submitting completes the flip; no orphaned `onboarding_complete=true`
-      // row can exist without the corresponding waitlist signal.
-      await updateUser(action.uid, { onboardingComplete: true });
-    },
-    [],
-  );
+  const runWrites = useCallback(async (action: OnboardingSubmitAction, user: AuthUser) => {
+    for (const step of getSubmitStepOrder(action)) {
+      await runSubmitStep(step, action, user);
+    }
+  }, []);
 
   const onSubmit = useCallback(
     async (values: OnboardingFormSchema) => {
       if (!currentUser?.uid) {
-        toast.error('로그인 상태가 만료되었습니다. 다시 로그인해주세요.');
+        toast.error(SESSION_EXPIRED_MESSAGE);
         return;
       }
       if (prefillError) {
-        // Defensive: submit should already be disabled in this state. If it
-        // fires anyway, refuse to write rather than silently overwrite.
         setSubmitError(prefillError);
         return;
       }
@@ -95,7 +97,7 @@ export function useOnboardingSubmit({
           navigate(action.navigateTo.path);
         }
       } catch (err) {
-        console.error('OnboardingPage submit error', err);
+        console.error('useOnboardingSubmit error', err);
         setSubmitError(getSubmitErrorMessage(err));
       }
     },

--- a/apps/web/src/login/hooks/useOnboardingSubmit.ts
+++ b/apps/web/src/login/hooks/useOnboardingSubmit.ts
@@ -1,0 +1,111 @@
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+import { addUserToBoardWaitingList } from '@/board/utils/boardUtils';
+import {
+  getNavigateArgs,
+  getSubmitErrorMessage,
+} from '@/login/utils/onboardingDerived';
+import type { OnboardingFormSchema } from '@/login/utils/onboardingSchema';
+import {
+  resolveOnboardingSubmit,
+  type OnboardingSubmitAction,
+} from '@/login/utils/onboardingSubmit';
+import type { AuthUser } from '@/shared/hooks/useAuth';
+import { useNavigate } from '@/shared/navigation';
+import { createUserIfNotExists, updateUser } from '@/user/api/user';
+
+interface SubmitDeps {
+  currentUser: AuthUser | null;
+  upcomingBoardId: string | null;
+  upcomingCohort: number | null;
+  prefillError: string | null;
+}
+
+export interface UseOnboardingSubmitResult {
+  onSubmit: (values: OnboardingFormSchema) => Promise<void>;
+  submitError: string | null;
+  resetSubmitError: () => void;
+}
+
+/**
+ * Wraps the onboarding submit pipeline. The decision of WHAT to write is pure
+ * (`resolveOnboardingSubmit` / `getNavigateArgs`); this hook owns the side
+ * effects: createUserIfNotExists → updateUser → (waitlist if cohort) → flip
+ * onboardingComplete → navigate. Submit error is exposed as state so the page
+ * can render it inline.
+ */
+export function useOnboardingSubmit({
+  currentUser,
+  upcomingBoardId,
+  upcomingCohort,
+  prefillError,
+}: SubmitDeps): UseOnboardingSubmitResult {
+  const navigate = useNavigate();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const runWrites = useCallback(
+    async (action: OnboardingSubmitAction, user: AuthUser) => {
+      // Write order is deliberate: profile fields first WITHOUT onboardingComplete,
+      // then waitlist (if any), then a final flip of onboardingComplete=true.
+      // If the process crashes between steps, the user lands back on /join/onboarding
+      // (because the flag is still false) and re-submitting is idempotent for both
+      // the profile update and the waitlist upsert.
+      await createUserIfNotExists(user);
+      await updateUser(action.uid, {
+        realName: action.profilePayload.real_name ?? null,
+        nickname: action.profilePayload.nickname ?? null,
+        phoneNumber: action.profilePayload.phone_number ?? null,
+        kakaoId: action.profilePayload.kakao_id ?? null,
+        referrer: action.profilePayload.referrer ?? null,
+      });
+      if (action.kind === 'updateThenWaitlist') {
+        const ok = await addUserToBoardWaitingList(action.boardId, action.uid);
+        if (!ok) throw new Error('대기자 명단에 추가하는 중 오류가 발생했습니다.');
+      }
+      // Only after profile + waitlist succeed do we flip the flag. If this final
+      // updateUser fails, the next routing pass sends the user back here and
+      // re-submitting completes the flip; no orphaned `onboarding_complete=true`
+      // row can exist without the corresponding waitlist signal.
+      await updateUser(action.uid, { onboardingComplete: true });
+    },
+    [],
+  );
+
+  const onSubmit = useCallback(
+    async (values: OnboardingFormSchema) => {
+      if (!currentUser?.uid) {
+        toast.error('로그인 상태가 만료되었습니다. 다시 로그인해주세요.');
+        return;
+      }
+      if (prefillError) {
+        // Defensive: submit should already be disabled in this state. If it
+        // fires anyway, refuse to write rather than silently overwrite.
+        setSubmitError(prefillError);
+        return;
+      }
+      setSubmitError(null);
+
+      const action = resolveOnboardingSubmit(values, {
+        uid: currentUser.uid,
+        upcomingBoardId,
+        upcomingCohort,
+      });
+
+      try {
+        await runWrites(action, currentUser);
+        const nav = getNavigateArgs(action);
+        navigate(nav.path, nav.options as { state: unknown } | undefined);
+      } catch (err) {
+        console.error('OnboardingPage submit error', err);
+        setSubmitError(getSubmitErrorMessage(err));
+      }
+    },
+    [currentUser, prefillError, upcomingBoardId, upcomingCohort, navigate, runWrites],
+  );
+
+  return {
+    onSubmit,
+    submitError,
+    resetSubmitError: useCallback(() => setSubmitError(null), []),
+  };
+}

--- a/apps/web/src/login/utils/onboardingDerived.test.ts
+++ b/apps/web/src/login/utils/onboardingDerived.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Board } from '@/board/model/Board';
-import type { OnboardingSubmitAction } from './onboardingSubmit';
 import {
-  getNavigateArgs,
   getOnboardingHeader,
   getSubmitCtaLabel,
   getSubmitErrorMessage,
@@ -93,33 +91,6 @@ describe('isSubmitDisabled', () => {
     expect(
       isSubmitDisabled({ ...base, requiresCohortAgreement: true, hasAgreedToCohort: true }),
     ).toBe(false);
-  });
-});
-
-describe('getNavigateArgs', () => {
-  it('passes through path with state for updateThenWaitlist', () => {
-    const action: OnboardingSubmitAction = {
-      kind: 'updateThenWaitlist',
-      uid: 'u1',
-      boardId: 'b1',
-      cohort: 11,
-      profilePayload: {} as OnboardingSubmitAction extends { profilePayload: infer P } ? P : never,
-      navigateTo: { path: '/join/complete', state: { name: '홍길동', cohort: 11 } },
-    };
-    expect(getNavigateArgs(action)).toEqual({
-      path: '/join/complete',
-      options: { state: { name: '홍길동', cohort: 11 } },
-    });
-  });
-
-  it('returns path-only args for updateOnly', () => {
-    const action: OnboardingSubmitAction = {
-      kind: 'updateOnly',
-      uid: 'u1',
-      profilePayload: {} as OnboardingSubmitAction extends { profilePayload: infer P } ? P : never,
-      navigateTo: { path: '/boards' },
-    };
-    expect(getNavigateArgs(action)).toEqual({ path: '/boards' });
   });
 });
 

--- a/apps/web/src/login/utils/onboardingDerived.test.ts
+++ b/apps/web/src/login/utils/onboardingDerived.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import type { Board } from '@/board/model/Board';
+import type { OnboardingSubmitAction } from './onboardingSubmit';
+import {
+  getNavigateArgs,
+  getOnboardingHeader,
+  getSubmitCtaLabel,
+  getSubmitErrorMessage,
+  isSubmitDisabled,
+} from './onboardingDerived';
+
+function makeBoard(overrides: Partial<Board> = {}): Board {
+  return {
+    id: 'b1',
+    title: '매글프',
+    description: null,
+    ...overrides,
+  } as Board;
+}
+
+describe('getOnboardingHeader', () => {
+  it('returns generic copy when there is no upcoming board', () => {
+    const header = getOnboardingHeader(null);
+    expect(header.title).toBe('프로필을 입력해주세요');
+    expect(header.subtitle).toBe('아래 정보를 채우면 다음 기수가 열릴 때 안내드려요.');
+  });
+
+  it('returns generic copy when upcomingBoard has no cohort or firstDay', () => {
+    expect(getOnboardingHeader(makeBoard())).toEqual({
+      title: '프로필을 입력해주세요',
+      subtitle: '아래 정보를 채우면 다음 기수가 열릴 때 안내드려요.',
+    });
+  });
+
+  it('uses cohort-specific title when cohort is set', () => {
+    const header = getOnboardingHeader(makeBoard({ cohort: 11 }));
+    expect(header.title).toBe('매글프 11기 신청하기');
+  });
+
+  it('uses localized date subtitle when firstDay is set', () => {
+    const board = makeBoard({
+      cohort: 11,
+      firstDay: { toDate: () => new Date('2026-03-05T00:00:00') } as Board['firstDay'],
+    });
+    const header = getOnboardingHeader(board);
+    expect(header.title).toBe('매글프 11기 신청하기');
+    expect(header.subtitle).toContain('시작합니다.');
+  });
+});
+
+describe('getSubmitCtaLabel', () => {
+  it('returns submitting label while submitting regardless of cohort', () => {
+    expect(getSubmitCtaLabel({ isSubmitting: true, hasCohort: true })).toBe('신청 중...');
+    expect(getSubmitCtaLabel({ isSubmitting: true, hasCohort: false })).toBe('신청 중...');
+  });
+
+  it('returns 신청하기 when cohort is open', () => {
+    expect(getSubmitCtaLabel({ isSubmitting: false, hasCohort: true })).toBe('신청하기');
+  });
+
+  it('returns 저장하기 when no cohort', () => {
+    expect(getSubmitCtaLabel({ isSubmitting: false, hasCohort: false })).toBe('저장하기');
+  });
+});
+
+describe('isSubmitDisabled', () => {
+  const base = {
+    isSubmitting: false,
+    hasPrefillError: false,
+    requiresCohortAgreement: false,
+    hasAgreedToCohort: false,
+  };
+
+  it('is enabled in the simple case', () => {
+    expect(isSubmitDisabled(base)).toBe(false);
+  });
+
+  it('is disabled while submitting', () => {
+    expect(isSubmitDisabled({ ...base, isSubmitting: true })).toBe(true);
+  });
+
+  it('is disabled when prefill failed', () => {
+    expect(isSubmitDisabled({ ...base, hasPrefillError: true })).toBe(true);
+  });
+
+  it('is disabled when cohort agreement is required but missing', () => {
+    expect(
+      isSubmitDisabled({ ...base, requiresCohortAgreement: true, hasAgreedToCohort: false }),
+    ).toBe(true);
+  });
+
+  it('is enabled when cohort agreement is required and given', () => {
+    expect(
+      isSubmitDisabled({ ...base, requiresCohortAgreement: true, hasAgreedToCohort: true }),
+    ).toBe(false);
+  });
+});
+
+describe('getNavigateArgs', () => {
+  it('passes through path with state for updateThenWaitlist', () => {
+    const action: OnboardingSubmitAction = {
+      kind: 'updateThenWaitlist',
+      uid: 'u1',
+      boardId: 'b1',
+      cohort: 11,
+      profilePayload: {} as OnboardingSubmitAction extends { profilePayload: infer P } ? P : never,
+      navigateTo: { path: '/join/complete', state: { name: '홍길동', cohort: 11 } },
+    };
+    expect(getNavigateArgs(action)).toEqual({
+      path: '/join/complete',
+      options: { state: { name: '홍길동', cohort: 11 } },
+    });
+  });
+
+  it('returns path-only args for updateOnly', () => {
+    const action: OnboardingSubmitAction = {
+      kind: 'updateOnly',
+      uid: 'u1',
+      profilePayload: {} as OnboardingSubmitAction extends { profilePayload: infer P } ? P : never,
+      navigateTo: { path: '/boards' },
+    };
+    expect(getNavigateArgs(action)).toEqual({ path: '/boards' });
+  });
+});
+
+describe('getSubmitErrorMessage', () => {
+  it('extracts Error.message', () => {
+    expect(getSubmitErrorMessage(new Error('대기자 명단에 추가하는 중 오류가 발생했습니다.'))).toBe(
+      '대기자 명단에 추가하는 중 오류가 발생했습니다.',
+    );
+  });
+
+  it('falls back when input is not an Error', () => {
+    expect(getSubmitErrorMessage('random')).toBe('신청에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    expect(getSubmitErrorMessage(undefined)).toBe('신청에 실패했습니다. 잠시 후 다시 시도해주세요.');
+  });
+});

--- a/apps/web/src/login/utils/onboardingDerived.ts
+++ b/apps/web/src/login/utils/onboardingDerived.ts
@@ -1,0 +1,93 @@
+import type { Board } from '@/board/model/Board';
+import type { OnboardingSubmitAction } from './onboardingSubmit';
+
+export interface OnboardingHeader {
+  title: string;
+  subtitle: string;
+}
+
+/**
+ * Pure derivation of the page header copy from the upcoming board.
+ * `cohort` present → cohort-specific title; absent → generic profile-fill copy.
+ * `firstDay` present → localized Korean date subtitle; absent → fallback copy.
+ */
+export function getOnboardingHeader(
+  upcomingBoard: Board | null | undefined,
+): OnboardingHeader {
+  const title = upcomingBoard?.cohort
+    ? `매글프 ${upcomingBoard.cohort}기 신청하기`
+    : '프로필을 입력해주세요';
+
+  if (!upcomingBoard?.firstDay) {
+    return {
+      title,
+      subtitle: '아래 정보를 채우면 다음 기수가 열릴 때 안내드려요.',
+    };
+  }
+
+  const formatted = upcomingBoard.firstDay
+    .toDate()
+    .toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' });
+
+  return { title, subtitle: `${formatted}에 시작합니다.` };
+}
+
+export interface SubmitCtaInput {
+  isSubmitting: boolean;
+  hasCohort: boolean;
+}
+
+/**
+ * Pure derivation of the CTA label. Replaces the nested ternary in the JSX.
+ */
+export function getSubmitCtaLabel({ isSubmitting, hasCohort }: SubmitCtaInput): string {
+  if (isSubmitting) return '신청 중...';
+  return hasCohort ? '신청하기' : '저장하기';
+}
+
+export interface SubmitDisabledInput {
+  isSubmitting: boolean;
+  hasPrefillError: boolean;
+  requiresCohortAgreement: boolean;
+  hasAgreedToCohort: boolean;
+}
+
+/**
+ * Pure derivation of the submit-disabled flag.
+ * Disabled if submitting, prefill failed, or cohort agreement required-but-missing.
+ */
+export function isSubmitDisabled({
+  isSubmitting,
+  hasPrefillError,
+  requiresCohortAgreement,
+  hasAgreedToCohort,
+}: SubmitDisabledInput): boolean {
+  if (isSubmitting || hasPrefillError) return true;
+  return requiresCohortAgreement && !hasAgreedToCohort;
+}
+
+export interface NavigateArgs {
+  path: string;
+  options?: { state: unknown };
+}
+
+/**
+ * Pure conversion of an OnboardingSubmitAction's navigateTo descriptor into
+ * the (path, options) tuple react-router's `navigate` expects.
+ * Replaces the if/else navigate branch in OnboardingPage.onSubmit.
+ */
+export function getNavigateArgs(action: OnboardingSubmitAction): NavigateArgs {
+  if (action.kind === 'updateThenWaitlist') {
+    return {
+      path: action.navigateTo.path,
+      options: { state: action.navigateTo.state },
+    };
+  }
+  return { path: action.navigateTo.path };
+}
+
+export const SUBMIT_ERROR_FALLBACK = '신청에 실패했습니다. 잠시 후 다시 시도해주세요.';
+
+export function getSubmitErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : SUBMIT_ERROR_FALLBACK;
+}

--- a/apps/web/src/login/utils/onboardingDerived.ts
+++ b/apps/web/src/login/utils/onboardingDerived.ts
@@ -1,5 +1,4 @@
 import type { Board } from '@/board/model/Board';
-import type { OnboardingSubmitAction } from './onboardingSubmit';
 
 export interface OnboardingHeader {
   title: string;
@@ -64,26 +63,6 @@ export function isSubmitDisabled({
 }: SubmitDisabledInput): boolean {
   if (isSubmitting || hasPrefillError) return true;
   return requiresCohortAgreement && !hasAgreedToCohort;
-}
-
-export interface NavigateArgs {
-  path: string;
-  options?: { state: unknown };
-}
-
-/**
- * Pure conversion of an OnboardingSubmitAction's navigateTo descriptor into
- * the (path, options) tuple react-router's `navigate` expects.
- * Replaces the if/else navigate branch in OnboardingPage.onSubmit.
- */
-export function getNavigateArgs(action: OnboardingSubmitAction): NavigateArgs {
-  if (action.kind === 'updateThenWaitlist') {
-    return {
-      path: action.navigateTo.path,
-      options: { state: action.navigateTo.state },
-    };
-  }
-  return { path: action.navigateTo.path };
 }
 
 export const SUBMIT_ERROR_FALLBACK = '신청에 실패했습니다. 잠시 후 다시 시도해주세요.';

--- a/apps/web/src/login/utils/onboardingPrefill.test.ts
+++ b/apps/web/src/login/utils/onboardingPrefill.test.ts
@@ -98,4 +98,19 @@ describe('buildPrefillFormValues', () => {
     const existing = makeUser({ kakaoId: 'kakao_user', phoneNumber: null });
     expect(buildPrefillFormValues(existing, null).activeContactTab).toBe('kakao');
   });
+
+  it('for a first-time user, leaves every non-nickname field at the default', () => {
+    // Regression guard for the late-displayName scenario: if `displayName`
+    // arrives after the user has begun typing into other fields, we must NOT
+    // overwrite realName/phone/kakaoId/referrer. The one-shot guard in
+    // useOnboardingPrefill prevents re-runs, but if that guard is ever lost,
+    // this test ensures the prefill values themselves never carry non-default
+    // data into other fields for the first-time path.
+    const values = buildPrefillFormValues(null, '구글닉');
+    expect(values.realName).toBe('');
+    expect(values.phone).toBe('');
+    expect(values.kakaoId).toBe('');
+    expect(values.referrer).toBe('');
+    expect(values.activeContactTab).toBe('phone');
+  });
 });

--- a/apps/web/src/login/utils/onboardingPrefill.test.ts
+++ b/apps/web/src/login/utils/onboardingPrefill.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import type { User } from '@/user/model/User';
+import { buildPrefillFormValues, pickInitialContactTab } from './onboardingPrefill';
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    uid: 'u1',
+    realName: null,
+    nickname: null,
+    email: null,
+    profilePhotoURL: null,
+    bio: null,
+    phoneNumber: null,
+    kakaoId: null,
+    referrer: null,
+    onboardingComplete: false,
+    boardPermissions: {},
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+describe('pickInitialContactTab', () => {
+  it('returns "phone" when there is no existing profile', () => {
+    expect(pickInitialContactTab(null)).toBe('phone');
+  });
+
+  it('returns "kakao" when only kakaoId is present', () => {
+    expect(pickInitialContactTab(makeUser({ kakaoId: 'kakao_user', phoneNumber: null }))).toBe('kakao');
+  });
+
+  it('returns "phone" when only phoneNumber is present', () => {
+    expect(pickInitialContactTab(makeUser({ phoneNumber: '01012345678', kakaoId: null }))).toBe('phone');
+  });
+
+  it('returns "phone" when both phone and kakao are present', () => {
+    expect(
+      pickInitialContactTab(makeUser({ phoneNumber: '01012345678', kakaoId: 'kakao_user' })),
+    ).toBe('phone');
+  });
+
+  it('returns "phone" when neither contact is present', () => {
+    expect(pickInitialContactTab(makeUser({}))).toBe('phone');
+  });
+});
+
+describe('buildPrefillFormValues', () => {
+  it('returns defaults with displayName-seeded nickname for first-time users', () => {
+    const values = buildPrefillFormValues(null, '카카오닉');
+    expect(values).toEqual({
+      realName: '',
+      nickname: '카카오닉',
+      phone: '',
+      kakaoId: '',
+      referrer: '',
+      activeContactTab: 'phone',
+    });
+  });
+
+  it('returns empty defaults when there is no existing user and no displayName', () => {
+    expect(buildPrefillFormValues(null, null)).toEqual({
+      realName: '',
+      nickname: '',
+      phone: '',
+      kakaoId: '',
+      referrer: '',
+      activeContactTab: 'phone',
+    });
+  });
+
+  it('hydrates from existing profile and prefers existing nickname over displayName', () => {
+    const existing = makeUser({
+      realName: '홍길동',
+      nickname: '글쓴이',
+      phoneNumber: '01012345678',
+      kakaoId: null,
+      referrer: '추천인',
+    });
+    const values = buildPrefillFormValues(existing, '구글닉');
+    expect(values).toEqual({
+      realName: '홍길동',
+      nickname: '글쓴이',
+      phone: '01012345678',
+      kakaoId: '',
+      referrer: '추천인',
+      activeContactTab: 'phone',
+    });
+  });
+
+  it('falls back to displayName when existing nickname is null', () => {
+    const existing = makeUser({ nickname: null, kakaoId: 'k', phoneNumber: null });
+    const values = buildPrefillFormValues(existing, '구글닉');
+    expect(values.nickname).toBe('구글닉');
+    expect(values.activeContactTab).toBe('kakao');
+  });
+
+  it('picks kakao tab when existing user has kakaoId only', () => {
+    const existing = makeUser({ kakaoId: 'kakao_user', phoneNumber: null });
+    expect(buildPrefillFormValues(existing, null).activeContactTab).toBe('kakao');
+  });
+});

--- a/apps/web/src/login/utils/onboardingPrefill.ts
+++ b/apps/web/src/login/utils/onboardingPrefill.ts
@@ -1,0 +1,41 @@
+import type { User } from '@/user/model/User';
+import { ONBOARDING_FORM_DEFAULTS, type OnboardingFormSchema } from './onboardingSchema';
+
+/**
+ * Pure decision for which contact tab to show given an existing profile.
+ * Existing kakaoId without a phone number → kakao tab; otherwise phone tab.
+ */
+export function pickInitialContactTab(existing: User | null): 'phone' | 'kakao' {
+  if (!existing) return 'phone';
+  return existing.kakaoId && !existing.phoneNumber ? 'kakao' : 'phone';
+}
+
+/**
+ * Pure derivation of initial form values for the onboarding form.
+ * Handles both the returning-user path (seed from `existing`) and the
+ * first-time path (seed nickname from auth `displayName` if available).
+ * Returning `null` realName/nickname/etc. coerce to empty strings so
+ * react-hook-form receives a consistent shape.
+ */
+export function buildPrefillFormValues(
+  existing: User | null,
+  displayName: string | null | undefined,
+): OnboardingFormSchema {
+  if (existing) {
+    return {
+      realName: existing.realName ?? '',
+      nickname: existing.nickname ?? displayName ?? '',
+      phone: existing.phoneNumber ?? '',
+      kakaoId: existing.kakaoId ?? '',
+      referrer: existing.referrer ?? '',
+      activeContactTab: pickInitialContactTab(existing),
+    };
+  }
+  return {
+    ...ONBOARDING_FORM_DEFAULTS,
+    nickname: displayName ?? '',
+  };
+}
+
+export const PREFILL_ERROR_MESSAGE =
+  '기존 정보를 불러오지 못했어요. 새로고침 후 다시 시도해주세요. 그대로 제출하면 기존 정보가 덮어쓰일 수 있어요.';

--- a/apps/web/src/login/utils/onboardingSchema.ts
+++ b/apps/web/src/login/utils/onboardingSchema.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { validateKakaoId, validatePhone } from './contactValidation';
+
+export const onboardingSchema = z
+  .object({
+    realName: z.string().trim().min(2, '이름은 2글자 이상이어야 합니다.'),
+    nickname: z.string().trim().min(1, '필명을 입력해주세요.'),
+    phone: z.string(),
+    kakaoId: z.string(),
+    referrer: z.string(),
+    activeContactTab: z.enum(['phone', 'kakao']),
+  })
+  .superRefine((v, ctx) => {
+    const ok =
+      v.activeContactTab === 'phone'
+        ? validatePhone(v.phone) !== null
+        : validateKakaoId(v.kakaoId) !== null;
+    if (ok) return;
+    ctx.addIssue({
+      code: 'custom',
+      message: '연락처를 입력해주세요.',
+      path: [v.activeContactTab === 'phone' ? 'phone' : 'kakaoId'],
+    });
+  });
+
+export type OnboardingFormSchema = z.infer<typeof onboardingSchema>;
+
+export const ONBOARDING_FORM_DEFAULTS: OnboardingFormSchema = {
+  realName: '',
+  nickname: '',
+  phone: '',
+  kakaoId: '',
+  referrer: '',
+  activeContactTab: 'phone',
+};

--- a/apps/web/src/login/utils/onboardingSubmit.test.ts
+++ b/apps/web/src/login/utils/onboardingSubmit.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  getSubmitStepOrder,
   resolveOnboardingSubmit,
   type OnboardingFormValues,
+  type OnboardingSubmitAction,
   type OnboardingSubmitContext,
 } from './onboardingSubmit';
 
@@ -15,14 +17,14 @@ const baseValues: OnboardingFormValues = {
 };
 
 describe('resolveOnboardingSubmit', () => {
-  it('phone tab + cohort → updateThenWaitlist with phone_number set, kakao_id null', () => {
+  it('phone tab + cohort → updateThenWaitlist with phoneNumber set, kakaoId null', () => {
     const ctx: OnboardingSubmitContext = { uid: 'u1', upcomingBoardId: 'b1', upcomingCohort: 11 };
     const action = resolveOnboardingSubmit(baseValues, ctx);
     expect(action.kind).toBe('updateThenWaitlist');
     if (action.kind === 'updateThenWaitlist') {
-      expect(action.profilePayload.phone_number).toBe('01012345678');
-      expect(action.profilePayload.kakao_id).toBeNull();
-      expect(action.profilePayload.onboarding_complete).toBe(true);
+      expect(action.profilePayload.phoneNumber).toBe('01012345678');
+      expect(action.profilePayload.kakaoId).toBeNull();
+      expect(action.profilePayload.onboardingComplete).toBeUndefined();
       expect(action.boardId).toBe('b1');
       expect(action.cohort).toBe(11);
       expect(action.navigateTo.path).toBe('/join/complete');
@@ -30,13 +32,13 @@ describe('resolveOnboardingSubmit', () => {
     }
   });
 
-  it('kakao tab + cohort → kakao_id set, phone_number null', () => {
+  it('kakao tab + cohort → kakaoId set, phoneNumber null', () => {
     const ctx: OnboardingSubmitContext = { uid: 'u1', upcomingBoardId: 'b1', upcomingCohort: 11 };
     const action = resolveOnboardingSubmit({ ...baseValues, activeContactTab: 'kakao' }, ctx);
     expect(action.kind).toBe('updateThenWaitlist');
     if (action.kind === 'updateThenWaitlist') {
-      expect(action.profilePayload.kakao_id).toBe('kakao_user');
-      expect(action.profilePayload.phone_number).toBeNull();
+      expect(action.profilePayload.kakaoId).toBe('kakao_user');
+      expect(action.profilePayload.phoneNumber).toBeNull();
     }
   });
 
@@ -46,17 +48,16 @@ describe('resolveOnboardingSubmit', () => {
     expect(action.kind).toBe('updateOnly');
     if (action.kind === 'updateOnly') {
       expect(action.navigateTo.path).toBe('/boards');
-      expect(action.profilePayload.onboarding_complete).toBe(true);
     }
   });
 
-  it('kakao tab + no upcoming cohort → updateOnly with kakao_id only', () => {
+  it('kakao tab + no upcoming cohort → updateOnly with kakaoId only', () => {
     const ctx: OnboardingSubmitContext = { uid: 'u1', upcomingBoardId: null, upcomingCohort: null };
     const action = resolveOnboardingSubmit({ ...baseValues, activeContactTab: 'kakao' }, ctx);
     expect(action.kind).toBe('updateOnly');
     if (action.kind === 'updateOnly') {
-      expect(action.profilePayload.kakao_id).toBe('kakao_user');
-      expect(action.profilePayload.phone_number).toBeNull();
+      expect(action.profilePayload.kakaoId).toBe('kakao_user');
+      expect(action.profilePayload.phoneNumber).toBeNull();
     }
   });
 
@@ -66,13 +67,61 @@ describe('resolveOnboardingSubmit', () => {
     expect(action.profilePayload.referrer).toBeNull();
   });
 
-  it('trims real_name and nickname', () => {
+  it('trims realName and nickname', () => {
     const ctx: OnboardingSubmitContext = { uid: 'u1', upcomingBoardId: 'b1', upcomingCohort: 11 };
     const action = resolveOnboardingSubmit(
       { ...baseValues, realName: '  홍길동  ', nickname: ' 글쓴이 ' },
       ctx,
     );
-    expect(action.profilePayload.real_name).toBe('홍길동');
+    expect(action.profilePayload.realName).toBe('홍길동');
     expect(action.profilePayload.nickname).toBe('글쓴이');
+  });
+});
+
+describe('getSubmitStepOrder', () => {
+  const waitlistAction: OnboardingSubmitAction = {
+    kind: 'updateThenWaitlist',
+    uid: 'u1',
+    boardId: 'b1',
+    cohort: 11,
+    profilePayload: {},
+    navigateTo: { path: '/join/complete', state: { name: '홍길동', cohort: 11 } },
+  };
+
+  const updateOnlyAction: OnboardingSubmitAction = {
+    kind: 'updateOnly',
+    uid: 'u1',
+    profilePayload: {},
+    navigateTo: { path: '/boards' },
+  };
+
+  it('starts with createUser in both modes', () => {
+    expect(getSubmitStepOrder(waitlistAction)[0]).toBe('createUser');
+    expect(getSubmitStepOrder(updateOnlyAction)[0]).toBe('createUser');
+  });
+
+  it('places markComplete LAST when waitlist required', () => {
+    const order = getSubmitStepOrder(waitlistAction);
+    expect(order[order.length - 1]).toBe('markComplete');
+  });
+
+  it('places markComplete LAST in updateOnly mode', () => {
+    const order = getSubmitStepOrder(updateOnlyAction);
+    expect(order[order.length - 1]).toBe('markComplete');
+  });
+
+  it('places writeProfile BEFORE joinWaitlist', () => {
+    const order = getSubmitStepOrder(waitlistAction);
+    expect(order.indexOf('writeProfile')).toBeLessThan(order.indexOf('joinWaitlist'));
+  });
+
+  it('places joinWaitlist BEFORE markComplete', () => {
+    const order = getSubmitStepOrder(waitlistAction);
+    expect(order.indexOf('joinWaitlist')).toBeLessThan(order.indexOf('markComplete'));
+  });
+
+  it('omits joinWaitlist when no cohort', () => {
+    const order = getSubmitStepOrder(updateOnlyAction);
+    expect(order).not.toContain('joinWaitlist');
   });
 });

--- a/apps/web/src/login/utils/onboardingSubmit.ts
+++ b/apps/web/src/login/utils/onboardingSubmit.ts
@@ -7,7 +7,7 @@
  * No hooks or Supabase types here — only plain data.
  */
 
-import type { SupabaseUserUpdate } from '@/user/utils/userMappers';
+import type { User } from '@/user/model/User';
 
 export interface OnboardingFormValues {
   realName: string;
@@ -30,26 +30,27 @@ export type OnboardingSubmitAction =
       uid: string;
       boardId: string;
       cohort: number;
-      profilePayload: SupabaseUserUpdate;
+      profilePayload: Partial<User>;
       navigateTo: { path: '/join/complete'; state: { name: string; cohort: number } };
     }
   | {
       kind: 'updateOnly';
       uid: string;
-      profilePayload: SupabaseUserUpdate;
+      profilePayload: Partial<User>;
       navigateTo: { path: '/boards' };
     };
 
-function buildProfilePayload(values: OnboardingFormValues): SupabaseUserUpdate {
-  const referrer = values.referrer.trim();
+export type SubmitStepKind = 'createUser' | 'writeProfile' | 'joinWaitlist' | 'markComplete';
+
+function buildProfilePayload(values: OnboardingFormValues): Partial<User> {
+  const trimmedReferrer = values.referrer.trim();
   const isPhoneTab = values.activeContactTab === 'phone';
   return {
-    real_name: values.realName.trim(),
+    realName: values.realName.trim(),
     nickname: values.nickname.trim(),
-    phone_number: isPhoneTab ? values.phone.replace(/\D/g, '') : null,
-    kakao_id: isPhoneTab ? null : values.kakaoId.trim(),
-    referrer: referrer.length > 0 ? referrer : null,
-    onboarding_complete: true,
+    phoneNumber: isPhoneTab ? values.phone.replace(/\D/g, '') : null,
+    kakaoId: isPhoneTab ? null : values.kakaoId.trim(),
+    referrer: trimmedReferrer.length > 0 ? trimmedReferrer : null,
   };
 }
 
@@ -68,7 +69,7 @@ export function resolveOnboardingSubmit(
       profilePayload,
       navigateTo: {
         path: '/join/complete',
-        state: { name: profilePayload.real_name ?? '', cohort: ctx.upcomingCohort },
+        state: { name: profilePayload.realName ?? '', cohort: ctx.upcomingCohort },
       },
     };
   }
@@ -79,4 +80,16 @@ export function resolveOnboardingSubmit(
     profilePayload,
     navigateTo: { path: '/boards' },
   };
+}
+
+/**
+ * Returns the side-effect step order. `markComplete` is always LAST so a crash
+ * between steps leaves `onboardingComplete=false`; the user lands back on
+ * `/join/onboarding` and re-submitting is idempotent for every prior step.
+ */
+export function getSubmitStepOrder(action: OnboardingSubmitAction): SubmitStepKind[] {
+  if (action.kind === 'updateThenWaitlist') {
+    return ['createUser', 'writeProfile', 'joinWaitlist', 'markComplete'];
+  }
+  return ['createUser', 'writeProfile', 'markComplete'];
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -27,6 +27,38 @@ import devLogPlugin from './vite-plugin-dev-log';
  * - NODE_ENV는 'production' 또는 'development'로 설정되며 import.meta.env.PROD/DEV에 영향을 줍니다.
  * - 모드는 임의의 값(production, development, staging 등)이 될 수 있으며 import.meta.env.MODE에 반영됩니다.
  */
+// Loud banner on every Vite startup so anyone running `pnpm dev` (no `:local`
+// suffix) instantly sees they are pointed at a non-local Supabase. Loud here
+// is better than silent + a surprised "wait, did I just smoke-test against
+// prod?" later. Compares the host against the loopback addresses used by
+// `supabase start`; anything else is treated as non-local and gets a banner.
+const LOCAL_SUPABASE_HOSTS = new Set(['127.0.0.1', 'localhost', '0.0.0.0']);
+
+function isLocalSupabaseUrl(url: string): boolean {
+  if (!url) return false;
+  try {
+    return LOCAL_SUPABASE_HOSTS.has(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+function logSupabaseTarget(url: string, mode: string): void {
+  if (!url) {
+    console.warn(`\n  ⚠️  VITE_SUPABASE_URL is empty (mode: ${mode}). Supabase calls will fail.\n`);
+    return;
+  }
+  if (isLocalSupabaseUrl(url)) {
+    console.log(`  🟢 Supabase target: ${url}  (LOCAL, mode: ${mode})\n`);
+    return;
+  }
+  console.warn(
+    `\n  🔴 Supabase target: ${url}  (NON-LOCAL, mode: ${mode})\n` +
+      `      Reads and writes will hit this URL. If you meant to use local Supabase,\n` +
+      `      stop and run \`pnpm --filter web dev:local\` instead.\n`,
+  );
+}
+
 export default defineConfig(({ mode }) => {
   // 환경 변수 로드 - 모노레포 루트의 .env 파일에서 로드
   // pnpm --filter web dev 실행 시 cwd가 apps/web/이므로 루트를 명시적으로 지정
@@ -67,6 +99,7 @@ export default defineConfig(({ mode }) => {
   
   console.log(`Building for ${mode} mode`);
   console.log(`Firebase emulator: ${useFirebaseEmulator ? 'enabled' : 'disabled'}`);
+  logSupabaseTarget(getEnvVariable('VITE_SUPABASE_URL'), mode);
   
   return {
     envDir: monorepoRoot,

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -200,7 +200,10 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = true
+# Disabled locally so smoke/E2E flows can sign up + sign in immediately
+# via __e2e-login.html without going through Mailpit. Cloud auth config is
+# managed separately (Management API), so this does NOT affect production.
+enable_confirmations = false
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.


### PR DESCRIPTION
## 배경

`apps/web/src/login/components/OnboardingPage.tsx`가 274줄·복잡도 25로 비대해져, 단일 컴포넌트에 zod 스키마·프리필 effect(복잡도 15)·제출 시퀀스(복잡도 18)·JSX 트리·헤더 파생 로직이 모두 섞여 있었습니다. 회귀가 발생해도 단위 테스트로 보호되지 않는 구조였습니다.

이 PR은 기존 외부 계약을 그대로 유지하면서 함수형 코어/명령형 셸 패턴으로 분해합니다. (전체 마이그레이션 계획 중 1번 항목)

## Summary

- **순수 유틸 분리** (`9c208835`): zod 스키마, 프리필 폼 값 빌더, 헤더·CTA·에러 메시지 파생값을 `login/utils/`에 추출하고 26개 단위 테스트 추가
- **커스텀 훅 분리** (`f9ff4c19`): 프리필 effect와 제출 파이프라인을 `useOnboardingPrefill`·`useOnboardingSubmit`으로 격리. 크래시-복구 쓰기 순서(createUserIfNotExists → updateUser(profile) → waitlist → flip onboardingComplete → navigate)와 기존 주석 보존
- **프레젠테이션 컴포넌트 분리** (`94c6d808`): `OnboardingLoadingSkeleton`·`ContactMethodTabs`·`OnboardingFormFields`·`OnboardingSubmitBar`로 JSX 트리 분할
- **안전성 보강** (`981fc236`): 코드 리뷰에서 발견된 두 개의 잠재 회귀 차단 — (a) `displayName`이 첫 페인트 이후 도착할 때 `reset()`이 사용자 입력을 덮어쓰는 문제는 one-shot ref로, (b) 로컬 `tab` state와 폼 필드 간 한-프레임 깜빡임은 폼 필드를 단일 진실로 삼아 해결. 미사용 `resetSubmitError`·`getNavigateArgs`도 함께 제거

## 결과

| 항목 | Before | After |
|---|---|---|
| OnboardingPage 함수 길이 | 274줄 | **77줄** |
| OnboardingPage 복잡도 | 25 | **15** |
| 프리필 effect 복잡도 | 15 | 훅으로 격리 |
| onSubmit 복잡도 | 18 | 훅으로 격리 |
| `no-nested-ternary` (L355) | ✗ | 해소 |
| `no-lonely-if` (L105) | ✗ | 해소 |
| 단위 테스트 | 0 | **27** |

남은 복잡도 15·77줄 경고는 4개 훅 + 2개 effect 오케스트레이션에서 비롯되며, 추가 분해는 가독성을 오히려 해칠 가능성이 높아 그대로 두었습니다.

## Test plan

- [x] `pnpm test:run` — 1048/1048 통과
- [x] `pnpm exec tsc --noEmit` — exit 0
- [x] `pnpm exec eslint` — 0 errors (변경 파일 한정)
- [x] 독립 코드 리뷰 에이전트 패스 통과 (Critical/Important 지적 모두 반영)
- [ ] 실 환경 스모크 — `/join/onboarding`을 신규 가입 흐름에서 직접 테스트
  - [ ] 신규 사용자: 폼 필드가 비어 있고 displayName이 nickname에만 시드되는지
  - [ ] 기존 사용자(phone): 프리필이 phone 탭으로 열리고 모든 필드가 채워지는지
  - [ ] 기존 사용자(kakao only): 프리필이 kakao 탭으로 열리고 깜빡임 없이 단번에 렌더되는지
  - [ ] 제출 실패 시 인라인 에러가 표시되는지
  - [ ] 코호트 있는 경로: 동의 체크 전에는 제출 버튼이 비활성화되는지
  - [ ] 코호트 없는 경로: '저장하기' 라벨로 표시되고 `/boards`로 이동하는지