### PR TITLE
chore(sentry): Web Vitals 측정용 BrowserTracing 부분 복원

### DIFF
--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react';
-import { createBrowserRouter, redirect, ScrollRestoration, type LoaderFunctionArgs } from 'react-router-dom';
+import { redirect, ScrollRestoration, type LoaderFunctionArgs } from 'react-router-dom';
+import { sentryCreateBrowserRouter } from '@/sentry';
 import './index.css';
 
 // Lazy-mount Toaster — not visible until a toast fires.
@@ -351,7 +352,7 @@ const devRoutes = import.meta.env.DEV ? {
 
 // --- Router 생성 ---
 
-export const router = createBrowserRouter([
+export const router = sentryCreateBrowserRouter([
   {
     path: '/',
     element: <RootLayout />,

--- a/apps/web/src/sentry.ts
+++ b/apps/web/src/sentry.ts
@@ -12,7 +12,7 @@ import { isIndexedDbConnectionError } from '@/shared/lib/queryErrorTracking';
 // Configuration constants
 const SENTRY_CONFIG = {
   DSN: 'https://8909fb2b0ca421e67d747c29dc427694@o4508460976635904.ingest.us.sentry.io/4508460981747712',
-  TRACE_SAMPLE_RATE: Number(import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE) || 0.2,
+  TRACE_SAMPLE_RATE: Number(import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE) || 1.0,
 } as const;
 
 const IGNORED_ERRORS = [

--- a/apps/web/src/sentry.ts
+++ b/apps/web/src/sentry.ts
@@ -1,9 +1,18 @@
 import * as Sentry from '@sentry/react';
+import { useEffect } from 'react';
+import {
+  createBrowserRouter,
+  createRoutesFromChildren,
+  matchRoutes,
+  useLocation,
+  useNavigationType,
+} from 'react-router-dom';
 import { isIndexedDbConnectionError } from '@/shared/lib/queryErrorTracking';
 
 // Configuration constants
 const SENTRY_CONFIG = {
   DSN: 'https://8909fb2b0ca421e67d747c29dc427694@o4508460976635904.ingest.us.sentry.io/4508460981747712',
+  TRACE_SAMPLE_RATE: Number(import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE) || 0.2,
 } as const;
 
 const IGNORED_ERRORS = [
@@ -94,7 +103,25 @@ export const initSentry = (): void => {
     dsn: SENTRY_CONFIG.DSN,
     environment,
     sendDefaultPii: true,
-    integrations: [],
+    integrations: [
+      Sentry.reactRouterV6BrowserTracingIntegration({
+        useEffect,
+        useLocation,
+        useNavigationType,
+        createRoutesFromChildren,
+        matchRoutes,
+        // Web Vitals (LCP/FCP/CLS) are captured by PerformanceObserver,
+        // so fetch/XHR span instrumentation stays off to avoid critical-path cost.
+        traceFetch: false,
+        traceXHR: false,
+      }),
+    ],
+    tracesSampleRate: SENTRY_CONFIG.TRACE_SAMPLE_RATE,
+    tracePropagationTargets: [
+      'localhost',
+      /^https:\/\/daily-writing-friends\.com\/api/,
+      import.meta.env.VITE_SUPABASE_URL,
+    ],
     ignoreErrors: [...IGNORED_ERRORS],
 
     beforeSend(event, hint) {
@@ -163,4 +190,6 @@ export const setSentryContext = (key: string, context: Record<string, unknown>) 
 export const setSentryTags = (tags: Record<string, string>) => {
   Sentry.setTags(tags);
 };
+
+export const sentryCreateBrowserRouter = Sentry.wrapCreateBrowserRouterV6(createBrowserRouter);
 


### PR DESCRIPTION
## Summary

PR #623 (`perf(web-vitals)`)의 loop iteration #26/#31/#37가 의도와 달리 **Sentry BrowserTracing을 완전히 차단**해서 프로덕션 Web Vital을 더 이상 측정할 수 없게 됐다. 이번 PR은 측정만 다시 켠다. 검증이 끝나면 후속 PR로 샘플링 비율을 낮춘다.

### 사건 경위 (확인됨)

- 2026-06-04 PR #623 머지 → `sentry.ts`에 `integrations: []`, `tracesSampleRate` 삭제
- Sentry Discover API 조회:
  - 머지 전 1주 (5/28 – 6/3): `/` 955 · `/notifications` 816 · `/board/{id}` 815 · `/board/{id}/post/*` 693 …
  - 머지 후 9일 (6/5 – 6/13): 전체 트랜잭션 216건, `has:measurements.lcp` 7건
- 즉, 프로덕션에서 **PR #623가 약속한 0.27 → 0.66 Web Vital 개선이 실제로 일어났는지 검증 불가능**한 상태

### 복원 내용

| 항목 | loop가 한 일 | 이 PR의 결정 |
|---|---|---|
| `browserTracingIntegration` | 제거 | **복원** — 없으면 LCP/FCP/CLS 자체가 안 들어옴 |
| `tracesSampleRate` default | 1.0 → 0 | **1.0 (단기 검증용)** — WAU 15 기준 0.2 샘플링은 좁은 윈도우에서 통계량 부족, 100%로 짧게 가고 추후 하향 |
| `traceFetch` / `traceXHR` | `false` (#26) | **`false` 유지** — Web Vitals은 PerformanceObserver 경로로 수집되므로 fetch span 없이도 측정값은 들어옴 |
| `sentryCreateBrowserRouter` | 제거 | **복원** — SPA navigation transaction까지 수집 |
| env override | 끊김 | `VITE_SENTRY_TRACES_SAMPLE_RATE` 다시 인식 |

### Sample rate 결정 근거

- WAU ~15, 머지 전 기준 4개 라우트 합 ~3,500 trans/주 (라우트당 700-950)
- 100% 샘플 시 2주 ~7k trans, Sentry Developer 티어 (~10k spans/월) 안전선 내
- 검증용 단기 100% → 후속 PR에서 장기 운용용으로 0.2-0.3 하향 예정

### Trade-off

PR #623 loop #31이 주장한 Sentry 관련 perf 이득 (Δ +0.0195)은 sample > 0이면 BrowserTracing의 `PerformanceObserver` 부착 비용 때문에 일부 회귀할 수 있음. 2주 데이터 수집 후 회귀가 ε 이내인지 확인하고 샘플링 하향.

## Test plan

- [x] `pnpm --filter web type-check` 통과
- [x] `pnpm --filter web test BoardListPage` 통과 (Sentry mock 호환)
- [ ] 배포 후 24h, Sentry Discover에서 4개 라우트 트랜잭션이 머지 전 1주 수준(라우트당 700-950)으로 회복되는지 확인
- [ ] 2주 누적 후 PR #623 머지 전 1주 vs 이번 배포 후 2주 LCP/FCP/CLS p75 비교
- [ ] 검증 결과 따라 후속 PR로 sample rate 0.2-0.3 하향