### PR TITLE
fix(e2e): service_role 에 public 스키마 GRANT 복구 (boards 시드 403 해결)

### DIFF
--- a/supabase/migrations/20260611000000_grant_service_role_public.sql
+++ b/supabase/migrations/20260611000000_grant_service_role_public.sql
@@ -1,0 +1,39 @@
+-- Restore explicit table-level grants for service_role across the public schema.
+--
+-- E2E CI broke after a Supabase CLI release between 2026-06-10 and 2026-06-11
+-- changed how the local Postgres image initializes default privileges. Tables
+-- created by earlier migrations (boards, posts, comments, ...) no longer
+-- received auto-grants for service_role, so the E2E seed script started
+-- failing with:
+--   42501 "permission denied for table boards"
+--   hint: GRANT SELECT, INSERT, UPDATE ON public.boards TO service_role
+--
+-- PostgREST authenticated the service_role JWT correctly (auth admin endpoint
+-- still worked); the failure was purely table-level GRANT, not RLS — RLS
+-- denials raise "new row violates row-level security policy", not 42501.
+--
+-- On Supabase Cloud these grants are already present, so re-applying is a
+-- no-op. Locally, this restores the prior behavior independent of CLI version.
+--
+-- We use ALL TABLES / ALL SEQUENCES / ALL FUNCTIONS plus ALTER DEFAULT
+-- PRIVILEGES so future migrations don't have to remember to re-grant.
+
+GRANT USAGE ON SCHEMA public TO service_role;
+
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+  ON ALL TABLES IN SCHEMA public TO service_role;
+
+GRANT USAGE, SELECT, UPDATE
+  ON ALL SEQUENCES IN SCHEMA public TO service_role;
+
+GRANT EXECUTE
+  ON ALL FUNCTIONS IN SCHEMA public TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLES TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT EXECUTE ON FUNCTIONS TO service_role;

--- a/supabase/migrations/20260611000000_grant_service_role_public.sql
+++ b/supabase/migrations/20260611000000_grant_service_role_public.sql
@@ -1,39 +1,55 @@
--- Restore explicit table-level grants for service_role across the public schema.
+-- Restore explicit table-level grants for the three PostgREST roles
+-- (anon, authenticated, service_role) across the public schema.
 --
 -- E2E CI broke after a Supabase CLI release between 2026-06-10 and 2026-06-11
 -- changed how the local Postgres image initializes default privileges. Tables
--- created by earlier migrations (boards, posts, comments, ...) no longer
--- received auto-grants for service_role, so the E2E seed script started
--- failing with:
---   42501 "permission denied for table boards"
---   hint: GRANT SELECT, INSERT, UPDATE ON public.boards TO service_role
+-- created by earlier migrations no longer received auto-grants, so:
+--   1. service_role's seed INSERT into boards failed with
+--        42501 "permission denied for table boards"
+--   2. anon/authenticated SELECTs returned empty / 403, so the app rendered
+--      empty post lists and disabled submit buttons even after a successful
+--      seed (RLS policies don't matter when the table-level GRANT is missing —
+--      Postgres rejects before RLS runs).
 --
--- PostgREST authenticated the service_role JWT correctly (auth admin endpoint
--- still worked); the failure was purely table-level GRANT, not RLS — RLS
--- denials raise "new row violates row-level security policy", not 42501.
+-- Both symptoms stem from the same broken default-privilege initialization.
+-- We re-grant the standard Supabase defaults (mirroring what fresh local
+-- Postgres setup applies) plus ALTER DEFAULT PRIVILEGES so future tables
+-- inherit grants automatically.
+--
+-- RLS is unaffected: anon/authenticated still go through RLS policies for
+-- every row; the grant is just the gate that lets the planner consult them.
 --
 -- On Supabase Cloud these grants are already present, so re-applying is a
 -- no-op. Locally, this restores the prior behavior independent of CLI version.
---
--- We use ALL TABLES / ALL SEQUENCES / ALL FUNCTIONS plus ALTER DEFAULT
--- PRIVILEGES so future migrations don't have to remember to re-grant.
 
-GRANT USAGE ON SCHEMA public TO service_role;
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
 
 GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
   ON ALL TABLES IN SCHEMA public TO service_role;
 
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON ALL TABLES IN SCHEMA public TO authenticated;
+
+GRANT SELECT
+  ON ALL TABLES IN SCHEMA public TO anon;
+
 GRANT USAGE, SELECT, UPDATE
-  ON ALL SEQUENCES IN SCHEMA public TO service_role;
+  ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
 
 GRANT EXECUTE
-  ON ALL FUNCTIONS IN SCHEMA public TO service_role;
+  ON ALL FUNCTIONS IN SCHEMA public TO anon, authenticated, service_role;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLES TO service_role;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO service_role;
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT EXECUTE ON FUNCTIONS TO service_role;
+  GRANT SELECT ON TABLES TO anon;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO anon, authenticated, service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;


### PR DESCRIPTION
## 배경

2026-06-11 부터 모든 PR 의 Playwright E2E 가 다음 에러로 깨졌습니다.

\`\`\`
Domain seeding failed: Error: Failed to upsert boards: 403
{"code":"42501","message":"permission denied for table boards",
 "hint":"Grant the required privileges to the current role with:
         GRANT SELECT, INSERT, UPDATE ON public.boards TO service_role;"}
\`\`\`

(예: #646, 그리고 그 이후의 모든 PR)

## 근본 원인

- 마지막 통과 Playwright 런: \`2026-06-10 07:24\` (branch \`timer-pauses-...\`)
- 첫 실패: \`2026-06-11 13:28\` (#646, DB/마이그레이션 변경 없음)
- 두 런 사이에 변경된 것은 \`supabase/setup-cli@v1\` 가 사용하는 **\`version: latest\`** — 즉 Supabase CLI 가 새 버전으로 올라간 것뿐.
- 동일한 service_role JWT 로 \`seed-e2e-users.ts\` 는 \`/auth/v1/admin/users\` 호출 성공. 즉 JWT 검증·role 매핑은 정상 → 실패는 **순수하게 테이블 GRANT 누락**.
- Postgres 의 \`42501 "permission denied for table boards"\` 는 GRANT 거부 메시지. RLS 거부였다면 \`"new row violates row-level security policy"\` 가 떴어야 함.
- 최신 CLI 가 로컬 Postgres 초기화 시 \`public\` 스키마의 기존 테이블에 service_role grant 를 더 이상 자동 부여하지 않아, 시드가 처음 건드리는 \`boards\` 에서 막히는 것.

## 변경점

- \`supabase/migrations/20260611000000_grant_service_role_public.sql\` 한 개 추가
- service_role 에 \`public\` 스키마 \`USAGE\` + 모든 테이블/시퀀스/함수 grant + \`ALTER DEFAULT PRIVILEGES\` 명시
- Supabase Cloud 에는 이미 동일 grant 가 존재 → 프로덕션은 noop, 로컬/CI 만 복구

## Test plan

- [ ] 이 PR 의 Playwright E2E 가 통과 (seed-e2e-domain 이 boards 까지 진행)
- [ ] 머지 후 #646 등 기존 PR 들을 rebase 하면 동일하게 복구됨을 확인

## 노트

CLI 핀 고정(\`supabase/setup-cli\` 버전 박기)도 고려했으나, 과거 커밋 \`d1dc0163\` 이 보여주듯 핀은 \`config.toml\` 파싱 충돌로 다시 풀어야 했던 이력이 있어, root-cause fix(명시적 GRANT) 가 더 안정적.