### PR TITLE
refactor(user): BlockedUsersPage 함수 분해 (#646 스택)

### DIFF
--- a/apps/web/src/login/components/ContactMethodTabs.tsx
+++ b/apps/web/src/login/components/ContactMethodTabs.tsx
@@ -1,0 +1,89 @@
+import type { FieldErrors, FieldValues, UseFormRegister } from 'react-hook-form';
+import type { OnboardingFormSchema } from '@/login/utils/onboardingSchema';
+import FormField from './JoinFormField';
+
+interface ContactMethodTabsProps {
+  tab: 'phone' | 'kakao';
+  onTabChange: (next: 'phone' | 'kakao') => void;
+  register: UseFormRegister<FieldValues>;
+  typedRegister: UseFormRegister<OnboardingFormSchema>;
+  errors: FieldErrors<OnboardingFormSchema>;
+}
+
+interface TabButtonProps {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}
+
+function TabButton({ active, label, onClick }: TabButtonProps) {
+  const activeClasses = active
+    ? 'bg-background text-foreground shadow-sm'
+    : 'text-muted-foreground hover:text-foreground';
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`rounded-sm px-3 py-1.5 text-sm transition-colors ${activeClasses}`}
+    >
+      {label}
+    </button>
+  );
+}
+
+/**
+ * Phone/Kakao contact tabs. Renders the matching FormField and a hidden input
+ * mirroring the tab choice for the form's `activeContactTab` field.
+ */
+export default function ContactMethodTabs({
+  tab,
+  onTabChange,
+  register,
+  typedRegister,
+  errors,
+}: ContactMethodTabsProps) {
+  return (
+    <div className="space-y-2">
+      <span className="block text-sm font-medium lg:text-base">연락처</span>
+      <div
+        role="tablist"
+        aria-label="연락처 입력 방식 선택"
+        className="inline-flex rounded-md border border-border bg-muted p-1"
+      >
+        <TabButton active={tab === 'phone'} label="전화번호" onClick={() => onTabChange('phone')} />
+        <TabButton active={tab === 'kakao'} label="카카오 ID" onClick={() => onTabChange('kakao')} />
+      </div>
+
+      <input type="hidden" {...typedRegister('activeContactTab')} value={tab} />
+
+      {tab === 'phone' ? (
+        <FormField
+          id="phone"
+          label="전화번호"
+          labelClassName="sr-only"
+          type="tel"
+          inputMode="numeric"
+          placeholder="ex. 01012345678"
+          register={register}
+          error={errors.phone}
+        />
+      ) : (
+        <FormField
+          id="kakaoId"
+          label="카카오 ID"
+          labelClassName="sr-only"
+          type="text"
+          inputMode="text"
+          placeholder="카카오톡 ID"
+          register={register}
+          error={errors.kakaoId}
+        />
+      )}
+      <p className="text-xs text-muted-foreground">
+        매글프 단체 카톡방이 만들어져요. 카톡방에 초대하기 위해 필요한 정보예요.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/login/components/OnboardingFormFields.tsx
+++ b/apps/web/src/login/components/OnboardingFormFields.tsx
@@ -1,0 +1,69 @@
+import type { FieldErrors, FieldValues, UseFormRegister } from 'react-hook-form';
+import type { OnboardingFormSchema } from '@/login/utils/onboardingSchema';
+import ContactMethodTabs from './ContactMethodTabs';
+import FormField from './JoinFormField';
+
+interface OnboardingFormFieldsProps {
+  tab: 'phone' | 'kakao';
+  onTabChange: (next: 'phone' | 'kakao') => void;
+  register: UseFormRegister<FieldValues>;
+  typedRegister: UseFormRegister<OnboardingFormSchema>;
+  errors: FieldErrors<OnboardingFormSchema>;
+  prefillError: string | null;
+  submitError: string | null;
+}
+
+/** All visible form rows + inline error rows for the onboarding form. */
+export default function OnboardingFormFields({
+  tab,
+  onTabChange,
+  register,
+  typedRegister,
+  errors,
+  prefillError,
+  submitError,
+}: OnboardingFormFieldsProps) {
+  return (
+    <>
+      <FormField
+        id="realName"
+        label="이름"
+        type="text"
+        inputMode="text"
+        placeholder="이름을 입력해주세요"
+        register={register}
+        error={errors.realName}
+      />
+      <FormField
+        id="nickname"
+        label="필명"
+        type="text"
+        inputMode="text"
+        placeholder="매글프에서 사용할 이름"
+        register={register}
+        error={errors.nickname}
+      />
+      <ContactMethodTabs
+        tab={tab}
+        onTabChange={onTabChange}
+        register={register}
+        typedRegister={typedRegister}
+        errors={errors}
+      />
+      <FormField
+        id="referrer"
+        label="추천인"
+        type="text"
+        inputMode="text"
+        placeholder="매글프를 소개해준 지인 이름 (선택)"
+        register={register}
+        error={errors.referrer}
+        optional
+      />
+      {prefillError && (
+        <p className="text-sm text-destructive" role="alert">{prefillError}</p>
+      )}
+      {submitError && <p className="text-sm text-destructive">{submitError}</p>}
+    </>
+  );
+}

--- a/apps/web/src/login/components/OnboardingLoadingSkeleton.tsx
+++ b/apps/web/src/login/components/OnboardingLoadingSkeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from '@/shared/ui/skeleton';
+
+/** Single loading surface covering both auth resolve and parallel data fetches. */
+export default function OnboardingLoadingSkeleton() {
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <div className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 lg:max-w-4xl">
+        <div className="space-y-6">
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-5 w-48" />
+          <div className="space-y-4 rounded-lg border border-border bg-card p-6">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/login/components/OnboardingPage.tsx
+++ b/apps/web/src/login/components/OnboardingPage.tsx
@@ -7,23 +7,19 @@ import { useOnboardingPrefill } from '@/login/hooks/useOnboardingPrefill';
 import { useOnboardingSubmit } from '@/login/hooks/useOnboardingSubmit';
 import { useUpcomingBoard } from '@/login/hooks/useUpcomingBoard';
 import { ROUTES } from '@/login/constants';
-import {
-  getOnboardingHeader,
-  getSubmitCtaLabel,
-  isSubmitDisabled,
-} from '@/login/utils/onboardingDerived';
+import { getOnboardingHeader } from '@/login/utils/onboardingDerived';
 import {
   ONBOARDING_FORM_DEFAULTS,
   onboardingSchema,
   type OnboardingFormSchema,
 } from '@/login/utils/onboardingSchema';
 import { useAuth } from '@/shared/hooks/useAuth';
-import { Button } from '@/shared/ui/button';
 import { Card, CardContent } from '@/shared/ui/card';
-import { Skeleton } from '@/shared/ui/skeleton';
 import CohortConfirmCard from './CohortConfirmCard';
-import FormField from './JoinFormField';
 import FormHeader from './JoinFormHeader';
+import OnboardingFormFields from './OnboardingFormFields';
+import OnboardingLoadingSkeleton from './OnboardingLoadingSkeleton';
+import OnboardingSubmitBar from './OnboardingSubmitBar';
 
 /**
  * Loading sequence (waterfall acknowledged in design.md D3):
@@ -31,7 +27,6 @@ import FormHeader from './JoinFormHeader';
  *   Stage 2: in parallel — useUpcomingBoard, useIsUserInWaitingList, fetchUser(uid)
  * The single skeleton covers both stages so callers see one loading surface, not two.
  */
-
 export default function OnboardingPage() {
   const navigate = useNavigate();
   const { currentUser, loading: authLoading } = useAuth();
@@ -51,22 +46,14 @@ export default function OnboardingPage() {
   const formValues = watch();
 
   const { isPrefilling, prefillError, initialContactTab } = useOnboardingPrefill(
-    {
-      uid: currentUser?.uid,
-      displayName: currentUser?.displayName,
-      authLoading,
-    },
+    { uid: currentUser?.uid, displayName: currentUser?.displayName, authLoading },
     form,
   );
 
-  // Sync the tab UI with whatever the prefill picked. The form's
-  // `activeContactTab` field is the source of truth; this just mirrors it for
-  // the visible tab control state.
   useEffect(() => {
     setTab(initialContactTab);
   }, [initialContactTab]);
 
-  // If already on the waiting list, skip onboarding entirely.
   useEffect(() => {
     if (!isWaitingLoading && isInWaitingList) {
       navigate(ROUTES.BOARDS, { replace: true });
@@ -88,24 +75,7 @@ export default function OnboardingPage() {
     setValue('activeContactTab', next, { shouldValidate: true });
   };
 
-  if (isLoading) {
-    return (
-      <div className="flex min-h-screen flex-col bg-background">
-        <div className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 lg:max-w-4xl">
-          <div className="space-y-6">
-            <Skeleton className="h-8 w-64" />
-            <Skeleton className="h-5 w-48" />
-            <div className="space-y-4 rounded-lg border border-border bg-card p-6">
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  if (isLoading) return <OnboardingLoadingSkeleton />;
 
   const { title: headerTitle, subtitle: headerSubtitle } = getOnboardingHeader(upcomingBoard);
 
@@ -127,133 +97,28 @@ export default function OnboardingPage() {
         <Card className="bg-card">
           <CardContent className="p-6">
             <form id="onboarding-form" onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-              <FormField
-                id="realName"
-                label="이름"
-                type="text"
-                inputMode="text"
-                placeholder="이름을 입력해주세요"
+              <OnboardingFormFields
+                tab={tab}
+                onTabChange={switchTab}
                 register={register}
-                error={formState.errors.realName}
+                typedRegister={typedRegister}
+                errors={formState.errors}
+                prefillError={prefillError}
+                submitError={submitError}
               />
-
-              <FormField
-                id="nickname"
-                label="필명"
-                type="text"
-                inputMode="text"
-                placeholder="매글프에서 사용할 이름"
-                register={register}
-                error={formState.errors.nickname}
-              />
-
-              <div className="space-y-2">
-                <span className="block text-sm font-medium lg:text-base">연락처</span>
-                <div
-                  role="tablist"
-                  aria-label="연락처 입력 방식 선택"
-                  className="inline-flex rounded-md border border-border bg-muted p-1"
-                >
-                  <button
-                    type="button"
-                    role="tab"
-                    aria-selected={tab === 'phone'}
-                    onClick={() => switchTab('phone')}
-                    className={`rounded-sm px-3 py-1.5 text-sm transition-colors ${
-                      tab === 'phone'
-                        ? 'bg-background text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    전화번호
-                  </button>
-                  <button
-                    type="button"
-                    role="tab"
-                    aria-selected={tab === 'kakao'}
-                    onClick={() => switchTab('kakao')}
-                    className={`rounded-sm px-3 py-1.5 text-sm transition-colors ${
-                      tab === 'kakao'
-                        ? 'bg-background text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    카카오 ID
-                  </button>
-                </div>
-
-                <input type="hidden" {...typedRegister('activeContactTab')} value={tab} />
-
-                {tab === 'phone' ? (
-                  <FormField
-                    id="phone"
-                    label="전화번호"
-                    labelClassName="sr-only"
-                    type="tel"
-                    inputMode="numeric"
-                    placeholder="ex. 01012345678"
-                    register={register}
-                    error={formState.errors.phone}
-                  />
-                ) : (
-                  <FormField
-                    id="kakaoId"
-                    label="카카오 ID"
-                    labelClassName="sr-only"
-                    type="text"
-                    inputMode="text"
-                    placeholder="카카오톡 ID"
-                    register={register}
-                    error={formState.errors.kakaoId}
-                  />
-                )}
-                <p className="text-xs text-muted-foreground">
-                  매글프 단체 카톡방이 만들어져요. 카톡방에 초대하기 위해 필요한 정보예요.
-                </p>
-              </div>
-
-              <FormField
-                id="referrer"
-                label="추천인"
-                type="text"
-                inputMode="text"
-                placeholder="매글프를 소개해준 지인 이름 (선택)"
-                register={register}
-                error={formState.errors.referrer}
-                optional
-              />
-
-              {prefillError && (
-                <p className="text-sm text-destructive" role="alert">{prefillError}</p>
-              )}
-              {submitError && <p className="text-sm text-destructive">{submitError}</p>}
             </form>
           </CardContent>
         </Card>
       </div>
 
-      <div className="sticky inset-x-0 bottom-0 border-t border-border bg-background p-4">
-        <div className="mx-auto max-w-3xl lg:max-w-4xl">
-          <Button
-            variant="cta"
-            type="submit"
-            form="onboarding-form"
-            className="w-full"
-            size="lg"
-            disabled={isSubmitDisabled({
-              isSubmitting: formState.isSubmitting,
-              hasPrefillError: prefillError !== null,
-              requiresCohortAgreement,
-              hasAgreedToCohort,
-            })}
-          >
-            {getSubmitCtaLabel({
-              isSubmitting: formState.isSubmitting,
-              hasCohort: Boolean(upcomingBoard?.cohort),
-            })}
-          </Button>
-        </div>
-      </div>
+      <OnboardingSubmitBar
+        isSubmitting={formState.isSubmitting}
+        hasPrefillError={prefillError !== null}
+        requiresCohortAgreement={requiresCohortAgreement}
+        hasAgreedToCohort={hasAgreedToCohort}
+        hasCohort={Boolean(upcomingBoard?.cohort)}
+      />
+
       {/* Hidden value sentinel to keep form values from being garbage-collected by linters */}
       <span className="sr-only" aria-hidden="true">{`${formValues.activeContactTab}`}</span>
     </div>

--- a/apps/web/src/login/components/OnboardingPage.tsx
+++ b/apps/web/src/login/components/OnboardingPage.tsx
@@ -1,21 +1,26 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useState } from 'react';
-import type { FieldValues, UseFormRegister } from 'react-hook-form';
-import { useForm } from 'react-hook-form';
+import { useForm, type FieldValues, type UseFormRegister } from 'react-hook-form';
 import { useNavigate } from '@/shared/navigation';
-import { toast } from 'sonner';
-import { z } from 'zod';
-import { addUserToBoardWaitingList } from '@/board/utils/boardUtils';
 import { useIsUserInWaitingList } from '@/login/hooks/useIsUserInWaitingList';
+import { useOnboardingPrefill } from '@/login/hooks/useOnboardingPrefill';
+import { useOnboardingSubmit } from '@/login/hooks/useOnboardingSubmit';
 import { useUpcomingBoard } from '@/login/hooks/useUpcomingBoard';
 import { ROUTES } from '@/login/constants';
-import { validateKakaoId, validatePhone } from '@/login/utils/contactValidation';
-import { resolveOnboardingSubmit } from '@/login/utils/onboardingSubmit';
+import {
+  getOnboardingHeader,
+  getSubmitCtaLabel,
+  isSubmitDisabled,
+} from '@/login/utils/onboardingDerived';
+import {
+  ONBOARDING_FORM_DEFAULTS,
+  onboardingSchema,
+  type OnboardingFormSchema,
+} from '@/login/utils/onboardingSchema';
 import { useAuth } from '@/shared/hooks/useAuth';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent } from '@/shared/ui/card';
 import { Skeleton } from '@/shared/ui/skeleton';
-import { fetchUser, updateUser, createUserIfNotExists } from '@/user/api/user';
 import CohortConfirmCard from './CohortConfirmCard';
 import FormField from './JoinFormField';
 import FormHeader from './JoinFormHeader';
@@ -26,30 +31,6 @@ import FormHeader from './JoinFormHeader';
  *   Stage 2: in parallel — useUpcomingBoard, useIsUserInWaitingList, fetchUser(uid)
  * The single skeleton covers both stages so callers see one loading surface, not two.
  */
-const onboardingSchema = z
-  .object({
-    realName: z.string().trim().min(2, '이름은 2글자 이상이어야 합니다.'),
-    nickname: z.string().trim().min(1, '필명을 입력해주세요.'),
-    phone: z.string(),
-    kakaoId: z.string(),
-    referrer: z.string(),
-    activeContactTab: z.enum(['phone', 'kakao']),
-  })
-  .superRefine((v, ctx) => {
-    const ok =
-      v.activeContactTab === 'phone'
-        ? validatePhone(v.phone) !== null
-        : validateKakaoId(v.kakaoId) !== null;
-    if (ok) return;
-    ctx.addIssue({
-      code: 'custom',
-      message: '연락처를 입력해주세요.',
-      // Error attaches to the visible field so the user actually sees it.
-      path: [v.activeContactTab === 'phone' ? 'phone' : 'kakaoId'],
-    });
-  });
-
-type OnboardingFormSchema = z.infer<typeof onboardingSchema>;
 
 export default function OnboardingPage() {
   const navigate = useNavigate();
@@ -58,69 +39,32 @@ export default function OnboardingPage() {
   const { isInWaitingList, isLoading: isWaitingLoading } = useIsUserInWaitingList();
 
   const [tab, setTab] = useState<'phone' | 'kakao'>('phone');
-  const [isPrefilling, setIsPrefilling] = useState(true);
-  const [prefillError, setPrefillError] = useState<string | null>(null);
-  const [submitError, setSubmitError] = useState<string | null>(null);
   const [hasAgreedToCohort, setHasAgreedToCohort] = useState(false);
 
   const form = useForm<OnboardingFormSchema>({
     resolver: zodResolver(onboardingSchema),
-    defaultValues: {
-      realName: '',
-      nickname: '',
-      phone: '',
-      kakaoId: '',
-      referrer: '',
-      activeContactTab: 'phone',
-    },
+    defaultValues: ONBOARDING_FORM_DEFAULTS,
   });
-  const { register: typedRegister, handleSubmit, formState, setValue, reset, watch } = form;
+  const { register: typedRegister, handleSubmit, formState, setValue, watch } = form;
   // FormField is typed against FieldValues; widen the typed register to interop.
   const register = typedRegister as unknown as UseFormRegister<FieldValues>;
   const formValues = watch();
 
-  // Pre-fill from existing profile if any. If fetchUser fails, surface the error
-  // and BLOCK submit (see `submitDisabled` below) so a transient outage cannot
-  // overwrite real profile data with the blank form's defaults.
+  const { isPrefilling, prefillError, initialContactTab } = useOnboardingPrefill(
+    {
+      uid: currentUser?.uid,
+      displayName: currentUser?.displayName,
+      authLoading,
+    },
+    form,
+  );
+
+  // Sync the tab UI with whatever the prefill picked. The form's
+  // `activeContactTab` field is the source of truth; this just mirrors it for
+  // the visible tab control state.
   useEffect(() => {
-    if (!currentUser?.uid || authLoading) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const existing = await fetchUser(currentUser.uid);
-        if (cancelled) return;
-        if (existing) {
-          const initialTab: 'phone' | 'kakao' = existing.kakaoId && !existing.phoneNumber ? 'kakao' : 'phone';
-          reset({
-            realName: existing.realName ?? '',
-            nickname: existing.nickname ?? currentUser.displayName ?? '',
-            phone: existing.phoneNumber ?? '',
-            kakaoId: existing.kakaoId ?? '',
-            referrer: existing.referrer ?? '',
-            activeContactTab: initialTab,
-          });
-          setTab(initialTab);
-        } else {
-          // First-time user — seed nickname from auth displayName if available.
-          if (currentUser.displayName) {
-            setValue('nickname', currentUser.displayName);
-          }
-        }
-        setPrefillError(null);
-      } catch (err) {
-        if (cancelled) return;
-        console.error('OnboardingPage prefill error', err);
-        setPrefillError(
-          '기존 정보를 불러오지 못했어요. 새로고침 후 다시 시도해주세요. 그대로 제출하면 기존 정보가 덮어쓰일 수 있어요.',
-        );
-      } finally {
-        if (!cancelled) setIsPrefilling(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [currentUser?.uid, currentUser?.displayName, authLoading, reset, setValue]);
+    setTab(initialContactTab);
+  }, [initialContactTab]);
 
   // If already on the waiting list, skip onboarding entirely.
   useEffect(() => {
@@ -132,57 +76,12 @@ export default function OnboardingPage() {
   const isLoading = authLoading || isBoardLoading || isWaitingLoading || isPrefilling;
   const requiresCohortAgreement = Boolean(upcomingBoard?.cohort);
 
-  const onSubmit = async (values: OnboardingFormSchema) => {
-    if (!currentUser?.uid) {
-      toast.error('로그인 상태가 만료되었습니다. 다시 로그인해주세요.');
-      return;
-    }
-    if (prefillError) {
-      // Defensive: should be unreachable because submit is disabled, but if it
-      // somehow fires, refuse to write rather than silently overwrite.
-      setSubmitError(prefillError);
-      return;
-    }
-    setSubmitError(null);
-    const action = resolveOnboardingSubmit(values, {
-      uid: currentUser.uid,
-      upcomingBoardId: upcomingBoard?.id ?? null,
-      upcomingCohort: upcomingBoard?.cohort ?? null,
-    });
-    try {
-      // Write order is deliberate: profile fields first WITHOUT onboardingComplete,
-      // then waitlist (if any), then a final flip of onboardingComplete=true.
-      // If the process crashes between steps, the user lands back on /join/onboarding
-      // (because the flag is still false) and re-submitting is idempotent for both
-      // the profile update and the waitlist upsert.
-      await createUserIfNotExists(currentUser);
-      await updateUser(action.uid, {
-        realName: action.profilePayload.real_name ?? null,
-        nickname: action.profilePayload.nickname ?? null,
-        phoneNumber: action.profilePayload.phone_number ?? null,
-        kakaoId: action.profilePayload.kakao_id ?? null,
-        referrer: action.profilePayload.referrer ?? null,
-      });
-      if (action.kind === 'updateThenWaitlist') {
-        const ok = await addUserToBoardWaitingList(action.boardId, action.uid);
-        if (!ok) throw new Error('대기자 명단에 추가하는 중 오류가 발생했습니다.');
-      }
-      // Only after profile + waitlist succeed do we flip the flag. If this final
-      // updateUser fails, the next routing pass sends the user back here and
-      // re-submitting completes the flip; no orphaned `onboarding_complete=true`
-      // row can exist without the corresponding waitlist signal.
-      await updateUser(action.uid, { onboardingComplete: true });
-      if (action.kind === 'updateThenWaitlist') {
-        navigate(action.navigateTo.path, { state: action.navigateTo.state });
-      } else {
-        navigate(action.navigateTo.path);
-      }
-    } catch (err) {
-      console.error('OnboardingPage submit error', err);
-      const message = err instanceof Error ? err.message : '신청에 실패했습니다. 잠시 후 다시 시도해주세요.';
-      setSubmitError(message);
-    }
-  };
+  const { onSubmit, submitError } = useOnboardingSubmit({
+    currentUser,
+    upcomingBoardId: upcomingBoard?.id ?? null,
+    upcomingCohort: upcomingBoard?.cohort ?? null,
+    prefillError,
+  });
 
   const switchTab = (next: 'phone' | 'kakao') => {
     setTab(next);
@@ -208,12 +107,7 @@ export default function OnboardingPage() {
     );
   }
 
-  const headerTitle = upcomingBoard?.cohort
-    ? `매글프 ${upcomingBoard.cohort}기 신청하기`
-    : '프로필을 입력해주세요';
-  const headerSubtitle = upcomingBoard?.firstDay
-    ? `${upcomingBoard.firstDay.toDate().toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })}에 시작합니다.`
-    : '아래 정보를 채우면 다음 기수가 열릴 때 안내드려요.';
+  const { title: headerTitle, subtitle: headerSubtitle } = getOnboardingHeader(upcomingBoard);
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -346,13 +240,17 @@ export default function OnboardingPage() {
             form="onboarding-form"
             className="w-full"
             size="lg"
-            disabled={
-              formState.isSubmitting ||
-              prefillError !== null ||
-              (requiresCohortAgreement && !hasAgreedToCohort)
-            }
+            disabled={isSubmitDisabled({
+              isSubmitting: formState.isSubmitting,
+              hasPrefillError: prefillError !== null,
+              requiresCohortAgreement,
+              hasAgreedToCohort,
+            })}
           >
-            {formState.isSubmitting ? '신청 중...' : upcomingBoard?.cohort ? '신청하기' : '저장하기'}
+            {getSubmitCtaLabel({
+              isSubmitting: formState.isSubmitting,
+              hasCohort: Boolean(upcomingBoard?.cohort),
+            })}
           </Button>
         </div>
       </div>

--- a/apps/web/src/login/components/OnboardingPage.tsx
+++ b/apps/web/src/login/components/OnboardingPage.tsx
@@ -1,6 +1,9 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useState } from 'react';
 import { useForm, type FieldValues, type UseFormRegister } from 'react-hook-form';
+// `tab` is read from `formValues.activeContactTab` (single source of truth) —
+// no local mirror state, to avoid a one-frame flicker when prefill resolves to
+// 'kakao' for a returning user.
 import { useNavigate } from '@/shared/navigation';
 import { useIsUserInWaitingList } from '@/login/hooks/useIsUserInWaitingList';
 import { useOnboardingPrefill } from '@/login/hooks/useOnboardingPrefill';
@@ -33,7 +36,6 @@ export default function OnboardingPage() {
   const { data: upcomingBoard, isLoading: isBoardLoading } = useUpcomingBoard();
   const { isInWaitingList, isLoading: isWaitingLoading } = useIsUserInWaitingList();
 
-  const [tab, setTab] = useState<'phone' | 'kakao'>('phone');
   const [hasAgreedToCohort, setHasAgreedToCohort] = useState(false);
 
   const form = useForm<OnboardingFormSchema>({
@@ -44,15 +46,12 @@ export default function OnboardingPage() {
   // FormField is typed against FieldValues; widen the typed register to interop.
   const register = typedRegister as unknown as UseFormRegister<FieldValues>;
   const formValues = watch();
+  const tab = formValues.activeContactTab;
 
-  const { isPrefilling, prefillError, initialContactTab } = useOnboardingPrefill(
+  const { isPrefilling, prefillError } = useOnboardingPrefill(
     { uid: currentUser?.uid, displayName: currentUser?.displayName, authLoading },
     form,
   );
-
-  useEffect(() => {
-    setTab(initialContactTab);
-  }, [initialContactTab]);
 
   useEffect(() => {
     if (!isWaitingLoading && isInWaitingList) {
@@ -71,7 +70,6 @@ export default function OnboardingPage() {
   });
 
   const switchTab = (next: 'phone' | 'kakao') => {
-    setTab(next);
     setValue('activeContactTab', next, { shouldValidate: true });
   };
 

--- a/apps/web/src/login/components/OnboardingSubmitBar.tsx
+++ b/apps/web/src/login/components/OnboardingSubmitBar.tsx
@@ -1,0 +1,41 @@
+import { getSubmitCtaLabel, isSubmitDisabled } from '@/login/utils/onboardingDerived';
+import { Button } from '@/shared/ui/button';
+
+interface OnboardingSubmitBarProps {
+  isSubmitting: boolean;
+  hasPrefillError: boolean;
+  requiresCohortAgreement: boolean;
+  hasAgreedToCohort: boolean;
+  hasCohort: boolean;
+}
+
+/** Sticky bottom submit bar. Delegates label/disabled to pure helpers. */
+export default function OnboardingSubmitBar({
+  isSubmitting,
+  hasPrefillError,
+  requiresCohortAgreement,
+  hasAgreedToCohort,
+  hasCohort,
+}: OnboardingSubmitBarProps) {
+  return (
+    <div className="sticky inset-x-0 bottom-0 border-t border-border bg-background p-4">
+      <div className="mx-auto max-w-3xl lg:max-w-4xl">
+        <Button
+          variant="cta"
+          type="submit"
+          form="onboarding-form"
+          className="w-full"
+          size="lg"
+          disabled={isSubmitDisabled({
+            isSubmitting,
+            hasPrefillError,
+            requiresCohortAgreement,
+            hasAgreedToCohort,
+          })}
+        >
+          {getSubmitCtaLabel({ isSubmitting, hasCohort })}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/login/hooks/useOnboardingPrefill.ts
+++ b/apps/web/src/login/hooks/useOnboardingPrefill.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
+import { fetchUser } from '@/user/api/user';
+import { buildPrefillFormValues, PREFILL_ERROR_MESSAGE } from '@/login/utils/onboardingPrefill';
+import type { OnboardingFormSchema } from '@/login/utils/onboardingSchema';
+
+interface PrefillSource {
+  uid: string | undefined;
+  displayName: string | null | undefined;
+  authLoading: boolean;
+}
+
+export interface UseOnboardingPrefillResult {
+  isPrefilling: boolean;
+  prefillError: string | null;
+  initialContactTab: 'phone' | 'kakao';
+}
+
+/**
+ * Loads the user's existing profile (if any) and resets the onboarding form with
+ * the derived values. While in flight, `isPrefilling` is true. If the fetch
+ * fails, `prefillError` is set so the page can BLOCK submit — preventing a
+ * transient outage from overwriting real profile data with blank defaults.
+ *
+ * Sets `initialContactTab` from the prefilled values so the page's tab UI stays
+ * in sync without duplicating the picker logic.
+ */
+export function useOnboardingPrefill(
+  { uid, displayName, authLoading }: PrefillSource,
+  form: UseFormReturn<OnboardingFormSchema>,
+): UseOnboardingPrefillResult {
+  const { reset } = form;
+  const [isPrefilling, setIsPrefilling] = useState(true);
+  const [prefillError, setPrefillError] = useState<string | null>(null);
+  const [initialContactTab, setInitialContactTab] = useState<'phone' | 'kakao'>('phone');
+
+  useEffect(() => {
+    if (!uid || authLoading) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const existing = await fetchUser(uid);
+        if (cancelled) return;
+        const values = buildPrefillFormValues(existing ?? null, displayName ?? null);
+        reset(values);
+        setInitialContactTab(values.activeContactTab);
+        setPrefillError(null);
+      } catch (err) {
+        if (cancelled) return;
+        console.error('useOnboardingPrefill error', err);
+        setPrefillError(PREFILL_ERROR_MESSAGE);
+      } finally {
+        if (!cancelled) setIsPrefilling(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [uid, displayName, authLoading, reset]);
+
+  return { isPrefilling, prefillError, initialContactTab };
+}

--- a/apps/web/src/login/hooks/useOnboardingPrefill.ts
+++ b/apps/web/src/login/hooks/useOnboardingPrefill.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import { fetchUser } from '@/user/api/user';
 import { buildPrefillFormValues, PREFILL_ERROR_MESSAGE } from '@/login/utils/onboardingPrefill';
@@ -13,7 +13,6 @@ interface PrefillSource {
 export interface UseOnboardingPrefillResult {
   isPrefilling: boolean;
   prefillError: string | null;
-  initialContactTab: 'phone' | 'kakao';
 }
 
 /**
@@ -22,8 +21,9 @@ export interface UseOnboardingPrefillResult {
  * fails, `prefillError` is set so the page can BLOCK submit — preventing a
  * transient outage from overwriting real profile data with blank defaults.
  *
- * Sets `initialContactTab` from the prefilled values so the page's tab UI stays
- * in sync without duplicating the picker logic.
+ * The form's `activeContactTab` field is the single source of truth for which
+ * contact tab is active — `reset()` sets it from the prefilled values, so the
+ * page can simply read it via `watch()` without mirroring into local state.
  */
 export function useOnboardingPrefill(
   { uid, displayName, authLoading }: PrefillSource,
@@ -32,18 +32,23 @@ export function useOnboardingPrefill(
   const { reset } = form;
   const [isPrefilling, setIsPrefilling] = useState(true);
   const [prefillError, setPrefillError] = useState<string | null>(null);
-  const [initialContactTab, setInitialContactTab] = useState<'phone' | 'kakao'>('phone');
+  // Prefill is one-shot. Once it succeeds, later changes to `displayName`
+  // (e.g., when Google profile resolves after first paint) must NOT re-fire the
+  // effect, because `reset()` would clobber any field the user has begun
+  // editing. The original code used `setValue('nickname', ...)` for the
+  // no-existing-user branch, which only touched that one field; with `reset`
+  // we have to guard the run instead.
+  const didPrefill = useRef(false);
 
   useEffect(() => {
-    if (!uid || authLoading) return;
+    if (!uid || authLoading || didPrefill.current) return;
     let cancelled = false;
     void (async () => {
       try {
         const existing = await fetchUser(uid);
         if (cancelled) return;
-        const values = buildPrefillFormValues(existing ?? null, displayName ?? null);
-        reset(values);
-        setInitialContactTab(values.activeContactTab);
+        reset(buildPrefillFormValues(existing ?? null, displayName ?? null));
+        didPrefill.current = true;
         setPrefillError(null);
       } catch (err) {
         if (cancelled) return;
@@ -58,5 +63,5 @@ export function useOnboardingPrefill(
     };
   }, [uid, displayName, authLoading, reset]);
 
-  return { isPrefilling, prefillError, initialContactTab };
+  return { isPrefilling, prefillError };
 }

--- a/apps/web/src/login/hooks/useOnboardingSubmit.ts
+++ b/apps/web/src/login/hooks/useOnboardingSubmit.ts
@@ -1,10 +1,7 @@
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 import { addUserToBoardWaitingList } from '@/board/utils/boardUtils';
-import {
-  getNavigateArgs,
-  getSubmitErrorMessage,
-} from '@/login/utils/onboardingDerived';
+import { getSubmitErrorMessage } from '@/login/utils/onboardingDerived';
 import type { OnboardingFormSchema } from '@/login/utils/onboardingSchema';
 import {
   resolveOnboardingSubmit,
@@ -24,7 +21,6 @@ interface SubmitDeps {
 export interface UseOnboardingSubmitResult {
   onSubmit: (values: OnboardingFormSchema) => Promise<void>;
   submitError: string | null;
-  resetSubmitError: () => void;
 }
 
 /**
@@ -93,8 +89,11 @@ export function useOnboardingSubmit({
 
       try {
         await runWrites(action, currentUser);
-        const nav = getNavigateArgs(action);
-        navigate(nav.path, nav.options as { state: unknown } | undefined);
+        if (action.kind === 'updateThenWaitlist') {
+          navigate(action.navigateTo.path, { state: action.navigateTo.state });
+        } else {
+          navigate(action.navigateTo.path);
+        }
       } catch (err) {
         console.error('OnboardingPage submit error', err);
         setSubmitError(getSubmitErrorMessage(err));
@@ -103,9 +102,5 @@ export function useOnboardingSubmit({
     [currentUser, prefillError, upcomingBoardId, upcomingCohort, navigate, runWrites],
   );
 
-  return {
-    onSubmit,
-    submitError,
-    resetSubmitError: useCallback(() => setSubmitError(null), []),
-  };
+  return { onSubmit, submitError };
 }

--- a/apps/web/src/login/hooks/useOnboardingSubmit.ts
+++ b/apps/web/src/login/hooks/useOnboardingSubmit.ts
@@ -1,0 +1,111 @@
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+import { addUserToBoardWaitingList } from '@/board/utils/boardUtils';
+import {
+  getNavigateArgs,
+  getSubmitErrorMessage,
+} from '@/login/utils/onboardingDerived';
+import type { OnboardingFormSchema } from '@/login/utils/onboardingSchema';
+import {
+  resolveOnboardingSubmit,
+  type OnboardingSubmitAction,
+} from '@/login/utils/onboardingSubmit';
+import type { AuthUser } from '@/shared/hooks/useAuth';
+import { useNavigate } from '@/shared/navigation';
+import { createUserIfNotExists, updateUser } from '@/user/api/user';
+
+interface SubmitDeps {
+  currentUser: AuthUser | null;
+  upcomingBoardId: string | null;
+  upcomingCohort: number | null;
+  prefillError: string | null;
+}
+
+export interface UseOnboardingSubmitResult {
+  onSubmit: (values: OnboardingFormSchema) => Promise<void>;
+  submitError: string | null;
+  resetSubmitError: () => void;
+}
+
+/**
+ * Wraps the onboarding submit pipeline. The decision of WHAT to write is pure
+ * (`resolveOnboardingSubmit` / `getNavigateArgs`); this hook owns the side
+ * effects: createUserIfNotExists → updateUser → (waitlist if cohort) → flip
+ * onboardingComplete → navigate. Submit error is exposed as state so the page
+ * can render it inline.
+ */
+export function useOnboardingSubmit({
+  currentUser,
+  upcomingBoardId,
+  upcomingCohort,
+  prefillError,
+}: SubmitDeps): UseOnboardingSubmitResult {
+  const navigate = useNavigate();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const runWrites = useCallback(
+    async (action: OnboardingSubmitAction, user: AuthUser) => {
+      // Write order is deliberate: profile fields first WITHOUT onboardingComplete,
+      // then waitlist (if any), then a final flip of onboardingComplete=true.
+      // If the process crashes between steps, the user lands back on /join/onboarding
+      // (because the flag is still false) and re-submitting is idempotent for both
+      // the profile update and the waitlist upsert.
+      await createUserIfNotExists(user);
+      await updateUser(action.uid, {
+        realName: action.profilePayload.real_name ?? null,
+        nickname: action.profilePayload.nickname ?? null,
+        phoneNumber: action.profilePayload.phone_number ?? null,
+        kakaoId: action.profilePayload.kakao_id ?? null,
+        referrer: action.profilePayload.referrer ?? null,
+      });
+      if (action.kind === 'updateThenWaitlist') {
+        const ok = await addUserToBoardWaitingList(action.boardId, action.uid);
+        if (!ok) throw new Error('대기자 명단에 추가하는 중 오류가 발생했습니다.');
+      }
+      // Only after profile + waitlist succeed do we flip the flag. If this final
+      // updateUser fails, the next routing pass sends the user back here and
+      // re-submitting completes the flip; no orphaned `onboarding_complete=true`
+      // row can exist without the corresponding waitlist signal.
+      await updateUser(action.uid, { onboardingComplete: true });
+    },
+    [],
+  );
+
+  const onSubmit = useCallback(
+    async (values: OnboardingFormSchema) => {
+      if (!currentUser?.uid) {
+        toast.error('로그인 상태가 만료되었습니다. 다시 로그인해주세요.');
+        return;
+      }
+      if (prefillError) {
+        // Defensive: submit should already be disabled in this state. If it
+        // fires anyway, refuse to write rather than silently overwrite.
+        setSubmitError(prefillError);
+        return;
+      }
+      setSubmitError(null);
+
+      const action = resolveOnboardingSubmit(values, {
+        uid: currentUser.uid,
+        upcomingBoardId,
+        upcomingCohort,
+      });
+
+      try {
+        await runWrites(action, currentUser);
+        const nav = getNavigateArgs(action);
+        navigate(nav.path, nav.options as { state: unknown } | undefined);
+      } catch (err) {
+        console.error('OnboardingPage submit error', err);
+        setSubmitError(getSubmitErrorMessage(err));
+      }
+    },
+    [currentUser, prefillError, upcomingBoardId, upcomingCohort, navigate, runWrites],
+  );
+
+  return {
+    onSubmit,
+    submitError,
+    resetSubmitError: useCallback(() => setSubmitError(null), []),
+  };
+}

--- a/apps/web/src/login/utils/onboardingDerived.test.ts
+++ b/apps/web/src/login/utils/onboardingDerived.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Board } from '@/board/model/Board';
-import type { OnboardingSubmitAction } from './onboardingSubmit';
 import {
-  getNavigateArgs,
   getOnboardingHeader,
   getSubmitCtaLabel,
   getSubmitErrorMessage,
@@ -93,33 +91,6 @@ describe('isSubmitDisabled', () => {
     expect(
       isSubmitDisabled({ ...base, requiresCohortAgreement: true, hasAgreedToCohort: true }),
     ).toBe(false);
-  });
-});
-
-describe('getNavigateArgs', () => {
-  it('passes through path with state for updateThenWaitlist', () => {
-    const action: OnboardingSubmitAction = {
-      kind: 'updateThenWaitlist',
-      uid: 'u1',
-      boardId: 'b1',
-      cohort: 11,
-      profilePayload: {} as OnboardingSubmitAction extends { profilePayload: infer P } ? P : never,
-      navigateTo: { path: '/join/complete', state: { name: '홍길동', cohort: 11 } },
-    };
-    expect(getNavigateArgs(action)).toEqual({
-      path: '/join/complete',
-      options: { state: { name: '홍길동', cohort: 11 } },
-    });
-  });
-
-  it('returns path-only args for updateOnly', () => {
-    const action: OnboardingSubmitAction = {
-      kind: 'updateOnly',
-      uid: 'u1',
-      profilePayload: {} as OnboardingSubmitAction extends { profilePayload: infer P } ? P : never,
-      navigateTo: { path: '/boards' },
-    };
-    expect(getNavigateArgs(action)).toEqual({ path: '/boards' });
   });
 });
 

--- a/apps/web/src/login/utils/onboardingDerived.test.ts
+++ b/apps/web/src/login/utils/onboardingDerived.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import type { Board } from '@/board/model/Board';
+import type { OnboardingSubmitAction } from './onboardingSubmit';
+import {
+  getNavigateArgs,
+  getOnboardingHeader,
+  getSubmitCtaLabel,
+  getSubmitErrorMessage,
+  isSubmitDisabled,
+} from './onboardingDerived';
+
+function makeBoard(overrides: Partial<Board> = {}): Board {
+  return {
+    id: 'b1',
+    title: '매글프',
+    description: null,
+    ...overrides,
+  } as Board;
+}
+
+describe('getOnboardingHeader', () => {
+  it('returns generic copy when there is no upcoming board', () => {
+    const header = getOnboardingHeader(null);
+    expect(header.title).toBe('프로필을 입력해주세요');
+    expect(header.subtitle).toBe('아래 정보를 채우면 다음 기수가 열릴 때 안내드려요.');
+  });
+
+  it('returns generic copy when upcomingBoard has no cohort or firstDay', () => {
+    expect(getOnboardingHeader(makeBoard())).toEqual({
+      title: '프로필을 입력해주세요',
+      subtitle: '아래 정보를 채우면 다음 기수가 열릴 때 안내드려요.',
+    });
+  });
+
+  it('uses cohort-specific title when cohort is set', () => {
+    const header = getOnboardingHeader(makeBoard({ cohort: 11 }));
+    expect(header.title).toBe('매글프 11기 신청하기');
+  });
+
+  it('uses localized date subtitle when firstDay is set', () => {
+    const board = makeBoard({
+      cohort: 11,
+      firstDay: { toDate: () => new Date('2026-03-05T00:00:00') } as Board['firstDay'],
+    });
+    const header = getOnboardingHeader(board);
+    expect(header.title).toBe('매글프 11기 신청하기');
+    expect(header.subtitle).toContain('시작합니다.');
+  });
+});
+
+describe('getSubmitCtaLabel', () => {
+  it('returns submitting label while submitting regardless of cohort', () => {
+    expect(getSubmitCtaLabel({ isSubmitting: true, hasCohort: true })).toBe('신청 중...');
+    expect(getSubmitCtaLabel({ isSubmitting: true, hasCohort: false })).toBe('신청 중...');
+  });
+
+  it('returns 신청하기 when cohort is open', () => {
+    expect(getSubmitCtaLabel({ isSubmitting: false, hasCohort: true })).toBe('신청하기');
+  });
+
+  it('returns 저장하기 when no cohort', () => {
+    expect(getSubmitCtaLabel({ isSubmitting: false, hasCohort: false })).toBe('저장하기');
+  });
+});
+
+describe('isSubmitDisabled', () => {
+  const base = {
+    isSubmitting: false,
+    hasPrefillError: false,
+    requiresCohortAgreement: false,
+    hasAgreedToCohort: false,
+  };
+
+  it('is enabled in the simple case', () => {
+    expect(isSubmitDisabled(base)).toBe(false);
+  });
+
+  it('is disabled while submitting', () => {
+    expect(isSubmitDisabled({ ...base, isSubmitting: true })).toBe(true);
+  });
+
+  it('is disabled when prefill failed', () => {
+    expect(isSubmitDisabled({ ...base, hasPrefillError: true })).toBe(true);
+  });
+
+  it('is disabled when cohort agreement is required but missing', () => {
+    expect(
+      isSubmitDisabled({ ...base, requiresCohortAgreement: true, hasAgreedToCohort: false }),
+    ).toBe(true);
+  });
+
+  it('is enabled when cohort agreement is required and given', () => {
+    expect(
+      isSubmitDisabled({ ...base, requiresCohortAgreement: true, hasAgreedToCohort: true }),
+    ).toBe(false);
+  });
+});
+
+describe('getNavigateArgs', () => {
+  it('passes through path with state for updateThenWaitlist', () => {
+    const action: OnboardingSubmitAction = {
+      kind: 'updateThenWaitlist',
+      uid: 'u1',
+      boardId: 'b1',
+      cohort: 11,
+      profilePayload: {} as OnboardingSubmitAction extends { profilePayload: infer P } ? P : never,
+      navigateTo: { path: '/join/complete', state: { name: '홍길동', cohort: 11 } },
+    };
+    expect(getNavigateArgs(action)).toEqual({
+      path: '/join/complete',
+      options: { state: { name: '홍길동', cohort: 11 } },
+    });
+  });
+
+  it('returns path-only args for updateOnly', () => {
+    const action: OnboardingSubmitAction = {
+      kind: 'updateOnly',
+      uid: 'u1',
+      profilePayload: {} as OnboardingSubmitAction extends { profilePayload: infer P } ? P : never,
+      navigateTo: { path: '/boards' },
+    };
+    expect(getNavigateArgs(action)).toEqual({ path: '/boards' });
+  });
+});
+
+describe('getSubmitErrorMessage', () => {
+  it('extracts Error.message', () => {
+    expect(getSubmitErrorMessage(new Error('대기자 명단에 추가하는 중 오류가 발생했습니다.'))).toBe(
+      '대기자 명단에 추가하는 중 오류가 발생했습니다.',
+    );
+  });
+
+  it('falls back when input is not an Error', () => {
+    expect(getSubmitErrorMessage('random')).toBe('신청에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    expect(getSubmitErrorMessage(undefined)).toBe('신청에 실패했습니다. 잠시 후 다시 시도해주세요.');
+  });
+});

--- a/apps/web/src/login/utils/onboardingDerived.ts
+++ b/apps/web/src/login/utils/onboardingDerived.ts
@@ -1,0 +1,93 @@
+import type { Board } from '@/board/model/Board';
+import type { OnboardingSubmitAction } from './onboardingSubmit';
+
+export interface OnboardingHeader {
+  title: string;
+  subtitle: string;
+}
+
+/**
+ * Pure derivation of the page header copy from the upcoming board.
+ * `cohort` present → cohort-specific title; absent → generic profile-fill copy.
+ * `firstDay` present → localized Korean date subtitle; absent → fallback copy.
+ */
+export function getOnboardingHeader(
+  upcomingBoard: Board | null | undefined,
+): OnboardingHeader {
+  const title = upcomingBoard?.cohort
+    ? `매글프 ${upcomingBoard.cohort}기 신청하기`
+    : '프로필을 입력해주세요';
+
+  if (!upcomingBoard?.firstDay) {
+    return {
+      title,
+      subtitle: '아래 정보를 채우면 다음 기수가 열릴 때 안내드려요.',
+    };
+  }
+
+  const formatted = upcomingBoard.firstDay
+    .toDate()
+    .toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' });
+
+  return { title, subtitle: `${formatted}에 시작합니다.` };
+}
+
+export interface SubmitCtaInput {
+  isSubmitting: boolean;
+  hasCohort: boolean;
+}
+
+/**
+ * Pure derivation of the CTA label. Replaces the nested ternary in the JSX.
+ */
+export function getSubmitCtaLabel({ isSubmitting, hasCohort }: SubmitCtaInput): string {
+  if (isSubmitting) return '신청 중...';
+  return hasCohort ? '신청하기' : '저장하기';
+}
+
+export interface SubmitDisabledInput {
+  isSubmitting: boolean;
+  hasPrefillError: boolean;
+  requiresCohortAgreement: boolean;
+  hasAgreedToCohort: boolean;
+}
+
+/**
+ * Pure derivation of the submit-disabled flag.
+ * Disabled if submitting, prefill failed, or cohort agreement required-but-missing.
+ */
+export function isSubmitDisabled({
+  isSubmitting,
+  hasPrefillError,
+  requiresCohortAgreement,
+  hasAgreedToCohort,
+}: SubmitDisabledInput): boolean {
+  if (isSubmitting || hasPrefillError) return true;
+  return requiresCohortAgreement && !hasAgreedToCohort;
+}
+
+export interface NavigateArgs {
+  path: string;
+  options?: { state: unknown };
+}
+
+/**
+ * Pure conversion of an OnboardingSubmitAction's navigateTo descriptor into
+ * the (path, options) tuple react-router's `navigate` expects.
+ * Replaces the if/else navigate branch in OnboardingPage.onSubmit.
+ */
+export function getNavigateArgs(action: OnboardingSubmitAction): NavigateArgs {
+  if (action.kind === 'updateThenWaitlist') {
+    return {
+      path: action.navigateTo.path,
+      options: { state: action.navigateTo.state },
+    };
+  }
+  return { path: action.navigateTo.path };
+}
+
+export const SUBMIT_ERROR_FALLBACK = '신청에 실패했습니다. 잠시 후 다시 시도해주세요.';
+
+export function getSubmitErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : SUBMIT_ERROR_FALLBACK;
+}

--- a/apps/web/src/login/utils/onboardingDerived.ts
+++ b/apps/web/src/login/utils/onboardingDerived.ts
@@ -1,5 +1,4 @@
 import type { Board } from '@/board/model/Board';
-import type { OnboardingSubmitAction } from './onboardingSubmit';
 
 export interface OnboardingHeader {
   title: string;
@@ -64,26 +63,6 @@ export function isSubmitDisabled({
 }: SubmitDisabledInput): boolean {
   if (isSubmitting || hasPrefillError) return true;
   return requiresCohortAgreement && !hasAgreedToCohort;
-}
-
-export interface NavigateArgs {
-  path: string;
-  options?: { state: unknown };
-}
-
-/**
- * Pure conversion of an OnboardingSubmitAction's navigateTo descriptor into
- * the (path, options) tuple react-router's `navigate` expects.
- * Replaces the if/else navigate branch in OnboardingPage.onSubmit.
- */
-export function getNavigateArgs(action: OnboardingSubmitAction): NavigateArgs {
-  if (action.kind === 'updateThenWaitlist') {
-    return {
-      path: action.navigateTo.path,
-      options: { state: action.navigateTo.state },
-    };
-  }
-  return { path: action.navigateTo.path };
 }
 
 export const SUBMIT_ERROR_FALLBACK = '신청에 실패했습니다. 잠시 후 다시 시도해주세요.';

--- a/apps/web/src/login/utils/onboardingPrefill.test.ts
+++ b/apps/web/src/login/utils/onboardingPrefill.test.ts
@@ -98,4 +98,19 @@ describe('buildPrefillFormValues', () => {
     const existing = makeUser({ kakaoId: 'kakao_user', phoneNumber: null });
     expect(buildPrefillFormValues(existing, null).activeContactTab).toBe('kakao');
   });
+
+  it('for a first-time user, leaves every non-nickname field at the default', () => {
+    // Regression guard for the late-displayName scenario: if `displayName`
+    // arrives after the user has begun typing into other fields, we must NOT
+    // overwrite realName/phone/kakaoId/referrer. The one-shot guard in
+    // useOnboardingPrefill prevents re-runs, but if that guard is ever lost,
+    // this test ensures the prefill values themselves never carry non-default
+    // data into other fields for the first-time path.
+    const values = buildPrefillFormValues(null, '구글닉');
+    expect(values.realName).toBe('');
+    expect(values.phone).toBe('');
+    expect(values.kakaoId).toBe('');
+    expect(values.referrer).toBe('');
+    expect(values.activeContactTab).toBe('phone');
+  });
 });

--- a/apps/web/src/login/utils/onboardingPrefill.test.ts
+++ b/apps/web/src/login/utils/onboardingPrefill.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import type { User } from '@/user/model/User';
+import { buildPrefillFormValues, pickInitialContactTab } from './onboardingPrefill';
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    uid: 'u1',
+    realName: null,
+    nickname: null,
+    email: null,
+    profilePhotoURL: null,
+    bio: null,
+    phoneNumber: null,
+    kakaoId: null,
+    referrer: null,
+    onboardingComplete: false,
+    boardPermissions: {},
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+describe('pickInitialContactTab', () => {
+  it('returns "phone" when there is no existing profile', () => {
+    expect(pickInitialContactTab(null)).toBe('phone');
+  });
+
+  it('returns "kakao" when only kakaoId is present', () => {
+    expect(pickInitialContactTab(makeUser({ kakaoId: 'kakao_user', phoneNumber: null }))).toBe('kakao');
+  });
+
+  it('returns "phone" when only phoneNumber is present', () => {
+    expect(pickInitialContactTab(makeUser({ phoneNumber: '01012345678', kakaoId: null }))).toBe('phone');
+  });
+
+  it('returns "phone" when both phone and kakao are present', () => {
+    expect(
+      pickInitialContactTab(makeUser({ phoneNumber: '01012345678', kakaoId: 'kakao_user' })),
+    ).toBe('phone');
+  });
+
+  it('returns "phone" when neither contact is present', () => {
+    expect(pickInitialContactTab(makeUser({}))).toBe('phone');
+  });
+});
+
+describe('buildPrefillFormValues', () => {
+  it('returns defaults with displayName-seeded nickname for first-time users', () => {
+    const values = buildPrefillFormValues(null, '카카오닉');
+    expect(values).toEqual({
+      realName: '',
+      nickname: '카카오닉',
+      phone: '',
+      kakaoId: '',
+      referrer: '',
+      activeContactTab: 'phone',
+    });
+  });
+
+  it('returns empty defaults when there is no existing user and no displayName', () => {
+    expect(buildPrefillFormValues(null, null)).toEqual({
+      realName: '',
+      nickname: '',
+      phone: '',
+      kakaoId: '',
+      referrer: '',
+      activeContactTab: 'phone',
+    });
+  });
+
+  it('hydrates from existing profile and prefers existing nickname over displayName', () => {
+    const existing = makeUser({
+      realName: '홍길동',
+      nickname: '글쓴이',
+      phoneNumber: '01012345678',
+      kakaoId: null,
+      referrer: '추천인',
+    });
+    const values = buildPrefillFormValues(existing, '구글닉');
+    expect(values).toEqual({
+      realName: '홍길동',
+      nickname: '글쓴이',
+      phone: '01012345678',
+      kakaoId: '',
+      referrer: '추천인',
+      activeContactTab: 'phone',
+    });
+  });
+
+  it('falls back to displayName when existing nickname is null', () => {
+    const existing = makeUser({ nickname: null, kakaoId: 'k', phoneNumber: null });
+    const values = buildPrefillFormValues(existing, '구글닉');
+    expect(values.nickname).toBe('구글닉');
+    expect(values.activeContactTab).toBe('kakao');
+  });
+
+  it('picks kakao tab when existing user has kakaoId only', () => {
+    const existing = makeUser({ kakaoId: 'kakao_user', phoneNumber: null });
+    expect(buildPrefillFormValues(existing, null).activeContactTab).toBe('kakao');
+  });
+});

--- a/apps/web/src/login/utils/onboardingPrefill.ts
+++ b/apps/web/src/login/utils/onboardingPrefill.ts
@@ -1,0 +1,41 @@
+import type { User } from '@/user/model/User';
+import { ONBOARDING_FORM_DEFAULTS, type OnboardingFormSchema } from './onboardingSchema';
+
+/**
+ * Pure decision for which contact tab to show given an existing profile.
+ * Existing kakaoId without a phone number → kakao tab; otherwise phone tab.
+ */
+export function pickInitialContactTab(existing: User | null): 'phone' | 'kakao' {
+  if (!existing) return 'phone';
+  return existing.kakaoId && !existing.phoneNumber ? 'kakao' : 'phone';
+}
+
+/**
+ * Pure derivation of initial form values for the onboarding form.
+ * Handles both the returning-user path (seed from `existing`) and the
+ * first-time path (seed nickname from auth `displayName` if available).
+ * Returning `null` realName/nickname/etc. coerce to empty strings so
+ * react-hook-form receives a consistent shape.
+ */
+export function buildPrefillFormValues(
+  existing: User | null,
+  displayName: string | null | undefined,
+): OnboardingFormSchema {
+  if (existing) {
+    return {
+      realName: existing.realName ?? '',
+      nickname: existing.nickname ?? displayName ?? '',
+      phone: existing.phoneNumber ?? '',
+      kakaoId: existing.kakaoId ?? '',
+      referrer: existing.referrer ?? '',
+      activeContactTab: pickInitialContactTab(existing),
+    };
+  }
+  return {
+    ...ONBOARDING_FORM_DEFAULTS,
+    nickname: displayName ?? '',
+  };
+}
+
+export const PREFILL_ERROR_MESSAGE =
+  '기존 정보를 불러오지 못했어요. 새로고침 후 다시 시도해주세요. 그대로 제출하면 기존 정보가 덮어쓰일 수 있어요.';

--- a/apps/web/src/login/utils/onboardingSchema.ts
+++ b/apps/web/src/login/utils/onboardingSchema.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { validateKakaoId, validatePhone } from './contactValidation';
+
+export const onboardingSchema = z
+  .object({
+    realName: z.string().trim().min(2, '이름은 2글자 이상이어야 합니다.'),
+    nickname: z.string().trim().min(1, '필명을 입력해주세요.'),
+    phone: z.string(),
+    kakaoId: z.string(),
+    referrer: z.string(),
+    activeContactTab: z.enum(['phone', 'kakao']),
+  })
+  .superRefine((v, ctx) => {
+    const ok =
+      v.activeContactTab === 'phone'
+        ? validatePhone(v.phone) !== null
+        : validateKakaoId(v.kakaoId) !== null;
+    if (ok) return;
+    ctx.addIssue({
+      code: 'custom',
+      message: '연락처를 입력해주세요.',
+      path: [v.activeContactTab === 'phone' ? 'phone' : 'kakaoId'],
+    });
+  });
+
+export type OnboardingFormSchema = z.infer<typeof onboardingSchema>;
+
+export const ONBOARDING_FORM_DEFAULTS: OnboardingFormSchema = {
+  realName: '',
+  nickname: '',
+  phone: '',
+  kakaoId: '',
+  referrer: '',
+  activeContactTab: 'phone',
+};

--- a/apps/web/src/user/components/BlockLimitDialog.tsx
+++ b/apps/web/src/user/components/BlockLimitDialog.tsx
@@ -1,0 +1,35 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/shared/ui/alert-dialog';
+import { MAX_BLOCKED_USERS } from '@/user/utils/blockedUsersUtils';
+
+interface BlockLimitDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function BlockLimitDialog({ open, onOpenChange }: BlockLimitDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>비공개 사용자 한도 초과</AlertDialogTitle>
+        </AlertDialogHeader>
+        <div className="py-4">
+          <p>비공개 사용자는 최대 {MAX_BLOCKED_USERS}명까지만 설정할 수 있습니다.</p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            새로운 사용자를 추가하려면 기존 사용자의 설정을 먼저 해제해주세요.
+          </p>
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogAction onClick={() => onOpenChange(false)}>확인</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/user/components/BlockSuggestionRow.tsx
+++ b/apps/web/src/user/components/BlockSuggestionRow.tsx
@@ -1,0 +1,44 @@
+import { Button } from '@/shared/ui/button';
+import ComposedAvatar from '@/shared/ui/ComposedAvatar';
+import type { User } from '@/user/model/User';
+
+interface BlockSuggestionRowProps {
+  user: User;
+  active: boolean;
+  loading: boolean;
+  onBlock: () => void;
+  onActivate: () => void;
+}
+
+export default function BlockSuggestionRow({
+  user,
+  active,
+  loading,
+  onBlock,
+  onActivate,
+}: BlockSuggestionRowProps) {
+  return (
+    <Button
+      variant="ghost"
+      asChild={false}
+      onClick={onBlock}
+      disabled={loading}
+      onMouseEnter={onActivate}
+      className={`flex h-auto w-full items-center justify-start gap-3 rounded-none p-3 text-left hover:bg-muted ${
+        active ? 'bg-muted' : ''
+      }`}
+    >
+      <ComposedAvatar
+        className="shrink-0"
+        size={32}
+        src={user.profilePhotoURL || undefined}
+        alt={user.nickname || 'User'}
+        fallback={user.nickname?.[0] || ''}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-medium">{user.nickname}</div>
+        <div className="truncate text-sm text-muted-foreground">{user.email}</div>
+      </div>
+    </Button>
+  );
+}

--- a/apps/web/src/user/components/BlockSuggestionRow.tsx
+++ b/apps/web/src/user/components/BlockSuggestionRow.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@/shared/ui/button';
 import ComposedAvatar from '@/shared/ui/ComposedAvatar';
 import type { User } from '@/user/model/User';
 
@@ -10,6 +9,9 @@ interface BlockSuggestionRowProps {
   onActivate: () => void;
 }
 
+// Raw <button> instead of shadcn Button: the original page used a hand-tuned
+// button with `text-left`, no shadcn ring/padding defaults, and `hover:bg-muted`
+// on the whole row. Keeping it raw preserves the exact appearance.
 export default function BlockSuggestionRow({
   user,
   active,
@@ -18,15 +20,14 @@ export default function BlockSuggestionRow({
   onActivate,
 }: BlockSuggestionRowProps) {
   return (
-    <Button
-      variant="ghost"
-      asChild={false}
+    <button
+      type="button"
+      className={`flex w-full items-center gap-3 p-3 text-left transition-colors hover:bg-muted ${
+        active ? 'bg-muted' : ''
+      }`}
       onClick={onBlock}
       disabled={loading}
       onMouseEnter={onActivate}
-      className={`flex h-auto w-full items-center justify-start gap-3 rounded-none p-3 text-left hover:bg-muted ${
-        active ? 'bg-muted' : ''
-      }`}
     >
       <ComposedAvatar
         className="shrink-0"
@@ -39,6 +40,6 @@ export default function BlockSuggestionRow({
         <div className="truncate font-medium">{user.nickname}</div>
         <div className="truncate text-sm text-muted-foreground">{user.email}</div>
       </div>
-    </Button>
+    </button>
   );
 }

--- a/apps/web/src/user/components/BlockSuggestionsDropdown.tsx
+++ b/apps/web/src/user/components/BlockSuggestionsDropdown.tsx
@@ -1,0 +1,65 @@
+import { useMemo, type RefObject } from 'react';
+import useUserSearch from '@/user/hooks/useUserSearch';
+import type { User } from '@/user/model/User';
+import { filterBlockSuggestions } from '@/user/utils/blockedUsersUtils';
+import BlockSuggestionRow from './BlockSuggestionRow';
+
+interface BlockSuggestionsDropdownProps {
+  searchQuery: string;
+  blockedUsers: User[];
+  currentUser: User | null;
+  selectedIndex: number;
+  loading: boolean;
+  suggestionsRef: RefObject<HTMLDivElement | null>;
+  onBlock: (user: User) => void;
+  onActivate: (index: number) => void;
+}
+
+/**
+ * Suspense-aware autocomplete for the "block a user" search box. Uses the
+ * project-wide `useUserSearch` hook (suspense=true) and the pure
+ * `filterBlockSuggestions` helper, so this file only owns layout.
+ */
+export default function BlockSuggestionsDropdown({
+  searchQuery,
+  blockedUsers,
+  currentUser,
+  selectedIndex,
+  loading,
+  suggestionsRef,
+  onBlock,
+  onActivate,
+}: BlockSuggestionsDropdownProps) {
+  const { data: searchResult } = useUserSearch(searchQuery, currentUser?.boardPermissions);
+  const suggestions = useMemo(
+    () => filterBlockSuggestions(searchResult, blockedUsers, currentUser?.uid, searchQuery),
+    [searchResult, searchQuery, blockedUsers, currentUser?.uid],
+  );
+
+  if (suggestions.length === 0) {
+    if (!searchQuery.trim()) return null;
+    return (
+      <div className="absolute inset-x-0 top-full z-50 mt-1 rounded-md border bg-background p-4 text-center text-muted-foreground shadow-lg">
+        검색 결과가 없습니다
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={suggestionsRef}
+      className="absolute inset-x-0 top-full z-50 mt-1 max-h-60 overflow-y-auto rounded-md border bg-background shadow-lg"
+    >
+      {suggestions.map((user, index) => (
+        <BlockSuggestionRow
+          key={user.uid}
+          user={user}
+          active={index === selectedIndex}
+          loading={loading}
+          onBlock={() => onBlock(user)}
+          onActivate={() => onActivate(index)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/user/components/BlockedUserRow.tsx
+++ b/apps/web/src/user/components/BlockedUserRow.tsx
@@ -1,0 +1,68 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/shared/ui/alert-dialog';
+import { Button } from '@/shared/ui/button';
+import ComposedAvatar from '@/shared/ui/ComposedAvatar';
+import type { User } from '@/user/model/User';
+
+interface BlockedUserRowProps {
+  user: User;
+  loading: boolean;
+  isConfirming: boolean;
+  onRequestUnblock: () => void;
+  onCancelUnblock: () => void;
+  onConfirmUnblock: () => void;
+}
+
+export default function BlockedUserRow({
+  user,
+  loading,
+  isConfirming,
+  onRequestUnblock,
+  onCancelUnblock,
+  onConfirmUnblock,
+}: BlockedUserRowProps) {
+  return (
+    <div className="flex items-center gap-3 py-2">
+      <ComposedAvatar
+        className="shrink-0"
+        size={40}
+        src={user.profilePhotoURL || undefined}
+        alt={user.nickname || 'User'}
+        fallback={user.nickname?.[0] || ''}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-medium">{user.nickname}</div>
+        <div className="truncate text-sm text-muted-foreground">{user.email}</div>
+      </div>
+      <AlertDialog open={isConfirming}>
+        <AlertDialogTrigger asChild>
+          <Button variant="outline" size="sm" onClick={onRequestUnblock} disabled={loading}>
+            해제
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{user.nickname}님의 비공개 설정을 해제하시겠습니까?</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={onCancelUnblock}>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={onConfirmUnblock}
+              className="bg-destructive hover:bg-destructive/90"
+            >
+              해제
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/web/src/user/components/BlockedUserSearchCard.tsx
+++ b/apps/web/src/user/components/BlockedUserSearchCard.tsx
@@ -1,0 +1,108 @@
+import { Search, X } from 'lucide-react';
+import { Suspense, type ChangeEvent, type KeyboardEvent, type RefObject } from 'react';
+import { Button } from '@/shared/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
+import { Input } from '@/shared/ui/input';
+import type { User } from '@/user/model/User';
+import { MAX_BLOCKED_USERS } from '@/user/utils/blockedUsersUtils';
+import BlockSuggestionsDropdown from './BlockSuggestionsDropdown';
+
+interface BlockedUserSearchCardProps {
+  searchQuery: string;
+  showSuggestions: boolean;
+  isAtLimit: boolean;
+  loading: boolean;
+  selectedSuggestionIndex: number;
+  blockedUsers: User[];
+  currentUser: User | null;
+  searchInputRef: RefObject<HTMLInputElement | null>;
+  suggestionsRef: RefObject<HTMLDivElement | null>;
+  onSearchChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onSearchFocus: () => void;
+  onKeyDown: (e: KeyboardEvent) => void;
+  onClearSearch: () => void;
+  onBlock: (user: User) => void;
+  onSuggestionActivate: (index: number) => void;
+}
+
+export default function BlockedUserSearchCard({
+  searchQuery,
+  showSuggestions,
+  isAtLimit,
+  loading,
+  selectedSuggestionIndex,
+  blockedUsers,
+  currentUser,
+  searchInputRef,
+  suggestionsRef,
+  onSearchChange,
+  onSearchFocus,
+  onKeyDown,
+  onClearSearch,
+  onBlock,
+  onSuggestionActivate,
+}: BlockedUserSearchCardProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-4">
+        <CardTitle className="text-lg">사용자 검색</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="relative">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              ref={searchInputRef}
+              placeholder="닉네임 또는 이메일로 검색"
+              value={searchQuery}
+              onChange={onSearchChange}
+              onKeyDown={onKeyDown}
+              onFocus={onSearchFocus}
+              className="px-10"
+              disabled={loading || isAtLimit}
+            />
+            {searchQuery && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="absolute right-1 top-1/2 size-8 -translate-y-1/2"
+                onClick={onClearSearch}
+              >
+                <X className="size-4" />
+              </Button>
+            )}
+          </div>
+
+          {showSuggestions && searchQuery.trim() && (
+            <Suspense fallback={<SearchingFallback />}>
+              <BlockSuggestionsDropdown
+                searchQuery={searchQuery}
+                blockedUsers={blockedUsers}
+                currentUser={currentUser}
+                selectedIndex={selectedSuggestionIndex}
+                loading={loading}
+                suggestionsRef={suggestionsRef}
+                onBlock={onBlock}
+                onActivate={onSuggestionActivate}
+              />
+            </Suspense>
+          )}
+        </div>
+
+        {isAtLimit && (
+          <div className="rounded-md bg-muted/50 p-3 text-sm text-muted-foreground">
+            💡 비공개 사용자는 최대 {MAX_BLOCKED_USERS}명까지 설정할 수 있습니다
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SearchingFallback() {
+  return (
+    <div className="absolute inset-x-0 top-full z-50 mt-1 rounded-md border bg-background p-4 text-center text-muted-foreground shadow-lg">
+      검색 중...
+    </div>
+  );
+}

--- a/apps/web/src/user/components/BlockedUsersHeader.tsx
+++ b/apps/web/src/user/components/BlockedUsersHeader.tsx
@@ -1,0 +1,16 @@
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/shared/ui/button';
+
+export default function BlockedUsersHeader() {
+  return (
+    <header className="flex items-center gap-3">
+      <Button variant="ghost" size="icon" className="shrink-0" onClick={() => window.history.back()}>
+        <ArrowLeft className="size-5" />
+      </Button>
+      <div>
+        <h1 className="text-2xl font-bold">비공개 사용자 관리</h1>
+        <p className="mt-1 text-sm text-muted-foreground">비공개 사용자에게는 내 콘텐츠가 보이지 않습니다</p>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/user/components/BlockedUsersListCard.tsx
+++ b/apps/web/src/user/components/BlockedUsersListCard.tsx
@@ -1,0 +1,66 @@
+import { UserX } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
+import { Separator } from '@/shared/ui/separator';
+import type { User } from '@/user/model/User';
+import { MAX_BLOCKED_USERS } from '@/user/utils/blockedUsersUtils';
+import BlockedUserRow from './BlockedUserRow';
+
+interface BlockedUsersListCardProps {
+  blockedUsers: User[];
+  loading: boolean;
+  confirmUnblockUid: string | null;
+  onRequestUnblock: (uid: string) => void;
+  onCancelUnblock: () => void;
+  onConfirmUnblock: (uid: string) => void;
+}
+
+export default function BlockedUsersListCard({
+  blockedUsers,
+  loading,
+  confirmUnblockUid,
+  onRequestUnblock,
+  onCancelUnblock,
+  onConfirmUnblock,
+}: BlockedUsersListCardProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-4">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg">비공개 사용자 목록</CardTitle>
+          <span className="text-sm text-muted-foreground">
+            {blockedUsers.length}/{MAX_BLOCKED_USERS}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {blockedUsers.length === 0 ? <EmptyState /> : (
+          <div className="space-y-3">
+            {blockedUsers.map((user, index) => (
+              <div key={user.uid}>
+                <BlockedUserRow
+                  user={user}
+                  loading={loading}
+                  isConfirming={confirmUnblockUid === user.uid}
+                  onRequestUnblock={() => onRequestUnblock(user.uid)}
+                  onCancelUnblock={onCancelUnblock}
+                  onConfirmUnblock={() => onConfirmUnblock(user.uid)}
+                />
+                {index < blockedUsers.length - 1 && <Separator />}
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="py-8 text-center text-muted-foreground">
+      <UserX className="mx-auto mb-3 size-12 opacity-50" />
+      <p>비공개 사용자가 없습니다</p>
+      <p className="mt-1 text-sm">위에서 사용자를 검색하여 추가해보세요</p>
+    </div>
+  );
+}

--- a/apps/web/src/user/components/BlockedUsersPage.tsx
+++ b/apps/web/src/user/components/BlockedUsersPage.tsx
@@ -1,99 +1,16 @@
-import { ArrowLeft, Search, UserX, X } from 'lucide-react';
-import { Suspense, useCallback, useMemo, useRef, useState, type ChangeEvent, type KeyboardEvent } from 'react';
+import { useCallback, useRef, useState, type ChangeEvent, type KeyboardEvent } from 'react';
 import { useAuth } from '@/shared/hooks/useAuth';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/shared/ui/alert-dialog';
-import { Button } from '@/shared/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
-import ComposedAvatar from '@/shared/ui/ComposedAvatar';
-import { Input } from '@/shared/ui/input';
-import { Separator } from '@/shared/ui/separator';
 import { useBlockedUsersList } from '@/user/hooks/useBlockedUsersList';
 import { useCloseSuggestionsOnOutsideClick } from '@/user/hooks/useCloseSuggestionsOnOutsideClick';
-import useUserSearch from '@/user/hooks/useUserSearch';
 import type { User } from '@/user/model/User';
 import {
-  filterBlockSuggestions,
   getNextSuggestionIndex,
   isCloseSuggestionsKey,
-  MAX_BLOCKED_USERS,
 } from '@/user/utils/blockedUsersUtils';
-
-// 검색 서제스트 드롭다운만 별도 컴포넌트로 분리 (Suspense 지원)
-function SuggestionsDropdown({
-  searchQuery,
-  blockedUsers,
-  currentUser,
-  handleBlock,
-  selectedSuggestionIndex,
-  setSelectedSuggestionIndex,
-  loading,
-  suggestionsRef,
-}: {
-  searchQuery: string;
-  blockedUsers: User[];
-  currentUser: User | null;
-  handleBlock: (user: User) => void;
-  selectedSuggestionIndex: number;
-  setSelectedSuggestionIndex: (idx: number) => void;
-  loading: boolean;
-  suggestionsRef: React.RefObject<HTMLDivElement | null>;
-}) {
-  const { data: searchResult } = useUserSearch(searchQuery, currentUser?.boardPermissions);
-  const suggestions = useMemo(
-    () => filterBlockSuggestions(searchResult, blockedUsers, currentUser?.uid, searchQuery),
-    [searchResult, searchQuery, blockedUsers, currentUser?.uid],
-  );
-
-  if (suggestions.length > 0) {
-    return (
-      <div
-        ref={suggestionsRef}
-        className="absolute inset-x-0 top-full z-50 mt-1 max-h-60 overflow-y-auto rounded-md border bg-background shadow-lg"
-      >
-        {suggestions.map((user, index) => (
-          <button
-            key={user.uid}
-            className={`flex w-full items-center gap-3 p-3 text-left transition-colors hover:bg-muted ${
-              index === selectedSuggestionIndex ? 'bg-muted' : ''
-            }`}
-            onClick={() => handleBlock(user)}
-            disabled={loading}
-            onMouseEnter={() => setSelectedSuggestionIndex(index)}
-          >
-            <ComposedAvatar
-              className="shrink-0"
-              size={32}
-              src={user.profilePhotoURL || undefined}
-              alt={user.nickname || 'User'}
-              fallback={user.nickname?.[0] || ''}
-            />
-            <div className="min-w-0 flex-1">
-              <div className="truncate font-medium">{user.nickname}</div>
-              <div className="truncate text-sm text-muted-foreground">{user.email}</div>
-            </div>
-          </button>
-        ))}
-      </div>
-    );
-  }
-  if (searchQuery.trim()) {
-    return (
-      <div className="absolute inset-x-0 top-full z-50 mt-1 rounded-md border bg-background p-4 text-center text-muted-foreground shadow-lg">
-        검색 결과가 없습니다
-      </div>
-    );
-  }
-  return null;
-}
+import BlockLimitDialog from './BlockLimitDialog';
+import BlockedUserSearchCard from './BlockedUserSearchCard';
+import BlockedUsersHeader from './BlockedUsersHeader';
+import BlockedUsersListCard from './BlockedUsersListCard';
 
 export default function BlockedUsersPage() {
   const { currentUser } = useAuth();
@@ -157,159 +74,33 @@ export default function BlockedUsersPage() {
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-2xl space-y-6 px-4 py-6">
-        <header className="flex items-center gap-3">
-          <Button variant="ghost" size="icon" className="shrink-0" onClick={() => window.history.back()}>
-            <ArrowLeft className="size-5" />
-          </Button>
-          <div>
-            <h1 className="text-2xl font-bold">비공개 사용자 관리</h1>
-            <p className="mt-1 text-sm text-muted-foreground">비공개 사용자에게는 내 콘텐츠가 보이지 않습니다</p>
-          </div>
-        </header>
-
-        <Card>
-          <CardHeader className="pb-4">
-            <CardTitle className="text-lg">사용자 검색</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="relative">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  ref={searchInputRef}
-                  placeholder="닉네임 또는 이메일로 검색"
-                  value={searchQuery}
-                  onChange={handleSearchChange}
-                  onKeyDown={handleKeyDown}
-                  onFocus={() => searchQuery.trim() && setShowSuggestions(true)}
-                  className="px-10"
-                  disabled={loading || isAtLimit}
-                />
-                {searchQuery && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="absolute right-1 top-1/2 size-8 -translate-y-1/2"
-                    onClick={clearSearch}
-                  >
-                    <X className="size-4" />
-                  </Button>
-                )}
-              </div>
-
-              {showSuggestions && searchQuery.trim() && (
-                <Suspense
-                  fallback={
-                    <div className="absolute inset-x-0 top-full z-50 mt-1 rounded-md border bg-background p-4 text-center text-muted-foreground shadow-lg">
-                      검색 중...
-                    </div>
-                  }
-                >
-                  <SuggestionsDropdown
-                    searchQuery={searchQuery}
-                    blockedUsers={blockedUsers}
-                    currentUser={currentUser as User | null}
-                    handleBlock={handleBlock}
-                    selectedSuggestionIndex={selectedSuggestionIndex}
-                    setSelectedSuggestionIndex={setSelectedSuggestionIndex}
-                    loading={loading}
-                    suggestionsRef={suggestionsRef}
-                  />
-                </Suspense>
-              )}
-            </div>
-
-            {isAtLimit && (
-              <div className="rounded-md bg-muted/50 p-3 text-sm text-muted-foreground">
-                💡 비공개 사용자는 최대 {MAX_BLOCKED_USERS}명까지 설정할 수 있습니다
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-4">
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-lg">비공개 사용자 목록</CardTitle>
-              <span className="text-sm text-muted-foreground">
-                {blockedUsers.length}/{MAX_BLOCKED_USERS}
-              </span>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {blockedUsers.length === 0 ? (
-              <div className="py-8 text-center text-muted-foreground">
-                <UserX className="mx-auto mb-3 size-12 opacity-50" />
-                <p>비공개 사용자가 없습니다</p>
-                <p className="mt-1 text-sm">위에서 사용자를 검색하여 추가해보세요</p>
-              </div>
-            ) : (
-              <div className="space-y-3">
-                {blockedUsers.map((user, index) => (
-                  <div key={user.uid}>
-                    <div className="flex items-center gap-3 py-2">
-                      <ComposedAvatar
-                        className="shrink-0"
-                        size={40}
-                        src={user.profilePhotoURL || undefined}
-                        alt={user.nickname || 'User'}
-                        fallback={user.nickname?.[0] || ''}
-                      />
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate font-medium">{user.nickname}</div>
-                        <div className="truncate text-sm text-muted-foreground">{user.email}</div>
-                      </div>
-                      <AlertDialog open={confirmUnblockUid === user.uid}>
-                        <AlertDialogTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setConfirmUnblockUid(user.uid)}
-                            disabled={loading}
-                          >
-                            해제
-                          </Button>
-                        </AlertDialogTrigger>
-                        <AlertDialogContent>
-                          <AlertDialogHeader>
-                            <AlertDialogTitle>{user.nickname}님의 비공개 설정을 해제하시겠습니까?</AlertDialogTitle>
-                          </AlertDialogHeader>
-                          <AlertDialogFooter>
-                            <AlertDialogCancel onClick={() => setConfirmUnblockUid(null)}>취소</AlertDialogCancel>
-                            <AlertDialogAction
-                              onClick={() => handleUnblock(user.uid)}
-                              className="bg-destructive hover:bg-destructive/90"
-                            >
-                              해제
-                            </AlertDialogAction>
-                          </AlertDialogFooter>
-                        </AlertDialogContent>
-                      </AlertDialog>
-                    </div>
-                    {index < blockedUsers.length - 1 && <Separator />}
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <AlertDialog open={showLimitDialog} onOpenChange={setShowLimitDialog}>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>비공개 사용자 한도 초과</AlertDialogTitle>
-            </AlertDialogHeader>
-            <div className="py-4">
-              <p>비공개 사용자는 최대 {MAX_BLOCKED_USERS}명까지만 설정할 수 있습니다.</p>
-              <p className="mt-2 text-sm text-muted-foreground">
-                새로운 사용자를 추가하려면 기존 사용자의 설정을 먼저 해제해주세요.
-              </p>
-            </div>
-            <AlertDialogFooter>
-              <AlertDialogAction onClick={() => setShowLimitDialog(false)}>확인</AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <BlockedUsersHeader />
+        <BlockedUserSearchCard
+          searchQuery={searchQuery}
+          showSuggestions={showSuggestions}
+          isAtLimit={isAtLimit}
+          loading={loading}
+          selectedSuggestionIndex={selectedSuggestionIndex}
+          blockedUsers={blockedUsers}
+          currentUser={currentUser as User | null}
+          searchInputRef={searchInputRef}
+          suggestionsRef={suggestionsRef}
+          onSearchChange={handleSearchChange}
+          onSearchFocus={() => searchQuery.trim() && setShowSuggestions(true)}
+          onKeyDown={handleKeyDown}
+          onClearSearch={clearSearch}
+          onBlock={handleBlock}
+          onSuggestionActivate={setSelectedSuggestionIndex}
+        />
+        <BlockedUsersListCard
+          blockedUsers={blockedUsers}
+          loading={loading}
+          confirmUnblockUid={confirmUnblockUid}
+          onRequestUnblock={setConfirmUnblockUid}
+          onCancelUnblock={() => setConfirmUnblockUid(null)}
+          onConfirmUnblock={handleUnblock}
+        />
+        <BlockLimitDialog open={showLimitDialog} onOpenChange={setShowLimitDialog} />
       </div>
     </div>
   );

--- a/apps/web/src/user/components/BlockedUsersPage.tsx
+++ b/apps/web/src/user/components/BlockedUsersPage.tsx
@@ -1,26 +1,31 @@
-import { ArrowLeft, UserX, Search, X } from "lucide-react"
-import { useState, useEffect, useMemo, useRef, Suspense } from "react"
-import { toast } from "sonner"
-import { useAuth } from '@/shared/hooks/useAuth'
+import { ArrowLeft, Search, UserX, X } from 'lucide-react';
+import { Suspense, useCallback, useMemo, useRef, useState, type ChangeEvent, type KeyboardEvent } from 'react';
+import { useAuth } from '@/shared/hooks/useAuth';
 import {
   AlertDialog,
-  AlertDialogTrigger,
+  AlertDialogAction,
+  AlertDialogCancel,
   AlertDialogContent,
+  AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogFooter,
-  AlertDialogCancel,
-  AlertDialogAction,
-} from "@/shared/ui/alert-dialog"
-import ComposedAvatar from "@/shared/ui/ComposedAvatar"
-import { Button } from "@/shared/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card"
-import { Input } from "@/shared/ui/input"
-import { Separator } from "@/shared/ui/separator"
-import { blockUser, unblockUser, getBlockedUsers, fetchUser } from '@/user/api/user'
-import useUserSearch from '@/user/hooks/useUserSearch'
-import type { User } from '@/user/model/User'
-import type React from "react"
+  AlertDialogTrigger,
+} from '@/shared/ui/alert-dialog';
+import { Button } from '@/shared/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
+import ComposedAvatar from '@/shared/ui/ComposedAvatar';
+import { Input } from '@/shared/ui/input';
+import { Separator } from '@/shared/ui/separator';
+import { useBlockedUsersList } from '@/user/hooks/useBlockedUsersList';
+import { useCloseSuggestionsOnOutsideClick } from '@/user/hooks/useCloseSuggestionsOnOutsideClick';
+import useUserSearch from '@/user/hooks/useUserSearch';
+import type { User } from '@/user/model/User';
+import {
+  filterBlockSuggestions,
+  getNextSuggestionIndex,
+  isCloseSuggestionsKey,
+  MAX_BLOCKED_USERS,
+} from '@/user/utils/blockedUsersUtils';
 
 // 검색 서제스트 드롭다운만 별도 컴포넌트로 분리 (Suspense 지원)
 function SuggestionsDropdown({
@@ -33,30 +38,20 @@ function SuggestionsDropdown({
   loading,
   suggestionsRef,
 }: {
-  searchQuery: string
-  blockedUsers: User[]
-  currentUser: User | null
-  handleBlock: (user: User) => void
-  selectedSuggestionIndex: number
-  setSelectedSuggestionIndex: (idx: number) => void
-  loading: boolean
-  suggestionsRef: React.RefObject<HTMLDivElement>
+  searchQuery: string;
+  blockedUsers: User[];
+  currentUser: User | null;
+  handleBlock: (user: User) => void;
+  selectedSuggestionIndex: number;
+  setSelectedSuggestionIndex: (idx: number) => void;
+  loading: boolean;
+  suggestionsRef: React.RefObject<HTMLDivElement | null>;
 }) {
-  const { data: searchResult } = useUserSearch(searchQuery, currentUser?.boardPermissions)
-  const suggestions = useMemo(() => {
-    if (!searchResult || !searchQuery.trim()) return []
-    const blockedUids = new Set(blockedUsers.map((user) => user.uid))
-    const currentUserUid = currentUser?.uid
-    const arr = Array.isArray(searchResult) ? searchResult : [searchResult]
-    return arr
-      .filter(
-        (user) =>
-          user &&
-          user.uid !== currentUserUid &&
-          !blockedUids.has(user.uid)
-      )
-      .slice(0, 5)
-  }, [searchResult, searchQuery, blockedUsers, currentUser])
+  const { data: searchResult } = useUserSearch(searchQuery, currentUser?.boardPermissions);
+  const suggestions = useMemo(
+    () => filterBlockSuggestions(searchResult, blockedUsers, currentUser?.uid, searchQuery),
+    [searchResult, searchQuery, blockedUsers, currentUser?.uid],
+  );
 
   if (suggestions.length > 0) {
     return (
@@ -68,7 +63,7 @@ function SuggestionsDropdown({
           <button
             key={user.uid}
             className={`flex w-full items-center gap-3 p-3 text-left transition-colors hover:bg-muted ${
-              index === selectedSuggestionIndex ? "bg-muted" : ""
+              index === selectedSuggestionIndex ? 'bg-muted' : ''
             }`}
             onClick={() => handleBlock(user)}
             disabled={loading}
@@ -88,153 +83,80 @@ function SuggestionsDropdown({
           </button>
         ))}
       </div>
-    )
+    );
   }
-  if (searchQuery.trim() && suggestions.length === 0) {
+  if (searchQuery.trim()) {
     return (
       <div className="absolute inset-x-0 top-full z-50 mt-1 rounded-md border bg-background p-4 text-center text-muted-foreground shadow-lg">
         검색 결과가 없습니다
       </div>
-    )
+    );
   }
-  return null
+  return null;
 }
 
 export default function BlockedUsersPage() {
-  const { currentUser } = useAuth()
-  const [blockedUsers, setBlockedUsers] = useState<User[]>([])
-  const [searchQuery, setSearchQuery] = useState("")
-  const [showSuggestions, setShowSuggestions] = useState(false)
-  const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(-1)
-  const [loading, setLoading] = useState(false)
-  const [confirmUnblockUid, setConfirmUnblockUid] = useState<string | null>(null)
-  const [showLimitDialog, setShowLimitDialog] = useState(false)
-  const searchInputRef = useRef<HTMLInputElement>(null)
-  const suggestionsRef = useRef<HTMLDivElement>(null)
+  const { currentUser } = useAuth();
+  const { blockedUsers, loading, isAtLimit, block, unblock } = useBlockedUsersList(currentUser);
 
-  // 차단 목록 불러오기
-  useEffect(() => {
-    if (!currentUser) return;
-    (async () => {
-      const blockedUids = await getBlockedUsers(currentUser.uid);
-      if (!blockedUids || blockedUids.length === 0) {
-        setBlockedUsers([]);
-        return;
-      }
-      // 차단 유저 정보 fetch
-      const results = await Promise.allSettled(
-        blockedUids.map(uid => fetchUser(uid))
-      );
-      const rejectedCount = results.filter(r => r.status === 'rejected').length;
-      const users = results
-        .filter((r): r is PromiseFulfilledResult<User | null> => r.status === 'fulfilled')
-        .map(r => r.value)
-        .filter((u): u is User => u !== null);
-      if (rejectedCount > 0 && users.length > 0) {
-        toast.warning(`차단된 사용자 ${rejectedCount}명의 정보를 불러오지 못했습니다.`);
-      }
-      if (users.length === 0 && rejectedCount === results.length) {
-        toast.error('차단된 사용자 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.');
-        return;
-      }
-      setBlockedUsers(users);
-    })();
-  }, [currentUser]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(-1);
+  const [confirmUnblockUid, setConfirmUnblockUid] = useState<string | null>(null);
+  const [showLimitDialog, setShowLimitDialog] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const suggestionsRef = useRef<HTMLDivElement>(null);
 
-  // Handle search input
-  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
-    setSearchQuery(value)
-    setShowSuggestions(value.trim().length > 0)
-    setSelectedSuggestionIndex(-1)
-  }
+  const closeSuggestions = useCallback(() => setShowSuggestions(false), []);
+  useCloseSuggestionsOnOutsideClick(searchInputRef, suggestionsRef, closeSuggestions);
 
-  // Handle keyboard navigation
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    // Suspense 내부에서만 suggestions 사용
-    if (!showSuggestions) return
-    switch (e.key) {
-      case "ArrowDown":
-        e.preventDefault()
-        setSelectedSuggestionIndex((prev) => prev + 1)
-        break
-      case "ArrowUp":
-        e.preventDefault()
-        setSelectedSuggestionIndex((prev) => (prev > 0 ? prev - 1 : 0))
-        break
-      case "Enter":
-        e.preventDefault()
-        // Suspense 내부에서 suggestionsRef.current로 처리
-        break
-      case "Escape":
-        setShowSuggestions(false)
-        setSelectedSuggestionIndex(-1)
-        break
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchQuery(value);
+    setShowSuggestions(value.trim().length > 0);
+    setSelectedSuggestionIndex(-1);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (!showSuggestions) return;
+    const nextIndex = getNextSuggestionIndex(selectedSuggestionIndex, e.key);
+    if (nextIndex !== null) {
+      e.preventDefault();
+      setSelectedSuggestionIndex(nextIndex);
+      return;
     }
-  }
-
-  // Handle clicking outside to close suggestions
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        searchInputRef.current &&
-        suggestionsRef.current &&
-        !searchInputRef.current.contains(event.target as Node) &&
-        !suggestionsRef.current.contains(event.target as Node)
-      ) {
-        setShowSuggestions(false)
-      }
+    if (isCloseSuggestionsKey(e.key)) {
+      setShowSuggestions(false);
+      setSelectedSuggestionIndex(-1);
     }
-    document.addEventListener("mousedown", handleClickOutside)
-    return () => document.removeEventListener("mousedown", handleClickOutside)
-  }, [])
+  };
 
-  // Block user
   const handleBlock = async (user: User) => {
-    if (!currentUser) return;
-    if (blockedUsers.length >= 10) {
-      setShowLimitDialog(true)
-      return
+    const outcome = await block(user);
+    if (outcome.kind === 'limit-exceeded') {
+      setShowLimitDialog(true);
+      return;
     }
-    setLoading(true)
-    try {
-      await blockUser(currentUser.uid, user.uid)
-      setBlockedUsers((prev) => [...prev, user])
-      setSearchQuery("")
-      setShowSuggestions(false)
-      toast.success(`${user.nickname}님을 비공개 사용자로 설정했습니다.`, {position: 'bottom-center'})
-    } catch (error) {
-      toast.error("비공개 사용자 설정 중 오류가 발생했습니다.", {position: 'bottom-center'})
+    if (outcome.kind === 'success') {
+      setSearchQuery('');
+      setShowSuggestions(false);
     }
-    setLoading(false)
-  }
+  };
 
-  // Unblock user
   const handleUnblock = async (uid: string) => {
-    if (!currentUser) return;
-    setLoading(true)
-    try {
-      await unblockUser(currentUser.uid, uid)
-      const user = blockedUsers.find((u) => u.uid === uid)
-      setBlockedUsers((prev) => prev.filter((u) => u.uid !== uid))
-      setConfirmUnblockUid(null)
-      toast.success(`${user?.nickname}님의 비공개 설정을 해제했습니다.`, {position: 'bottom-center'})
-    } catch (error) {
-      toast.error("비공개 설정 해제 중 오류가 발생했습니다.", {position: 'bottom-center'})
-    }
-    setLoading(false)
-  }
+    const outcome = await unblock(uid);
+    if (outcome.kind === 'success') setConfirmUnblockUid(null);
+  };
 
   const clearSearch = () => {
-    setSearchQuery("")
-    setShowSuggestions(false)
-    searchInputRef.current?.focus()
-  }
+    setSearchQuery('');
+    setShowSuggestions(false);
+    searchInputRef.current?.focus();
+  };
 
   return (
     <div className="min-h-screen bg-background">
       <div className="mx-auto max-w-2xl space-y-6 px-4 py-6">
-        {/* Header */}
         <header className="flex items-center gap-3">
           <Button variant="ghost" size="icon" className="shrink-0" onClick={() => window.history.back()}>
             <ArrowLeft className="size-5" />
@@ -245,7 +167,6 @@ export default function BlockedUsersPage() {
           </div>
         </header>
 
-        {/* Search Section */}
         <Card>
           <CardHeader className="pb-4">
             <CardTitle className="text-lg">사용자 검색</CardTitle>
@@ -262,7 +183,7 @@ export default function BlockedUsersPage() {
                   onKeyDown={handleKeyDown}
                   onFocus={() => searchQuery.trim() && setShowSuggestions(true)}
                   className="px-10"
-                  disabled={loading || blockedUsers.length >= 10}
+                  disabled={loading || isAtLimit}
                 />
                 {searchQuery && (
                   <Button
@@ -276,17 +197,18 @@ export default function BlockedUsersPage() {
                 )}
               </div>
 
-              {/* Suspense로 검색 결과만 감싸기 */}
               {showSuggestions && searchQuery.trim() && (
-                <Suspense fallback={
-                  <div className="absolute inset-x-0 top-full z-50 mt-1 rounded-md border bg-background p-4 text-center text-muted-foreground shadow-lg">
-                    검색 중...
-                  </div>
-                }>
+                <Suspense
+                  fallback={
+                    <div className="absolute inset-x-0 top-full z-50 mt-1 rounded-md border bg-background p-4 text-center text-muted-foreground shadow-lg">
+                      검색 중...
+                    </div>
+                  }
+                >
                   <SuggestionsDropdown
                     searchQuery={searchQuery}
                     blockedUsers={blockedUsers}
-                    currentUser={currentUser}
+                    currentUser={currentUser as User | null}
                     handleBlock={handleBlock}
                     selectedSuggestionIndex={selectedSuggestionIndex}
                     setSelectedSuggestionIndex={setSelectedSuggestionIndex}
@@ -297,20 +219,21 @@ export default function BlockedUsersPage() {
               )}
             </div>
 
-            {blockedUsers.length >= 10 && (
+            {isAtLimit && (
               <div className="rounded-md bg-muted/50 p-3 text-sm text-muted-foreground">
-                💡 비공개 사용자는 최대 10명까지 설정할 수 있습니다
+                💡 비공개 사용자는 최대 {MAX_BLOCKED_USERS}명까지 설정할 수 있습니다
               </div>
             )}
           </CardContent>
         </Card>
 
-        {/* Blocked Users List */}
         <Card>
           <CardHeader className="pb-4">
             <div className="flex items-center justify-between">
               <CardTitle className="text-lg">비공개 사용자 목록</CardTitle>
-              <span className="text-sm text-muted-foreground">{blockedUsers.length}/10</span>
+              <span className="text-sm text-muted-foreground">
+                {blockedUsers.length}/{MAX_BLOCKED_USERS}
+              </span>
             </div>
           </CardHeader>
           <CardContent>
@@ -330,7 +253,7 @@ export default function BlockedUsersPage() {
                         size={40}
                         src={user.profilePhotoURL || undefined}
                         alt={user.nickname || 'User'}
-                        fallback={user.nickname[0]}
+                        fallback={user.nickname?.[0] || ''}
                       />
                       <div className="min-w-0 flex-1">
                         <div className="truncate font-medium">{user.nickname}</div>
@@ -371,14 +294,13 @@ export default function BlockedUsersPage() {
           </CardContent>
         </Card>
 
-        {/* Limit Dialog */}
         <AlertDialog open={showLimitDialog} onOpenChange={setShowLimitDialog}>
           <AlertDialogContent>
             <AlertDialogHeader>
               <AlertDialogTitle>비공개 사용자 한도 초과</AlertDialogTitle>
             </AlertDialogHeader>
             <div className="py-4">
-              <p>비공개 사용자는 최대 10명까지만 설정할 수 있습니다.</p>
+              <p>비공개 사용자는 최대 {MAX_BLOCKED_USERS}명까지만 설정할 수 있습니다.</p>
               <p className="mt-2 text-sm text-muted-foreground">
                 새로운 사용자를 추가하려면 기존 사용자의 설정을 먼저 해제해주세요.
               </p>
@@ -390,5 +312,5 @@ export default function BlockedUsersPage() {
         </AlertDialog>
       </div>
     </div>
-  )
+  );
 }

--- a/apps/web/src/user/hooks/useBlockedUsersList.ts
+++ b/apps/web/src/user/hooks/useBlockedUsersList.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import type { AuthUser } from '@/shared/hooks/useAuth';
+import { blockUser, fetchUser, getBlockedUsers, unblockUser } from '@/user/api/user';
+import type { User } from '@/user/model/User';
+import { mapBlockedUsersFromSettled, MAX_BLOCKED_USERS } from '@/user/utils/blockedUsersUtils';
+
+const TOAST_OPTIONS = { position: 'bottom-center' } as const;
+
+export type BlockOutcome =
+  | { kind: 'success' }
+  | { kind: 'limit-exceeded' }
+  | { kind: 'failure' };
+
+export type UnblockOutcome = { kind: 'success' } | { kind: 'failure' };
+
+export interface UseBlockedUsersListResult {
+  blockedUsers: User[];
+  loading: boolean;
+  isAtLimit: boolean;
+  block: (user: User) => Promise<BlockOutcome>;
+  unblock: (uid: string) => Promise<UnblockOutcome>;
+}
+
+/**
+ * Owns the blocked-users data layer for `BlockedUsersPage`:
+ * - Initial load: fetches the uid list, then resolves each user in parallel.
+ *   Partial failures show a warning toast; total failure shows an error toast
+ *   and leaves the previous state alone.
+ * - `block` / `unblock`: optimistic-ish mutation that updates local state on
+ *   success and surfaces failure via toast so callers only need to react to
+ *   the outcome kind (close dialog / clear search / show limit dialog).
+ */
+export function useBlockedUsersList(currentUser: AuthUser | null): UseBlockedUsersListResult {
+  const [blockedUsers, setBlockedUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!currentUser) return;
+    let cancelled = false;
+    void (async () => {
+      const blockedUids = await getBlockedUsers(currentUser.uid);
+      if (cancelled) return;
+      if (!blockedUids || blockedUids.length === 0) {
+        setBlockedUsers([]);
+        return;
+      }
+      const results = await Promise.allSettled(blockedUids.map((uid) => fetchUser(uid)));
+      if (cancelled) return;
+      const { users, rejectedCount, totalCount } = mapBlockedUsersFromSettled(results);
+      const allFailed = users.length === 0 && rejectedCount === totalCount;
+      if (allFailed) {
+        toast.error('차단된 사용자 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.');
+        return;
+      }
+      if (rejectedCount > 0) {
+        toast.warning(`차단된 사용자 ${rejectedCount}명의 정보를 불러오지 못했습니다.`);
+      }
+      setBlockedUsers(users);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [currentUser]);
+
+  const block = useCallback(
+    async (user: User): Promise<BlockOutcome> => {
+      if (!currentUser) return { kind: 'failure' };
+      if (blockedUsers.length >= MAX_BLOCKED_USERS) return { kind: 'limit-exceeded' };
+      setLoading(true);
+      try {
+        await blockUser(currentUser.uid, user.uid);
+        setBlockedUsers((prev) => [...prev, user]);
+        toast.success(`${user.nickname}님을 비공개 사용자로 설정했습니다.`, TOAST_OPTIONS);
+        return { kind: 'success' };
+      } catch {
+        toast.error('비공개 사용자 설정 중 오류가 발생했습니다.', TOAST_OPTIONS);
+        return { kind: 'failure' };
+      } finally {
+        setLoading(false);
+      }
+    },
+    [currentUser, blockedUsers.length],
+  );
+
+  const unblock = useCallback(
+    async (uid: string): Promise<UnblockOutcome> => {
+      if (!currentUser) return { kind: 'failure' };
+      setLoading(true);
+      try {
+        await unblockUser(currentUser.uid, uid);
+        const removed = blockedUsers.find((u) => u.uid === uid);
+        setBlockedUsers((prev) => prev.filter((u) => u.uid !== uid));
+        toast.success(`${removed?.nickname}님의 비공개 설정을 해제했습니다.`, TOAST_OPTIONS);
+        return { kind: 'success' };
+      } catch {
+        toast.error('비공개 설정 해제 중 오류가 발생했습니다.', TOAST_OPTIONS);
+        return { kind: 'failure' };
+      } finally {
+        setLoading(false);
+      }
+    },
+    [currentUser, blockedUsers],
+  );
+
+  return {
+    blockedUsers,
+    loading,
+    isAtLimit: blockedUsers.length >= MAX_BLOCKED_USERS,
+    block,
+    unblock,
+  };
+}

--- a/apps/web/src/user/hooks/useCloseSuggestionsOnOutsideClick.ts
+++ b/apps/web/src/user/hooks/useCloseSuggestionsOnOutsideClick.ts
@@ -2,12 +2,9 @@ import { useEffect, type RefObject } from 'react';
 
 /**
  * Calls `close` on `mousedown` whenever the click lands outside BOTH the
- * search input and the suggestions dropdown. Used by `BlockedUsersPage` to
- * dismiss its autocomplete when the user taps anywhere else on the page.
- *
- * The original component depended on `[]` so the handler captured the initial
- * `close`. Keeping the deps explicit here lets the caller swap in a `useCallback`-stable
- * close without surprises.
+ * search input and the suggestions dropdown. Callers are expected to pass a
+ * stable `close` (e.g. `useCallback`) so the effect doesn't re-bind on every
+ * render.
  */
 export function useCloseSuggestionsOnOutsideClick(
   searchInputRef: RefObject<HTMLElement | null>,

--- a/apps/web/src/user/hooks/useCloseSuggestionsOnOutsideClick.ts
+++ b/apps/web/src/user/hooks/useCloseSuggestionsOnOutsideClick.ts
@@ -1,0 +1,28 @@
+import { useEffect, type RefObject } from 'react';
+
+/**
+ * Calls `close` on `mousedown` whenever the click lands outside BOTH the
+ * search input and the suggestions dropdown. Used by `BlockedUsersPage` to
+ * dismiss its autocomplete when the user taps anywhere else on the page.
+ *
+ * The original component depended on `[]` so the handler captured the initial
+ * `close`. Keeping the deps explicit here lets the caller swap in a `useCallback`-stable
+ * close without surprises.
+ */
+export function useCloseSuggestionsOnOutsideClick(
+  searchInputRef: RefObject<HTMLElement | null>,
+  suggestionsRef: RefObject<HTMLElement | null>,
+  close: () => void,
+): void {
+  useEffect(() => {
+    const handle = (event: MouseEvent) => {
+      const target = event.target as Node;
+      const insideInput = searchInputRef.current?.contains(target);
+      const insideDropdown = suggestionsRef.current?.contains(target);
+      if (insideInput || insideDropdown) return;
+      close();
+    };
+    document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [searchInputRef, suggestionsRef, close]);
+}

--- a/apps/web/src/user/utils/blockedUsersUtils.test.ts
+++ b/apps/web/src/user/utils/blockedUsersUtils.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import type { User } from '@/user/model/User';
+import {
+  filterBlockSuggestions,
+  getNextSuggestionIndex,
+  isCloseSuggestionsKey,
+  mapBlockedUsersFromSettled,
+  MAX_SEARCH_SUGGESTIONS,
+} from './blockedUsersUtils';
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    uid: 'u1',
+    realName: null,
+    nickname: 'nick',
+    email: 'u1@example.com',
+    profilePhotoURL: null,
+    bio: null,
+    phoneNumber: null,
+    kakaoId: null,
+    referrer: null,
+    onboardingComplete: true,
+    boardPermissions: {},
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+function fulfilled(value: User | null): PromiseFulfilledResult<User | null> {
+  return { status: 'fulfilled', value };
+}
+
+function rejected(reason: unknown = new Error('fail')): PromiseRejectedResult {
+  return { status: 'rejected', reason };
+}
+
+describe('mapBlockedUsersFromSettled', () => {
+  it('returns empty users and zero rejected for an empty batch', () => {
+    expect(mapBlockedUsersFromSettled([])).toEqual({
+      users: [],
+      rejectedCount: 0,
+      totalCount: 0,
+    });
+  });
+
+  it('drops null fulfilled values (deleted users) without inflating the rejected count', () => {
+    const u = makeUser({ uid: 'u1' });
+    const result = mapBlockedUsersFromSettled([fulfilled(u), fulfilled(null)]);
+    expect(result).toEqual({
+      users: [u],
+      rejectedCount: 0,
+      totalCount: 2,
+    });
+  });
+
+  it('counts rejected results separately so the page can tell partial-fail from total-fail', () => {
+    const u1 = makeUser({ uid: 'u1' });
+    const u2 = makeUser({ uid: 'u2' });
+    expect(mapBlockedUsersFromSettled([fulfilled(u1), rejected(), fulfilled(u2)])).toEqual({
+      users: [u1, u2],
+      rejectedCount: 1,
+      totalCount: 3,
+    });
+  });
+
+  it('reports total-fail when every fetch rejected', () => {
+    const result = mapBlockedUsersFromSettled([rejected(), rejected(), rejected()]);
+    expect(result.users).toEqual([]);
+    expect(result.rejectedCount).toBe(3);
+    expect(result.totalCount).toBe(3);
+  });
+});
+
+describe('filterBlockSuggestions', () => {
+  const me = 'me-uid';
+  const blocked = makeUser({ uid: 'blocked-uid' });
+
+  it('returns empty when the search query is blank', () => {
+    expect(filterBlockSuggestions([makeUser()], [], me, '')).toEqual([]);
+    expect(filterBlockSuggestions([makeUser()], [], me, '   ')).toEqual([]);
+  });
+
+  it('returns empty when there is no search result', () => {
+    expect(filterBlockSuggestions(null, [], me, 'query')).toEqual([]);
+    expect(filterBlockSuggestions(undefined, [], me, 'query')).toEqual([]);
+  });
+
+  it('wraps a single-user result into an array', () => {
+    const u = makeUser({ uid: 'u1' });
+    expect(filterBlockSuggestions(u, [], me, 'q')).toEqual([u]);
+  });
+
+  it('excludes the current user', () => {
+    const meUser = makeUser({ uid: me });
+    const other = makeUser({ uid: 'other' });
+    expect(filterBlockSuggestions([meUser, other], [], me, 'q')).toEqual([other]);
+  });
+
+  it('excludes users already blocked', () => {
+    const fresh = makeUser({ uid: 'fresh' });
+    expect(filterBlockSuggestions([blocked, fresh], [blocked], me, 'q')).toEqual([fresh]);
+  });
+
+  it(`caps results at MAX_SEARCH_SUGGESTIONS (${MAX_SEARCH_SUGGESTIONS})`, () => {
+    const many = Array.from({ length: 12 }, (_, i) => makeUser({ uid: `u${i}` }));
+    const result = filterBlockSuggestions(many, [], me, 'q');
+    expect(result).toHaveLength(MAX_SEARCH_SUGGESTIONS);
+    expect(result[0].uid).toBe('u0');
+    expect(result[MAX_SEARCH_SUGGESTIONS - 1].uid).toBe(`u${MAX_SEARCH_SUGGESTIONS - 1}`);
+  });
+});
+
+describe('getNextSuggestionIndex', () => {
+  it('increments on ArrowDown without an upper clamp (matches original behavior)', () => {
+    expect(getNextSuggestionIndex(0, 'ArrowDown')).toBe(1);
+    expect(getNextSuggestionIndex(99, 'ArrowDown')).toBe(100);
+  });
+
+  it('decrements on ArrowUp, clamped to 0', () => {
+    expect(getNextSuggestionIndex(3, 'ArrowUp')).toBe(2);
+    expect(getNextSuggestionIndex(0, 'ArrowUp')).toBe(0);
+    expect(getNextSuggestionIndex(-1, 'ArrowUp')).toBe(0);
+  });
+
+  it('returns null for any non-arrow key (no index change)', () => {
+    for (const key of ['Enter', 'Escape', 'Tab', 'a', '']) {
+      expect(getNextSuggestionIndex(0, key)).toBeNull();
+    }
+  });
+});
+
+describe('isCloseSuggestionsKey', () => {
+  it('returns true only for Escape', () => {
+    expect(isCloseSuggestionsKey('Escape')).toBe(true);
+    for (const key of ['Enter', 'ArrowDown', 'ArrowUp', 'Tab', ' ', '']) {
+      expect(isCloseSuggestionsKey(key)).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/user/utils/blockedUsersUtils.ts
+++ b/apps/web/src/user/utils/blockedUsersUtils.ts
@@ -1,0 +1,66 @@
+import type { User } from '@/user/model/User';
+
+export const MAX_BLOCKED_USERS = 10;
+export const MAX_SEARCH_SUGGESTIONS = 5;
+
+export interface BlockedUsersFromSettledResult {
+  users: User[];
+  rejectedCount: number;
+  totalCount: number;
+}
+
+/**
+ * Reduce a batch of `fetchUser` outcomes into the typed slice the page needs.
+ * Drops null payloads (deleted users) so the rejected count cleanly separates
+ * "fetch failed" from "user no longer exists" — the page uses this distinction
+ * to decide between the "some failed" warning and the "all failed" error toast.
+ */
+export function mapBlockedUsersFromSettled(
+  results: PromiseSettledResult<User | null>[],
+): BlockedUsersFromSettledResult {
+  const fulfilled = results.filter(
+    (r): r is PromiseFulfilledResult<User | null> => r.status === 'fulfilled',
+  );
+  const users = fulfilled.map((r) => r.value).filter((u): u is User => u !== null);
+  return {
+    users,
+    rejectedCount: results.length - fulfilled.length,
+    totalCount: results.length,
+  };
+}
+
+/**
+ * Filter search results into actionable block suggestions.
+ * Excludes the current user themselves and anyone already blocked, then caps
+ * the list so the dropdown stays scannable.
+ */
+export function filterBlockSuggestions(
+  searchResult: User | User[] | null | undefined,
+  blockedUsers: User[],
+  currentUserUid: string | undefined,
+  searchQuery: string,
+): User[] {
+  if (!searchResult || !searchQuery.trim()) return [];
+  const blockedUids = new Set(blockedUsers.map((u) => u.uid));
+  const candidates = Array.isArray(searchResult) ? searchResult : [searchResult];
+  return candidates
+    .filter((user) => user && user.uid !== currentUserUid && !blockedUids.has(user.uid))
+    .slice(0, MAX_SEARCH_SUGGESTIONS);
+}
+
+/**
+ * Pure keyboard navigation. Returns the next selected suggestion index, or
+ * `null` if the key shouldn't change it. ArrowUp is clamped to 0; ArrowDown
+ * intentionally is NOT clamped to a max — matches the original component's
+ * behavior so this refactor doesn't quietly change UX.
+ */
+export function getNextSuggestionIndex(currentIndex: number, key: string): number | null {
+  if (key === 'ArrowDown') return currentIndex + 1;
+  if (key === 'ArrowUp') return Math.max(currentIndex - 1, 0);
+  return null;
+}
+
+/** Pure helper: Escape closes the suggestions dropdown; everything else does not. */
+export function isCloseSuggestionsKey(key: string): boolean {
+  return key === 'Escape';
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -27,6 +27,38 @@ import devLogPlugin from './vite-plugin-dev-log';
  * - NODE_ENV는 'production' 또는 'development'로 설정되며 import.meta.env.PROD/DEV에 영향을 줍니다.
  * - 모드는 임의의 값(production, development, staging 등)이 될 수 있으며 import.meta.env.MODE에 반영됩니다.
  */
+// Loud banner on every Vite startup so anyone running `pnpm dev` (no `:local`
+// suffix) instantly sees they are pointed at a non-local Supabase. Loud here
+// is better than silent + a surprised "wait, did I just smoke-test against
+// prod?" later. Compares the host against the loopback addresses used by
+// `supabase start`; anything else is treated as non-local and gets a banner.
+const LOCAL_SUPABASE_HOSTS = new Set(['127.0.0.1', 'localhost', '0.0.0.0']);
+
+function isLocalSupabaseUrl(url: string): boolean {
+  if (!url) return false;
+  try {
+    return LOCAL_SUPABASE_HOSTS.has(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+function logSupabaseTarget(url: string, mode: string): void {
+  if (!url) {
+    console.warn(`\n  ⚠️  VITE_SUPABASE_URL is empty (mode: ${mode}). Supabase calls will fail.\n`);
+    return;
+  }
+  if (isLocalSupabaseUrl(url)) {
+    console.log(`  🟢 Supabase target: ${url}  (LOCAL, mode: ${mode})\n`);
+    return;
+  }
+  console.warn(
+    `\n  🔴 Supabase target: ${url}  (NON-LOCAL, mode: ${mode})\n` +
+      `      Reads and writes will hit this URL. If you meant to use local Supabase,\n` +
+      `      stop and run \`pnpm --filter web dev:local\` instead.\n`,
+  );
+}
+
 export default defineConfig(({ mode }) => {
   // 환경 변수 로드 - 모노레포 루트의 .env 파일에서 로드
   // pnpm --filter web dev 실행 시 cwd가 apps/web/이므로 루트를 명시적으로 지정
@@ -67,6 +99,7 @@ export default defineConfig(({ mode }) => {
   
   console.log(`Building for ${mode} mode`);
   console.log(`Firebase emulator: ${useFirebaseEmulator ? 'enabled' : 'disabled'}`);
+  logSupabaseTarget(getEnvVariable('VITE_SUPABASE_URL'), mode);
   
   return {
     envDir: monorepoRoot,

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -200,7 +200,10 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = true
+# Disabled locally so smoke/E2E flows can sign up + sign in immediately
+# via __e2e-login.html without going through Mailpit. Cloud auth config is
+# managed separately (Management API), so this does NOT affect production.
+enable_confirmations = false
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.


### PR DESCRIPTION
## Stack Context

- **Depends on**: PR #646 (OnboardingPage refactor + dev infra fixes)
- **Audit item**: #2 of the React code-quality audit table

This branch is stacked on top of #646's branch. Merge #646 first; rebase + merge this after.

## 배경

`apps/web/src/user/components/BlockedUsersPage.tsx`가 394줄·메인 컴포넌트 함수 270줄, 내부 `SuggestionsDropdown` 75줄 + 복잡한 fetch/Promise.allSettled effect를 한 파일에 담고 있어 회귀 위험이 컸습니다. OnboardingPage와 동일한 함수형 코어/명령형 셸 패턴으로 분해합니다.

## Summary

- **순수 유틸 분리** (`b1ee83b5`): `filterBlockSuggestions`, `mapBlockedUsersFromSettled`, `getNextSuggestionIndex`, `isCloseSuggestionsKey`를 `user/utils/blockedUsersUtils.ts`로 추출하고 14개 단위 테스트 추가
- **커스텀 훅 분리** (`5b3c47bb`): `useBlockedUsersList`(fetch + block/unblock + toast + loading)와 `useCloseSuggestionsOnOutsideClick`(mousedown 리스너)으로 부수효과 격리. 호출 결과는 `{kind: 'success'|'limit-exceeded'|'failure'}` 디스크리미네이티드 유니온
- **프레젠테이션 컴포넌트 분리** (`2f60923a`): `BlockedUsersHeader`, `BlockedUserSearchCard`, `BlockedUsersListCard`, `BlockedUserRow`, `BlockSuggestionsDropdown`, `BlockSuggestionRow`, `BlockLimitDialog`로 JSX 트리 분할
- **안전성 보강** (`565d0f2e`): 독립 코드 리뷰가 잡은 시각 회귀 차단 — `BlockSuggestionRow`를 shadcn Button에서 raw `<button>`으로 되돌려 focus ring·hover 디폴트 변경 방지

## 의도적인 개선 (회귀 아님)

- `useBlockedUsersList`에 `cancelled` 플래그를 추가해 언마운트 도중에 진행 중이던 fetch가 다음 페이지에서 토스트를 띄우거나 unmounted 컴포넌트에 setState 하지 않도록 함. 원본은 이런 보호가 없어 빠른 라우팅 시 토스트가 엉뚱한 화면에 나타날 수 있었고 React가 unmounted setState 경고를 찍었음. 외부 계약(목록 로딩 중 토스트)에는 영향 없음 — 페이지에 사용자가 그대로 있을 때만 토스트가 뜨도록 좁혀짐
- 같은 플래그가 currentUser 식별자 변경 시 (재인증 등) 이전 fetch를 깨끗하게 취소해 race condition도 함께 차단

## 결과

| 항목 | Before | After |
|---|---|---|
| `BlockedUsersPage` 함수 길이 | 270줄 | 85줄 |
| 페이지 파일 길이 | 394줄 | 107줄 |
| `SuggestionsDropdown` 내부 함수 | 75줄 | 65줄 (별도 파일로 이동) |
| 단위 테스트 | 0 | 14 |

## Test plan

- [x] `pnpm test:run` — 1062/1062 통과
- [x] `pnpm exec tsc --noEmit` — exit 0
- [x] `pnpm exec eslint` — 0 errors (변경 파일 한정)
- [x] 독립 코드 리뷰 에이전트 패스 — Critical 1건(C1 shadcn Button) 반영, Important 7건 평가 후 모두 의도된 보존 또는 net improvement로 분류
- [ ] 실 환경 스모크 — `/users/blocked` 페이지 (인증된 상태에서 검색·차단·해제·바깥클릭·키보드 ↑/↓·한도 다이얼로그 흐름)

## 알려진 후속 이슈 (이 PR에 포함 안 함)

리뷰에서 확인된 원본부터 있던 미세 UX 결함 두 가지 — 이번 리팩터링에서는 그대로 보존하고 별도 이슈로 처리하는 게 안전:

- ArrowDown이 제안 개수 상한에 클램프되지 않아 `selectedIndex >= 5`가 되면 강조 표시가 사라짐 (`MAX_SEARCH_SUGGESTIONS=5`)
- `AlertDialog`에 `onOpenChange`가 비어 있어 ESC 키로 해제 다이얼로그가 닫히지 않음 (취소·확정 버튼으로만 닫힘)