### PR TITLE
fix: 한글 IME 합성 중 프리라이팅 타이머가 일시정지로 빠지는 문제

### DIFF
--- a/apps/web/src/post/hooks/__tests__/useTiptapEditor.test.ts
+++ b/apps/web/src/post/hooks/__tests__/useTiptapEditor.test.ts
@@ -1,0 +1,70 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useTiptapEditor } from '../useTiptapEditor';
+
+describe('useTiptapEditor — typing signal', () => {
+  it('calls onTyping when beforeinput fires on the editor DOM (covers normal input)', () => {
+    const onTyping = vi.fn();
+    const { result } = renderHook(() =>
+      useTiptapEditor({
+        initialHtml: '<p></p>',
+        onChange: () => {},
+        onTyping,
+      }),
+    );
+
+    const editor = result.current;
+    expect(editor).not.toBeNull();
+
+    act(() => {
+      editor!.view.dom.dispatchEvent(new InputEvent('beforeinput', { data: 'a' }));
+    });
+
+    expect(onTyping).toHaveBeenCalled();
+  });
+
+  it('calls onTyping when compositionupdate fires (covers IME mid-composition where Tiptap onUpdate is silent)', () => {
+    const onTyping = vi.fn();
+    const { result } = renderHook(() =>
+      useTiptapEditor({
+        initialHtml: '<p></p>',
+        onChange: () => {},
+        onTyping,
+      }),
+    );
+
+    const editor = result.current;
+    expect(editor).not.toBeNull();
+
+    act(() => {
+      editor!.view.dom.dispatchEvent(new CompositionEvent('compositionupdate', { data: 'ㄱ' }));
+    });
+
+    expect(onTyping).toHaveBeenCalled();
+  });
+
+  it('keeps onTyping ref fresh so latest callback fires (not the first-render closure)', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ onTyping }) =>
+        useTiptapEditor({
+          initialHtml: '<p></p>',
+          onChange: () => {},
+          onTyping,
+        }),
+      { initialProps: { onTyping: first } },
+    );
+
+    rerender({ onTyping: second });
+
+    act(() => {
+      result.current!.view.dom.dispatchEvent(
+        new CompositionEvent('compositionupdate', { data: 'ㄱ' }),
+      );
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/post/hooks/useTiptapEditor.ts
+++ b/apps/web/src/post/hooks/useTiptapEditor.ts
@@ -129,6 +129,25 @@ export function useTiptapEditor({
     };
   }, []);
 
+  // DOM-level typing signal. Tiptap's onUpdate only fires when ProseMirror
+  // dispatches a transaction, but ProseMirror suppresses transactions during
+  // IME composition (Korean/Japanese/Chinese). For a Korean user composing a
+  // syllable, onUpdate stays silent until the syllable finalizes — long enough
+  // for the freewriting 2s pause timer to expire mid-typing. beforeinput and
+  // compositionupdate fire even while composing, so they keep the keepalive
+  // alive through IME.
+  useEffect(() => {
+    if (!editor) return;
+    const dom = editor.view.dom;
+    const handleTypingSignal = () => onTypingRef.current?.();
+    dom.addEventListener('beforeinput', handleTypingSignal);
+    dom.addEventListener('compositionupdate', handleTypingSignal);
+    return () => {
+      dom.removeEventListener('beforeinput', handleTypingSignal);
+      dom.removeEventListener('compositionupdate', handleTypingSignal);
+    };
+  }, [editor]);
+
   // Tiptap's useEditor only seeds `content` once. Refs keep the freshest
   // target/onChange visible to the blur handler without re-binding it.
   const initialHtmlRef = useRef(initialHtml);

--- a/tests/freewriting-timer.spec.ts
+++ b/tests/freewriting-timer.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from './fixtures/auth';
+import { imeType } from './helpers/ime-helper';
+
+/**
+ * E2E tests for the freewriting page typing-presence chip.
+ *
+ * Regression target: ProseMirror suppresses transactions during IME composition,
+ * so Tiptap's onUpdate stays silent while a Korean syllable is being composed.
+ * The chip flipped to "일시정지" mid-typing because the 2s pause timer expired
+ * with no keepalive. The fix wires DOM-level beforeinput/compositionupdate
+ * listeners that fire during composition; this spec proves the chip survives
+ * sustained IME composition.
+ */
+
+const TEST_BOARD_ID = 'test-board-1';
+const EDITOR_SELECTOR = '.ProseMirror';
+const WRITING_LABEL = '쓰는 중';
+const PAUSED_LABEL = '일시정지';
+
+// The chip sits in the sticky header next to the elapsed-time readout. We
+// match it via its label text so the assertion doesn't depend on Tailwind
+// classes, which are shared with other rounded badges across the app.
+const writingChip = (page: import('@playwright/test').Page) =>
+  page.getByText(WRITING_LABEL, { exact: true }).first();
+const pausedChip = (page: import('@playwright/test').Page) =>
+  page.getByText(PAUSED_LABEL, { exact: true }).first();
+
+test.describe('Freewriting timer chip', () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    await page.goto(`/create/${TEST_BOARD_ID}/free-writing`);
+    await page.waitForSelector(EDITOR_SELECTOR, { timeout: 10000 });
+    await page.click(EDITOR_SELECTOR);
+  });
+
+  test('stays in "쓰는 중" through sustained Korean IME composition (>2s)', async ({
+    authenticatedPage: page,
+  }) => {
+    // Drive composition every 400ms for 4 seconds — well past the 2s pause
+    // window. Without the DOM-level listener fix, Tiptap onUpdate is silent
+    // during composition and the chip flips to "일시정지" mid-typing.
+    const syllables = ['가', '나', '다', '라', '마', '바', '사', '아', '자', '차'];
+    for (const syllable of syllables) {
+      await imeType(page, syllable);
+      await page.waitForTimeout(400);
+      await expect(writingChip(page)).toBeVisible();
+    }
+  });
+
+  test('flips to "일시정지" after 2s of no typing', async ({ authenticatedPage: page }) => {
+    await imeType(page, '가');
+    await expect(writingChip(page)).toBeVisible();
+
+    // Idle long enough for the 2s pause timeout to expire.
+    await page.waitForTimeout(2500);
+    await expect(pausedChip(page)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- ProseMirror가 IME 합성 동안 transaction을 dispatch하지 않아 Tiptap `onUpdate` 신호가 끊겼음. 한 음절을 2초 넘게 합성하면 keepalive가 만료돼 타이핑 중인데도 칩이 "일시정지"로 표시됨
- `editor.view.dom`에 `beforeinput` / `compositionupdate` 리스너를 직접 묶어 합성 중에도 `onTyping` 신호가 흐르도록 수정
- 회귀 잠금을 위해 두 이벤트 경로와 `onTyping` ref 최신성에 대한 단위 테스트 추가

## Test plan
- [x] \`npx vitest run src/post\` — 28개 테스트 파일, 363개 테스트 모두 통과
- [x] Fix를 stash로 빼낸 상태에서 신규 테스트 3개 모두 실패하는 것 확인 (회귀 잠금 유효)
- [ ] 로컬에서 한글 연속 입력 시 칩이 "쓰는 중"에 유지되는지 수동 검증
- [ ] 영문 연속 입력 / 합성 중단 / 2초 멈춤 → "일시정지" 전환 동작 확인